### PR TITLE
Refactor `DEFAULT_LOGGING_CONF_PATH` calculation to allow fine-grained pants dep inference

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853 #5848
+  #5846 #5853 #5848 #5858
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/st2common/st2common/conf/BUILD
+++ b/st2common/st2common/conf/BUILD
@@ -3,3 +3,7 @@ resource(
     name="base.logging.conf",
     source="base.logging.conf",
 )
+
+python_sources(
+    dependencies=[":base.logging.conf"],
+)

--- a/st2common/st2common/conf/__init__.py
+++ b/st2common/st2common/conf/__init__.py
@@ -1,5 +1,4 @@
-# Copyright 2020 The StackStorm Authors.
-# Copyright 2019 Extreme Networks, Inc.
+# Copyright 2021 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from st2common.conf import BASE_LOGGING_CONF_PATH as DEFAULT_LOGGING_CONF_PATH
+import os
 
-__all__ = ["DEFAULT_LOGGING_CONF_PATH"]
+CONF_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+BASE_LOGGING_CONF_PATH = os.path.join(CONF_DIR, "base.logging.conf")

--- a/st2common/st2common/conf/__init__.py
+++ b/st2common/st2common/conf/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/st2common/st2common/constants/BUILD
+++ b/st2common/st2common/constants/BUILD
@@ -1,5 +1,1 @@
-python_sources(
-    dependencies=[
-        "st2common/st2common/conf:base.logging.conf",
-    ]
-)
+python_sources()


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This is primarily a follow-up to:
- #5846

Unlike the simple BUILD config added in #5846, this PR refactors one constant so that pants can better use python imports to precisely detect who needs `st2common/st2common/conf/base.logging.conf`.

Before this PR, anything that uses any of the constants had a hard-coded dependency on `base.logging.conf`:

https://github.com/StackStorm/st2/blob/63f66b9595bf5b4e3974e7c5f327fa59f864ba3d/st2common/st2common/constants/BUILD#L1-L3

After this PR, each file will only get an inferred dependency if it actually imports the `DEFAULT_LOGGING_CONF_PATH` constant that refers to that file.

This also has the benefit of moving the constant calculation closer to the file it references. But, it still maintains backwards compatibility by also making the constant available in the old location.