### PR TITLE
Add `pants-plugins/api_spec` to streamline regenerating `openapi.yaml`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853 #5848 #5847 #5858
+  #5846 #5853 #5848 #5847 #5858 #5857
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/Makefile
+++ b/Makefile
@@ -460,7 +460,7 @@ generate-api-spec: requirements .generate-api-spec
 	@echo
 	@echo "================== Generate openapi.yaml file ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; python st2common/bin/st2-generate-api-spec --config-file conf/st2.dev.conf >> st2common/st2common/openapi.yaml
+	. $(VIRTUALENV_DIR)/bin/activate; python st2common/bin/st2-generate-api-spec --config-file conf/st2.dev.conf > st2common/st2common/openapi.yaml
 
 .PHONY: circle-lint-api-spec
 circle-lint-api-spec:

--- a/Makefile
+++ b/Makefile
@@ -460,10 +460,6 @@ generate-api-spec: requirements .generate-api-spec
 	@echo
 	@echo "================== Generate openapi.yaml file ===================="
 	@echo
-	echo "# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY" > st2common/st2common/openapi.yaml
-	echo "# Edit st2common/st2common/openapi.yaml.j2 and then run" >> st2common/st2common/openapi.yaml
-	echo "# make .generate-api-spec" >> st2common/st2common/openapi.yaml
-	echo "# to generate the final spec file" >> st2common/st2common/openapi.yaml
 	. $(VIRTUALENV_DIR)/bin/activate; python st2common/bin/st2-generate-api-spec --config-file conf/st2.dev.conf >> st2common/st2common/openapi.yaml
 
 .PHONY: circle-lint-api-spec

--- a/pants-plugins/README.md
+++ b/pants-plugins/README.md
@@ -9,7 +9,21 @@ The plugins here add custom goals or other logic into pants.
 To see available goals, do "./pants help goals" and "./pants help $goal".
 
 These StackStorm-specific plugins are probably only useful for the st2 repo.
+- `api_spec`
 - `schemas`
+
+### `api_spec` plugin
+
+This plugin wires up pants to make sure `st2common/st2common/openapi.yaml`
+gets regenerated if needed. Now, whenever someone runs the `fmt` goal
+(eg `./pants fmt st2common/st2common/openapi.yaml`), the api spec will
+be regenerated if any of the files used to generate it has changed.
+Also, running the `lint` goal will fail if the schemas need to be
+regenerated.
+
+This plugin also wires up pants so that the `lint` goal runs additional
+api spec validation on `st2common/st2common/openapi.yaml` with something
+like `./pants lint st2common/st2common/openapi.yaml`.
 
 ### `schemas` plugin
 

--- a/pants-plugins/api_spec/BUILD
+++ b/pants-plugins/api_spec/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/pants-plugins/api_spec/BUILD
+++ b/pants-plugins/api_spec/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/api_spec/register.py
+++ b/pants-plugins/api_spec/register.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/api_spec/register.py
+++ b/pants-plugins/api_spec/register.py
@@ -1,0 +1,24 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from api_spec.rules import rules as api_spec_rules
+from api_spec.target_types import APISpec
+
+
+def rules():
+    return [*api_spec_rules()]
+
+
+def target_types():
+    return [APISpec]

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -12,19 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from textwrap import dedent
 
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import (
-    PexRequest,
     VenvPex,
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.util_rules.python_sources import (
-    PythonSourceFiles,
-    PythonSourceFilesRequest,
-)
 from pants.core.goals.fmt import FmtResult, FmtRequest
 from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.target_types import FileSourceField, ResourceSourceField
@@ -48,10 +42,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
-from api_spec.target_types import (
-    APISpecSourceField,
-    APISpec,
-)
+from api_spec.target_types import APISpecSourceField
 
 
 GENERATE_SCRIPT = "generate_api_spec"
@@ -159,7 +150,7 @@ async def generate_api_spec_via_fmt(
                 "conf/st2.dev.conf",
             ),
             input_digest=input_digest,
-            description=f"Regenerating openapi.yaml api spec",
+            description="Regenerating openapi.yaml api spec",
             level=LogLevel.DEBUG,
         ),
     )
@@ -250,7 +241,7 @@ async def validate_api_spec(
                 # "--verbose",  # show definitions on failure
             ),
             input_digest=input_digest,
-            description=f"Validating openapi.yaml api spec",
+            description="Validating openapi.yaml api spec",
             level=LogLevel.DEBUG,
         ),
     )

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -246,6 +246,8 @@ async def validate_api_spec(
             argv=(
                 "--config-file",
                 "conf/st2.dev.conf",
+                # "--validate-defs",  # check for x-api-model in definitions
+                # "--verbose",  # show definitions on failure
             ),
             input_digest=input_digest,
             description=f"Validating openapi.yaml api spec",

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -1,0 +1,265 @@
+# Copyright 2021 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+from textwrap import dedent
+
+from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules.pex import (
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+)
+from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.python_sources import (
+    PythonSourceFiles,
+    PythonSourceFilesRequest,
+)
+from pants.core.goals.fmt import FmtResult, FmtRequest
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
+from pants.core.target_types import FileSourceField, ResourceSourceField
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    FileContent,
+    MergeDigests,
+    Snapshot,
+)
+from pants.engine.process import FallibleProcessResult, ProcessResult
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    FieldSet,
+    SourcesField,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from api_spec.target_types import (
+    APISpecSourceField,
+    APISpec,
+)
+
+
+GENERATE_SCRIPT = "generate_api_spec"
+VALIDATE_SCRIPT = "validate_api_spec"
+
+SPEC_HEADER = b"""\
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
+# Edit st2common/st2common/openapi.yaml.j2 and then run
+# ./pants fmt st2common/st2common/openapi.yaml
+# to generate the final spec file
+"""
+
+
+@dataclass(frozen=True)
+class APISpecFieldSet(FieldSet):
+    required_fields = (APISpecSourceField,)
+
+    source: APISpecSourceField
+
+
+class GenerateAPISpecViaFmtRequest(FmtRequest):
+    field_set_type = APISpecFieldSet
+    name = GENERATE_SCRIPT
+
+
+class ValidateAPISpecRequest(LintTargetsRequest):
+    field_set_type = APISpecFieldSet
+    name = VALIDATE_SCRIPT
+
+
+@rule(
+    desc="Update openapi.yaml with st2-generate-api-spec",
+    level=LogLevel.DEBUG,
+)
+async def generate_api_spec_via_fmt(
+    request: GenerateAPISpecViaFmtRequest,
+) -> FmtResult:
+    # There will only be one target+field_set, but we iterate
+    # to satisfy how fmt expects that there could be more than one.
+    # If there is more than one, they will all get the same contents.
+
+    # Find all the dependencies of our target
+    transitive_targets = await Get(
+        TransitiveTargets,
+        TransitiveTargetsRequest(
+            [field_set.address for field_set in request.field_sets]
+        ),
+    )
+
+    dependency_files_get = Get(
+        SourceFiles,
+        SourceFilesRequest(
+            sources_fields=[
+                tgt.get(SourcesField) for tgt in transitive_targets.dependencies
+            ],
+            for_sources_types=(FileSourceField, ResourceSourceField),
+            # enable_codegen=True,
+        ),
+    )
+
+    source_files_get = Get(
+        SourceFiles,
+        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    )
+
+    # actually generate it with an external script.
+    # Generation cannot be inlined here because it needs to import the st2 code.
+    pex_get = Get(
+        VenvPex,
+        PexFromTargetsRequest(
+            [
+                Address(
+                    "st2common/st2common/cmd",
+                    target_name="cmd",
+                    relative_file_path=f"{GENERATE_SCRIPT}.py",
+                ),
+            ],
+            output_filename=f"{GENERATE_SCRIPT}.pex",
+            internal_only=True,
+            main=EntryPoint.parse(f"st2common.cmd.{GENERATE_SCRIPT}:main"),
+        ),
+    )
+
+    pex, dependency_files, source_files = await MultiGet(
+        pex_get, dependency_files_get, source_files_get
+    )
+
+    # If we were given an input digest from a previous formatter for the source files, then we
+    # should use that input digest instead of the one we read from the filesystem.
+    source_files_snapshot = (
+        source_files.snapshot if request.snapshot is None else request.snapshot
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests((dependency_files.snapshot.digest, source_files_snapshot.digest)),
+    )
+
+    result = await Get(
+        ProcessResult,
+        VenvPexProcess(
+            pex,
+            argv=(
+                "--config-file",
+                "conf/st2.dev.conf",
+            ),
+            input_digest=input_digest,
+            description=f"Regenerating openapi.yaml api spec",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    contents = [
+        FileContent(
+            f"{field_set.address.spec_path}/{field_set.source.value}",
+            SPEC_HEADER + result.stdout,
+        )
+        for field_set in request.field_sets
+    ]
+
+    output_digest = await Get(Digest, CreateDigest(contents))
+    output_snapshot = await Get(Snapshot, Digest, output_digest)
+    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+
+
+@rule(
+    desc="Validate openapi.yaml with st2-validate-api-spec",
+    level=LogLevel.DEBUG,
+)
+async def validate_api_spec(
+    request: ValidateAPISpecRequest,
+) -> LintResults:
+    # There will only be one target+field_set, but we iterate
+    # to satisfy how lint expects that there could be more than one.
+    # If there is more than one, they will all get the same contents.
+
+    # Find all the dependencies of our target
+    transitive_targets = await Get(
+        TransitiveTargets,
+        TransitiveTargetsRequest(
+            [field_set.address for field_set in request.field_sets]
+        ),
+    )
+
+    dependency_files_get = Get(
+        SourceFiles,
+        SourceFilesRequest(
+            sources_fields=[
+                tgt.get(SourcesField) for tgt in transitive_targets.dependencies
+            ],
+            for_sources_types=(FileSourceField, ResourceSourceField),
+            # enable_codegen=True,
+        ),
+    )
+
+    source_files_get = Get(
+        SourceFiles,
+        SourceFilesRequest(field_set.source for field_set in request.field_sets),
+    )
+
+    # actually validate it with an external script.
+    # Validation cannot be inlined here because it needs to import the st2 code.
+    pex_get = Get(
+        VenvPex,
+        PexFromTargetsRequest(
+            [
+                Address(
+                    "st2common/st2common/cmd",
+                    target_name="cmd",
+                    relative_file_path=f"{VALIDATE_SCRIPT}.py",
+                ),
+            ],
+            output_filename=f"{VALIDATE_SCRIPT}.pex",
+            internal_only=True,
+            main=EntryPoint.parse(f"st2common.cmd.{VALIDATE_SCRIPT}:main"),
+        ),
+    )
+
+    pex, dependency_files, source_files = await MultiGet(
+        pex_get, dependency_files_get, source_files_get
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests((dependency_files.snapshot.digest, source_files.snapshot.digest)),
+    )
+
+    process_result = await Get(
+        FallibleProcessResult,
+        VenvPexProcess(
+            pex,
+            argv=(
+                "--config-file",
+                "conf/st2.dev.conf",
+            ),
+            input_digest=input_digest,
+            description=f"Validating openapi.yaml api spec",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    result = LintResult.from_fallible_process_result(process_result)
+    return LintResults([result], linter_name=request.name)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(FmtRequest, GenerateAPISpecViaFmtRequest),
+        UnionRule(LintTargetsRequest, ValidateAPISpecRequest),
+    ]

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.core.goals.fmt import FmtResult, FmtRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -63,7 +63,7 @@ class APISpecFieldSet(FieldSet):
     source: APISpecSourceField
 
 
-class GenerateAPISpecViaFmtRequest(FmtRequest):
+class GenerateAPISpecViaFmtTargetsRequest(FmtTargetsRequest):
     field_set_type = APISpecFieldSet
     name = GENERATE_SCRIPT
 
@@ -78,7 +78,7 @@ class ValidateAPISpecRequest(LintTargetsRequest):
     level=LogLevel.DEBUG,
 )
 async def generate_api_spec_via_fmt(
-    request: GenerateAPISpecViaFmtRequest,
+    request: GenerateAPISpecViaFmtTargetsRequest,
 ) -> FmtResult:
     # There will only be one target+field_set, but we iterate
     # to satisfy how fmt expects that there could be more than one.
@@ -253,6 +253,6 @@ async def validate_api_spec(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, GenerateAPISpecViaFmtRequest),
+        UnionRule(FmtTargetsRequest, GenerateAPISpecViaFmtTargetsRequest),
         UnionRule(LintTargetsRequest, ValidateAPISpecRequest),
     ]

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -14,6 +14,7 @@
 from dataclasses import dataclass
 
 from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules import pex, pex_from_targets
 from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
@@ -253,4 +254,6 @@ def rules():
         *collect_rules(),
         UnionRule(FmtTargetsRequest, GenerateAPISpecViaFmtTargetsRequest),
         UnionRule(LintTargetsRequest, ValidateAPISpecRequest),
+        *pex.rules(),
+        *pex_from_targets.rules(),
     ]

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -45,8 +45,12 @@ from pants.util.logging import LogLevel
 from api_spec.target_types import APISpecSourceField
 
 
-GENERATE_SCRIPT = "generate_api_spec"
-VALIDATE_SCRIPT = "validate_api_spec"
+# these constants are also used in the tests
+CMD_SOURCE_ROOT = "st2common"
+CMD_DIR = "st2common/st2common/cmd"
+CMD_MODULE = "st2common.cmd"
+GENERATE_CMD = "generate_api_spec"
+VALIDATE_CMD = "validate_api_spec"
 
 SPEC_HEADER = b"""\
 # NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
@@ -65,12 +69,12 @@ class APISpecFieldSet(FieldSet):
 
 class GenerateAPISpecViaFmtTargetsRequest(FmtTargetsRequest):
     field_set_type = APISpecFieldSet
-    name = GENERATE_SCRIPT
+    name = GENERATE_CMD
 
 
 class ValidateAPISpecRequest(LintTargetsRequest):
     field_set_type = APISpecFieldSet
-    name = VALIDATE_SCRIPT
+    name = VALIDATE_CMD
 
 
 @rule(
@@ -115,14 +119,14 @@ async def generate_api_spec_via_fmt(
         PexFromTargetsRequest(
             [
                 Address(
-                    "st2common/st2common/cmd",
+                    CMD_DIR,
                     target_name="cmd",
-                    relative_file_path=f"{GENERATE_SCRIPT}.py",
+                    relative_file_path=f"{GENERATE_CMD}.py",
                 ),
             ],
-            output_filename=f"{GENERATE_SCRIPT}.pex",
+            output_filename=f"{GENERATE_CMD}.pex",
             internal_only=True,
-            main=EntryPoint.parse(f"st2common.cmd.{GENERATE_SCRIPT}:main"),
+            main=EntryPoint.parse(f"{CMD_MODULE}.{GENERATE_CMD}:main"),
         ),
     )
 
@@ -165,6 +169,7 @@ async def generate_api_spec_via_fmt(
 
     output_digest = await Get(Digest, CreateDigest(contents))
     output_snapshot = await Get(Snapshot, Digest, output_digest)
+    # TODO: Drop result.stdout since we already wrote it to a file?
     return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
 
 
@@ -210,14 +215,14 @@ async def validate_api_spec(
         PexFromTargetsRequest(
             [
                 Address(
-                    "st2common/st2common/cmd",
+                    CMD_DIR,
                     target_name="cmd",
-                    relative_file_path=f"{VALIDATE_SCRIPT}.py",
+                    relative_file_path=f"{VALIDATE_CMD}.py",
                 ),
             ],
-            output_filename=f"{VALIDATE_SCRIPT}.pex",
+            output_filename=f"{VALIDATE_CMD}.pex",
             internal_only=True,
-            main=EntryPoint.parse(f"st2common.cmd.{VALIDATE_SCRIPT}:main"),
+            main=EntryPoint.parse(f"{CMD_MODULE}.{VALIDATE_CMD}:main"),
         ),
     )
 

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -52,13 +52,6 @@ CMD_MODULE = "st2common.cmd"
 GENERATE_CMD = "generate_api_spec"
 VALIDATE_CMD = "validate_api_spec"
 
-SPEC_HEADER = b"""\
-# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
-# Edit st2common/st2common/openapi.yaml.j2 and then run
-# ./pants fmt st2common/st2common/openapi.yaml
-# to generate the final spec file
-"""
-
 
 @dataclass(frozen=True)
 class APISpecFieldSet(FieldSet):
@@ -162,7 +155,7 @@ async def generate_api_spec_via_fmt(
     contents = [
         FileContent(
             f"{field_set.address.spec_path}/{field_set.source.value}",
-            SPEC_HEADER + result.stdout,
+            result.stdout,
         )
         for field_set in request.field_sets
     ]

--- a/pants-plugins/api_spec/rules.py
+++ b/pants-plugins/api_spec/rules.py
@@ -97,7 +97,6 @@ async def generate_api_spec_via_fmt(
                 tgt.get(SourcesField) for tgt in transitive_targets.dependencies
             ],
             for_sources_types=(FileSourceField, ResourceSourceField),
-            # enable_codegen=True,
         ),
     )
 
@@ -193,7 +192,6 @@ async def validate_api_spec(
                 tgt.get(SourcesField) for tgt in transitive_targets.dependencies
             ],
             for_sources_types=(FileSourceField, ResourceSourceField),
-            # enable_codegen=True,
         ),
     )
 
@@ -236,8 +234,10 @@ async def validate_api_spec(
             argv=(
                 "--config-file",
                 "conf/st2.dev.conf",
+                # TODO: Uncomment these as part of a project to fix the (many) issues it identifies.
+                #       We can uncomment --validate-defs (and possibly --verbose) once the spec defs are valid.
                 # "--validate-defs",  # check for x-api-model in definitions
-                # "--verbose",  # show definitions on failure
+                # "--verbose",  # show model definitions on failure (only applies to --validate-defs)
             ),
             input_digest=input_digest,
             description="Validating openapi.yaml api spec",

--- a/pants-plugins/api_spec/rules_test.py
+++ b/pants-plugins/api_spec/rules_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/api_spec/rules_test.py
+++ b/pants-plugins/api_spec/rules_test.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import os
 
+from typing import Sequence
+
 import pytest
 
 from pants.backend.python import target_types_rules
@@ -132,7 +134,11 @@ def main():
 
 
 def write_generate_files(
-    api_spec_dir: str, api_spec_file: str, before: str, after: str, rule_runner: RuleRunner
+    api_spec_dir: str,
+    api_spec_file: str,
+    before: str,
+    after: str,
+    rule_runner: RuleRunner,
 ) -> None:
     files = {
         f"{api_spec_dir}/{api_spec_file}": before,
@@ -201,7 +207,11 @@ def main():
 
 
 def write_validate_files(
-    api_spec_dir: str, api_spec_file: str, contents: str, rc: int, rule_runner: RuleRunner
+    api_spec_dir: str,
+    api_spec_file: str,
+    contents: str,
+    rc: int,
+    rule_runner: RuleRunner,
 ) -> None:
     files = {
         f"{api_spec_dir}/{api_spec_file}": contents,
@@ -237,7 +247,6 @@ def test_validate_passed(rule_runner: RuleRunner) -> None:
     assert len(lint_result) == 1
     assert lint_result[0].exit_code == 0
     assert lint_result[0].report == EMPTY_DIGEST
-
 
 
 def test_validate_failed(rule_runner: RuleRunner) -> None:

--- a/pants-plugins/api_spec/rules_test.py
+++ b/pants-plugins/api_spec/rules_test.py
@@ -1,0 +1,162 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pants.backend.python import target_types_rules
+from pants.backend.python.target_types import PythonSourcesGeneratorTarget
+
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.target import Target
+from pants.core.goals.fmt import FmtResult
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .rules import (
+    CMD_DIR,
+    CMD_SOURCE_ROOT,
+    GENERATE_CMD,
+    APISpecFieldSet,
+    GenerateAPISpecViaFmtTargetsRequest,
+    rules as api_spec_rules,
+)
+from .target_types import APISpec
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *api_spec_rules(),
+            *target_types_rules.rules(),
+            QueryRule(FmtResult, (GenerateAPISpecViaFmtTargetsRequest,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[APISpec, PythonSourcesGeneratorTarget],
+    )
+
+
+def run_st2_generate_api_spec(
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    *,
+    extra_args: list[str] | None = None,
+) -> FmtResult:
+    rule_runner.set_options(
+        [
+            "--backend-packages=api_spec",
+            f"--source-root-patterns=/{CMD_SOURCE_ROOT}",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    field_sets = [APISpecFieldSet.create(tgt) for tgt in targets]
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.sources for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            GenerateAPISpecViaFmtTargetsRequest(
+                field_sets, snapshot=input_sources.snapshot
+            ),
+        ],
+    )
+    return fmt_result
+
+
+# copied from pantsbuild/pants.git/src/python/pants/backend/python/lint/black/rules_integration_test.py
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
+    files = [
+        FileContent(path, content.encode()) for path, content in source_files.items()
+    ]
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
+
+
+# add dummy script at st2common/st2common/cmd/generate_api_spec.py that the test can load.
+GENERATE_API_SPEC_PY = """
+import os
+
+
+def main():
+    api_spec_text = "{api_spec_text}"
+    print(api_spec_text)
+"""
+
+
+def write_generate_files(
+    api_spec_dir: str, api_spec_file: str, before: str, after: str, rule_runner: RuleRunner
+) -> None:
+    files = {
+        f"{api_spec_dir}/{api_spec_file}": before,
+        f"{api_spec_dir}/BUILD": "api_spec(name='t')",
+        # add in the target that's hard-coded in the generate_api_spec_via_fmt rue
+        f"{CMD_DIR}/{GENERATE_CMD}.py": GENERATE_API_SPEC_PY.format(
+            api_spec_dir=api_spec_dir, api_spec_text=after
+        ),
+        f"{CMD_DIR}/BUILD": "python_sources()",
+    }
+
+    module = CMD_DIR
+    while module != CMD_SOURCE_ROOT:
+        files[f"{module}/__init__.py"] = ""
+        module = os.path.dirname(module)
+
+    rule_runner.write_files(files)
+
+
+def test_generate_changed(rule_runner: RuleRunner) -> None:
+    write_generate_files(
+        api_spec_dir="my_dir",
+        api_spec_file="dummy.yaml",
+        before="BEFORE",
+        after="AFTER",
+        rule_runner=rule_runner,
+    )
+
+    tgt = rule_runner.get_target(
+        Address("my_dir", target_name="t", relative_file_path="dummy.yaml")
+    )
+    fmt_result = run_st2_generate_api_spec(rule_runner, [tgt])
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"my_dir/dummy.yaml": "AFTER"}
+    )
+    assert fmt_result.did_change is True
+
+
+def test_generate_unchanged(rule_runner: RuleRunner) -> None:
+    write_generate_files(
+        api_spec_dir="my_dir",
+        api_spec_file="dummy.yaml",
+        before="AFTER",
+        after="AFTER",
+        rule_runner=rule_runner,
+    )
+
+    tgt = rule_runner.get_target(
+        Address("my_dir", target_name="t", relative_file_path="dummy.yaml")
+    )
+    fmt_result = run_st2_generate_api_spec(rule_runner, [tgt])
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"my_dir/dummy.yaml": "AFTER"}
+    )
+    assert fmt_result.did_change is False

--- a/pants-plugins/api_spec/rules_test.py
+++ b/pants-plugins/api_spec/rules_test.py
@@ -143,7 +143,7 @@ def write_generate_files(
     files = {
         f"{api_spec_dir}/{api_spec_file}": before,
         f"{api_spec_dir}/BUILD": f"api_spec(name='t', source='{api_spec_file}')",
-        # add in the target that's hard-coded in the generate_api_spec_via_fmt rue
+        # add in the target that's hard-coded in the generate_api_spec_via_fmt rule
         f"{CMD_DIR}/{GENERATE_CMD}.py": GENERATE_API_SPEC_PY.format(
             api_spec_dir=api_spec_dir, api_spec_text=after
         ),
@@ -216,7 +216,7 @@ def write_validate_files(
     files = {
         f"{api_spec_dir}/{api_spec_file}": contents,
         f"{api_spec_dir}/BUILD": f"api_spec(name='t', source='{api_spec_file}')",
-        # add in the target that's hard-coded in the generate_api_spec_via_fmt rue
+        # add in the target that's hard-coded in the generate_api_spec_via_fmt rule
         f"{CMD_DIR}/{VALIDATE_CMD}.py": VALIDATE_API_SPEC_PY.format(
             api_spec_dir=api_spec_dir, rc=rc
         ),

--- a/pants-plugins/api_spec/target_types.py
+++ b/pants-plugins/api_spec/target_types.py
@@ -1,0 +1,29 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    SingleSourceField,
+    Target,
+)
+
+
+class APISpecSourceField(SingleSourceField):
+    default = "openapi.yaml"
+
+
+class APISpec(Target):
+    alias = "api_spec"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, APISpecSourceField)
+    help = "Generate openapi.yaml file from Jinja2 template and python sources."

--- a/pants-plugins/api_spec/target_types.py
+++ b/pants-plugins/api_spec/target_types.py
@@ -15,12 +15,14 @@ from pants.backend.python.target_types import PythonResolveField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
-    SingleSourceField,
     Target,
+)
+from pants.core.target_types import (
+    ResourceSourceField,
 )
 
 
-class APISpecSourceField(SingleSourceField):
+class APISpecSourceField(ResourceSourceField):
     default = "openapi.yaml"
 
 

--- a/pants-plugins/api_spec/target_types.py
+++ b/pants-plugins/api_spec/target_types.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pants.backend.python.target_types import PythonResolveField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -25,5 +26,13 @@ class APISpecSourceField(SingleSourceField):
 
 class APISpec(Target):
     alias = "api_spec"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, APISpecSourceField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        Dependencies,
+        APISpecSourceField,
+        # hack: work around an issue in the pylint backend that tries to
+        # use this field on the api_spec target, possibly because
+        # it depends on python files.
+        PythonResolveField,
+    )
     help = "Generate openapi.yaml file from Jinja2 template and python sources."

--- a/pants-plugins/api_spec/target_types.py
+++ b/pants-plugins/api_spec/target_types.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants.toml
+++ b/pants.toml
@@ -24,6 +24,7 @@ backend_packages = [
 
   # internal plugins in pants-plugins/
   "pants.backend.plugin_development",
+  "api_spec",
   "schemas",
 ]
 # pants ignores files in .gitignore, .*/ directories, /dist/ directory, and __pycache__.

--- a/st2common/st2common/BUILD
+++ b/st2common/st2common/BUILD
@@ -5,7 +5,17 @@ python_sources(
 )
 
 # These may be loaded with st2common.util.spec_loader
-resources(
+resource(
+    name="openapi_spec_template",
+    source="openapi.yaml.j2",
+)
+api_spec(
     name="openapi_spec",
-    sources=["openapi.yaml", "openapi.yaml.j2"],
+    source="openapi.yaml",
+    dependencies=[
+        ":openapi_spec_template",
+        "st2common/st2common/cmd/generate_api_spec.py",  # st2-generate-api-spec
+        "st2common/st2common/cmd/validate_api_spec.py",  # st2-validate-api-spec
+        "//conf:st2_dev_conf",  # used for both generate and validate
+    ],
 )

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -30,12 +30,23 @@ __all__ = ["main"]
 LOG = logging.getLogger(__name__)
 
 
+# TODO: replace makefile reference with pants equivalent
+# ./pants fmt st2common/st2common/openapi.yaml
+SPEC_HEADER = """\
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
+# Edit st2common/st2common/openapi.yaml.j2 and then run
+# make .generate-api-spec
+# to generate the final spec file
+"""
+
+
 def setup():
     common_setup(config=config, setup_db=False, register_mq_exchanges=False)
 
 
 def generate_spec():
     spec_string = spec_loader.generate_spec("st2common", "openapi.yaml.j2")
+    print(SPEC_HEADER)
     print(spec_string)
 
 

--- a/st2common/st2common/cmd/generate_api_spec.py
+++ b/st2common/st2common/cmd/generate_api_spec.py
@@ -46,7 +46,7 @@ def setup():
 
 def generate_spec():
     spec_string = spec_loader.generate_spec("st2common", "openapi.yaml.j2")
-    print(SPEC_HEADER)
+    print(SPEC_HEADER.rstrip())
     print(spec_string)
 
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1,6 +1,6 @@
 # NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
 # Edit st2common/st2common/openapi.yaml.j2 and then run
-# make .generate-api-spec
+# ./pants fmt st2common/st2common/openapi.yaml
 # to generate the final spec file
 swagger: '2.0'
 

--- a/st2common/st2common/openapi.yaml
+++ b/st2common/st2common/openapi.yaml
@@ -1,6 +1,6 @@
 # NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
 # Edit st2common/st2common/openapi.yaml.j2 and then run
-# ./pants fmt st2common/st2common/openapi.yaml
+# make .generate-api-spec
 # to generate the final spec file
 swagger: '2.0'
 


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR improves the DX (developer experience) by wiring up:
- the `fmt` goal to generate `st2common/st2common/openapi.yaml` if needed (effectively runs `st2-generate-api-spec`), and
- the `lint` goal to validate `st2common/st2common/openapi.yaml` to make sure the generated schema is valid (effectively runs `st2-validate-api-spec`)

This includes creating a `api_spec` plugin for pants that adds a `api_spec` target.

### Developer Experience

Today, if someone changes one of the files/scripts used to generate our openapi spec, then CI might complain as part of the `ci-checks` Makefile target, with instructions to `Please run "make generate-api-spec"`. This also gets regenerated any time someone runs the `lint` or `tests` Makefile targets, which might be surprising (tests generally shouldn't handle codegen).

In any case, this wires up pants to run `st2-generate-api-spec` and `st2-validate-api-spec` at times that are analogous to when the Makefile runs them.

With this PR, we add api spec generation into the `fmt` goal and validation to the `lint` goal. Anything that runs under `fmt` _also_ runs under the `lint` goal, so we will get two signals about the api spec: (1) whether or not it needs to be regenerated, and (2) whether or not there are validation errors in the spec.

Our api spec is generated from a jinja template, which only does minimal interpolation (populating the values for some of the enums). There are actually quite a few inconsistencies between our models and the api spec, so we will have to refactor the spec, the spec generation, and possibly the models in the future. That refactoring work, however, is out-of-scope for this PR. After we get pants in, it would be excellent to revisit these issues.

In working on this plugin, I discovered that our api spec validation has been broken for awhile, which I fixed in #5709. Part of our custom validation is still disabled because there are so many things in the spec that are out of date. This PR also does not fix that, but it does leave a comment in the pants plugin on how to enable that later.

### Fine grained results cache

After someone runs `./pants fmt ::` once, they will benefit from the pants' results cache. For the api_spec plugin, here's what that means:

First, the `api_spec` target in `st2common/st2common` depends on the generate/validate binaries in `st2common/bin`:

https://github.com/StackStorm/st2/blob/1856f6108219ebb1a6886afb798fd0f6c97b184c/st2common/st2common/BUILD#L12-L21

If either script (`st2-generate-api-spec` or `st2-validate-api-spec`) changes, then pants now knows that `openapi.yaml` need to be regenerated. Or, in other words, the `st2-generate-api-spec` file is part of the cache key for `st2common/st2common/openapi.yaml`. If that file changes, then pants will re-run the generator.

`st2-generate-api-spec` is a python script, and we use pants' python dependency inference. So pants (effectively) also adds the python files imported by `st2-generate-api-spec` to the cache key. Stepping through the code, we can see what pants would infer:

https://github.com/StackStorm/st2/blob/1856f6108219ebb1a6886afb798fd0f6c97b184c/st2common/bin/st2-generate-api-spec#L18
https://github.com/StackStorm/st2/blob/1856f6108219ebb1a6886afb798fd0f6c97b184c/st2common/st2common/cmd/generate_api_spec.py#L22-L26
https://github.com/StackStorm/st2/blob/1856f6108219ebb1a6886afb798fd0f6c97b184c/st2common/st2common/util/spec_loader.py#L21-L26

Here we reach the few things that get interpolated into the Jinja Template:

https://github.com/StackStorm/st2/blob/1856f6108219ebb1a6886afb798fd0f6c97b184c/st2common/st2common/util/spec_loader.py#L30-L35

Now, if anyone changes any of these files, or any of the python bits that get imported to help define things in them, then the next time someone runs the `lint` goal (or in CI) they will find out that they need to run the `fmt` goal.

### Developing pants plugins

Pants has extensive documentation on the plugin API, including how to create targets, how to write rules, and there are even mini tutorials about how to add a linter or a formatter (adding formatters/linters is a very common thing plugins to do).

- [Plugins overview](https://www.pantsbuild.org/docs/plugins-overview)
- [The Target API](https://www.pantsbuild.org/docs/target-api)
- [The Rules API](https://www.pantsbuild.org/docs/rules-api)
    - [Processes](https://www.pantsbuild.org/docs/rules-api-process) (running subprocesses in pants plugins)
- [Add a linter](https://www.pantsbuild.org/docs/plugins-lint-goal)
- [Add a formatter](https://www.pantsbuild.org/docs/plugins-fmt-goal)
- [Testing Plugins](https://www.pantsbuild.org/docs/rules-api-testing)