### PR TITLE
Add `pants-plugins/sample_conf` to streamline regenerating `conf/st2.conf.sample`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,12 +31,12 @@ python_requirements(
                 "//:reqs#zake",
             ]
         },
-		# make sure anything that uses st2-auth-ldap gets the st2auth constant
-		"st2-auth-ldap": {
+        # make sure anything that uses st2-auth-ldap gets the st2auth constant
+        "st2-auth-ldap": {
             "dependencies": [
                 "st2auth/st2auth/backends/constants.py",
             ]
-		}
+        },
     },
 )
 

--- a/BUILD
+++ b/BUILD
@@ -31,7 +31,21 @@ python_requirements(
                 "//:reqs#zake",
             ]
         },
+		# make sure anything that uses st2-auth-ldap gets the st2auth constant
+		"st2-auth-ldap": {
+            "dependencies": [
+                "st2auth/st2auth/backends/constants.py",
+            ]
+		}
     },
+)
+
+target(
+    name="auth_backends",
+    dependencies=[
+        "//:reqs#st2-auth-backend-flat-file",
+        "//:reqs#st2-auth-ldap",
+    ],
 )
 
 python_test_utils(

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853 #5848 #5847 #5858 #5857
+  #5846 #5853 #5848 #5847 #5858 #5857 #5860
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/conf/BUILD
+++ b/conf/BUILD
@@ -3,10 +3,14 @@ file(
     source="st2rc.sample.ini",
 )
 
-file(
+sample_conf(
     name="st2.conf.sample",
-    source="st2.conf.sample",
+    # source="st2.conf.sample",
 )
+#file(
+#    name="st2.conf.sample",
+#    source="st2.conf.sample",
+#)
 
 file(
     name="logrotate",

--- a/conf/BUILD
+++ b/conf/BUILD
@@ -3,14 +3,13 @@ file(
     source="st2rc.sample.ini",
 )
 
-sample_conf(
+sample_conf(  # defined in pants-plugins/sample_conf
     name="st2.conf.sample",
-    # source="st2.conf.sample",
+    source="st2.conf.sample",
+    dependencies=[
+        "tools/config_gen.py",
+    ],
 )
-#file(
-#    name="st2.conf.sample",
-#    source="st2.conf.sample",
-#)
 
 file(
     name="logrotate",

--- a/pants-plugins/README.md
+++ b/pants-plugins/README.md
@@ -10,6 +10,7 @@ To see available goals, do "./pants help goals" and "./pants help $goal".
 
 These StackStorm-specific plugins are probably only useful for the st2 repo.
 - `api_spec`
+- `sample_conf`
 - `schemas`
 
 ### `api_spec` plugin
@@ -24,6 +25,15 @@ regenerated.
 This plugin also wires up pants so that the `lint` goal runs additional
 api spec validation on `st2common/st2common/openapi.yaml` with something
 like `./pants lint st2common/st2common/openapi.yaml`.
+
+### `sample_conf` plugin
+
+This plugin wires up pants to make sure `conf/st2.conf.sample` gets
+regenerated whenever the source files change. Now, whenever someone runs
+the `fmt` goal (eg `./pants fmt conf/st2.conf.sample`), the sample will
+be regenerated if any of the files used to generate it have changed.
+Also, running the `lint` goal will fail if the sample needs to be
+regenerated.
 
 ### `schemas` plugin
 

--- a/pants-plugins/sample_conf/BUILD
+++ b/pants-plugins/sample_conf/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/pants-plugins/sample_conf/BUILD
+++ b/pants-plugins/sample_conf/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/sample_conf/register.py
+++ b/pants-plugins/sample_conf/register.py
@@ -1,0 +1,24 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sample_conf.rules import rules as sample_conf_rules
+from sample_conf.target_types import SampleConf
+
+
+def rules():
+    return [*sample_conf_rules()]
+
+
+def target_types():
+    return [SampleConf]

--- a/pants-plugins/sample_conf/register.py
+++ b/pants-plugins/sample_conf/register.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -85,7 +85,7 @@ async def generate_sample_conf_via_fmt(
 
     # actually generate it with an external script.
     # Generation cannot be inlined here because it needs to import the st2 code.
-    pex_get = Get(
+    pex = await Get(
         VenvPex,
         PexFromTargetsRequest(
             [Address("tools", target_name="tools", relative_file_path=f"{SCRIPT}.py")],
@@ -94,11 +94,6 @@ async def generate_sample_conf_via_fmt(
             main=EntryPoint(SCRIPT),
         ),
     )
-    sources_get = Get(
-        PythonSourceFiles,
-        PythonSourceFilesRequest(transitive_targets.closure, include_files=True),
-    )
-    pex, sources = await MultiGet(pex_get, sources_get)
 
     result = await Get(
         FallibleProcessResult,

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -15,15 +15,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import (
-    PexRequest,
     VenvPex,
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.backend.python.util_rules.python_sources import (
-    PythonSourceFiles,
-    PythonSourceFilesRequest,
-)
 from pants.core.goals.fmt import FmtResult, FmtRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import (
@@ -33,20 +28,12 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    FieldSet,
-    SourcesField,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
-from sample_conf.target_types import (
-    SampleConfSourceField,
-    SampleConf,
-)
+from sample_conf.target_types import SampleConfSourceField
 
 
 SCRIPT = "config_gen"
@@ -91,7 +78,7 @@ async def generate_sample_conf_via_fmt(
         FallibleProcessResult,
         VenvPexProcess(
             pex,
-            description=f"Regenerating st2.conf.sample",
+            description="Regenerating st2.conf.sample",
         ),
     )
 

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -19,7 +19,7 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.core.goals.fmt import FmtResult, FmtRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import (
     CreateDigest,
@@ -46,7 +46,7 @@ class GenerateSampleConfFieldSet(FieldSet):
     source: SampleConfSourceField
 
 
-class GenerateSampleConfViaFmtRequest(FmtRequest):
+class GenerateSampleConfViaFmtTargetsRequest(FmtTargetsRequest):
     field_set_type = GenerateSampleConfFieldSet
     name = SCRIPT
 
@@ -56,7 +56,7 @@ class GenerateSampleConfViaFmtRequest(FmtRequest):
     level=LogLevel.DEBUG,
 )
 async def generate_sample_conf_via_fmt(
-    request: GenerateSampleConfViaFmtRequest,
+    request: GenerateSampleConfViaFmtTargetsRequest,
 ) -> FmtResult:
     # There will only be one target+field_set, but we iterate
     # to satisfy how fmt expects that there could be more than one.
@@ -98,5 +98,5 @@ async def generate_sample_conf_via_fmt(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, GenerateSampleConfViaFmtRequest),
+        UnionRule(FmtTargetsRequest, GenerateSampleConfViaFmtTargetsRequest),
     ]

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -75,14 +75,6 @@ async def generate_sample_conf_via_fmt(
     # to satisfy how fmt expects that there could be more than one.
     # If there is more than one, they will all get the same contents.
 
-    # Find all the dependencies of our target
-    transitive_targets = await Get(
-        TransitiveTargets,
-        TransitiveTargetsRequest(
-            [field_set.address for field_set in request.field_sets]
-        ),
-    )
-
     # actually generate it with an external script.
     # Generation cannot be inlined here because it needs to import the st2 code.
     pex = await Get(

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -1,0 +1,83 @@
+# Copyright 2021 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pants.backend.python.target_types import PythonSourceField
+from pants.core.target_types import FileSourceField
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestContents,
+    FileContent,
+    Snapshot,
+)
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    GeneratedSources,
+    GenerateSourcesRequest,
+    SourcesField,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
+from pants.engine.unions import UnionRule
+
+from sample_conf.target_types import (
+    #GenerateSampleConfSourceField,
+    SampleConfSourceField,
+    SampleConf,
+)
+
+
+class GenerateSampleConfRequest(GenerateSourcesRequest):
+    input = SampleConfSourceField
+    output = SampleConfSourceField
+    #output = FileSourceField
+
+
+@rule
+async def generate_sample_conf(
+    request: GenerateSampleConfRequest,
+) -> GeneratedSources:
+    target = request.protocol_target
+
+    # Find all the dependencies of our target
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([target.address]))
+
+    # Get the source files without the source-root prefix.
+    #stripped_sources = await Get(StrippedSourceFiles, SourceFilesRequest(
+    #    (tgt.get(SourcesField) for tgt in transitive_targets.closure)
+    #))
+
+    #contents = await Get(DigestContents, Digest, stripped_sources)
+
+    # actually generate it with an external script.
+    # Generation cannot be inlined here because it needs to import the st2 code.
+    sample_conf = "asdf\n"
+
+    output_path = f"{target.address.spec_path}/{target[SampleConfSourceField].value}"
+    content = FileContent(output_path, sample_conf.encode("utf-8"))
+
+    output_digest = await Get(Digest, CreateDigest([content]))
+    output_snapshot = await Get(Snapshot, Digest, output_digest)
+    return GeneratedSources(output_snapshot)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(
+            GenerateSourcesRequest,
+            GenerateSampleConfRequest,
+        ),
+    ]

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -63,7 +63,6 @@ from sample_conf.target_types import (
 class GenerateSampleConfRequest(GenerateSourcesRequest):
     input = SampleConfSourceField
     output = SampleConfSourceField
-    #output = FileSourceField
 
 
 @rule
@@ -127,15 +126,11 @@ class GenerateSampleConfViaFmtRequest(FmtRequest, LintTargetsRequest):
 
 
 @rule(desc="Generate st2.conf.sample")
-async def gen_sample_conf_via_fmt(request: GenerateSampleConfViaFmtRequest) -> FmtResult:
+async def gen_sample_conf_via_fmt(
+    request: GenerateSampleConfViaFmtRequest,
+) -> FmtResult:
     ...
     return FmtResult(..., formatter_name=request.name)
-
-
-#@rule(desc="Ensure st2.conf.sample is up-to-date")
-#async def sample_conf_lint(request: GenerateSampleConfViaFmtRequest) -> LintResults:
-#    ...
-#    return LintResults([], linter_name=request.name)
 
 
 def rules():
@@ -143,5 +138,5 @@ def rules():
         *collect_rules(),
         UnionRule(GenerateSourcesRequest, GenerateSampleConfRequest),
         UnionRule(FmtRequest, GenerateSampleConfViaFmtRequest),
-#        UnionRule(LintTargetsRequest, GenerateSampleConfViaFmtRequest),
+        # UnionRule(LintTargetsRequest, GenerateSampleConfViaFmtRequest),
     ]

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -14,6 +14,7 @@
 from dataclasses import dataclass
 
 from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules import pex, pex_from_targets
 from pants.backend.python.util_rules.pex import (
     VenvPex,
     VenvPexProcess,
@@ -99,4 +100,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(FmtTargetsRequest, GenerateSampleConfViaFmtTargetsRequest),
+        *pex.rules(),
+        *pex_from_targets.rules(),
     ]

--- a/pants-plugins/sample_conf/rules.py
+++ b/pants-plugins/sample_conf/rules.py
@@ -37,6 +37,8 @@ from pants.util.logging import LogLevel
 from sample_conf.target_types import SampleConfSourceField
 
 
+# these constants are also used in the tests.
+SCRIPT_DIR = "tools"
 SCRIPT = "config_gen"
 
 
@@ -53,7 +55,7 @@ class GenerateSampleConfViaFmtTargetsRequest(FmtTargetsRequest):
 
 
 @rule(
-    desc="Update conf/st2.conf.sample with tools/config_gen.py",
+    desc=f"Update conf/st2.conf.sample with {SCRIPT_DIR}/{SCRIPT}.py",
     level=LogLevel.DEBUG,
 )
 async def generate_sample_conf_via_fmt(
@@ -68,7 +70,13 @@ async def generate_sample_conf_via_fmt(
     pex = await Get(
         VenvPex,
         PexFromTargetsRequest(
-            [Address("tools", target_name="tools", relative_file_path=f"{SCRIPT}.py")],
+            [
+                Address(
+                    SCRIPT_DIR,
+                    target_name=SCRIPT_DIR,
+                    relative_file_path=f"{SCRIPT}.py",
+                )
+            ],
             output_filename=f"{SCRIPT}.pex",
             internal_only=True,
             main=EntryPoint(SCRIPT),

--- a/pants-plugins/sample_conf/rules_test.py
+++ b/pants-plugins/sample_conf/rules_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/sample_conf/rules_test.py
+++ b/pants-plugins/sample_conf/rules_test.py
@@ -1,0 +1,156 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pants.backend.python import target_types_rules
+from pants.backend.python.target_types import PythonSourcesGeneratorTarget
+
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.target import Target
+from pants.core.goals.fmt import FmtResult
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .rules import (
+    SCRIPT,
+    SCRIPT_DIR,
+    GenerateSampleConfFieldSet,
+    GenerateSampleConfViaFmtTargetsRequest,
+    rules as sample_conf_rules,
+)
+from .target_types import SampleConf
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *sample_conf_rules(),
+            *target_types_rules.rules(),
+            QueryRule(FmtResult, (GenerateSampleConfViaFmtTargetsRequest,)),
+            QueryRule(SourceFiles, (SourceFilesRequest,)),
+        ],
+        target_types=[SampleConf, PythonSourcesGeneratorTarget],
+    )
+
+
+def run_st2_generate_sample_conf(
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    *,
+    extra_args: list[str] | None = None,
+) -> FmtResult:
+    rule_runner.set_options(
+        [
+            "--backend-packages=sample_conf",
+            f"--source-root-patterns=/{SCRIPT_DIR}",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    field_sets = [GenerateSampleConfFieldSet.create(tgt) for tgt in targets]
+    input_sources = rule_runner.request(
+        SourceFiles,
+        [
+            SourceFilesRequest(field_set.source for field_set in field_sets),
+        ],
+    )
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            GenerateSampleConfViaFmtTargetsRequest(
+                field_sets, snapshot=input_sources.snapshot
+            ),
+        ],
+    )
+    return fmt_result
+
+
+# copied from pantsbuild/pants.git/src/python/pants/backend/python/lint/black/rules_integration_test.py
+def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
+    files = [
+        FileContent(path, content.encode()) for path, content in source_files.items()
+    ]
+    digest = rule_runner.request(Digest, [CreateDigest(files)])
+    return rule_runner.request(Snapshot, [digest])
+
+
+# add dummy script at tools/config_gen.py that the test can load.
+SCRIPT_PY = """
+def main():
+    sample_conf_text = "{sample_conf_text}"
+    print(sample_conf_text)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def write_files(
+    sample_conf_dir: str, sample_conf_file: str, before: str, after: str, rule_runner: RuleRunner
+) -> None:
+    files = {
+        f"{sample_conf_dir}/{sample_conf_file}": before,
+        f"{sample_conf_dir}/BUILD": f"sample_conf(name='t', source='{sample_conf_file}')",
+        # add in the target that's hard-coded in the generate_sample_conf_via_fmt rue
+        f"{SCRIPT_DIR}/{SCRIPT}.py": SCRIPT_PY.format(sample_conf_text=after),
+        f"{SCRIPT_DIR}/__init__.py": "",
+        f"{SCRIPT_DIR}/BUILD": "python_sources()",
+    }
+
+    rule_runner.write_files(files)
+
+
+def test_changed(rule_runner: RuleRunner) -> None:
+    write_files(
+        sample_conf_dir="my_dir",
+        sample_conf_file="dummy.conf",
+        before="BEFORE",
+        after="AFTER",
+        rule_runner=rule_runner,
+    )
+
+    tgt = rule_runner.get_target(
+        Address("my_dir", target_name="t", relative_file_path="dummy.conf")
+    )
+    fmt_result = run_st2_generate_sample_conf(rule_runner, [tgt])
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"my_dir/dummy.conf": "AFTER\n"}
+    )
+    assert fmt_result.did_change is True
+
+
+def test_unchanged(rule_runner: RuleRunner) -> None:
+    write_files(
+        sample_conf_dir="my_dir",
+        sample_conf_file="dummy.conf",
+        before="AFTER\n",
+        after="AFTER",  # print() adds a newline
+        rule_runner=rule_runner,
+    )
+
+    tgt = rule_runner.get_target(
+        Address("my_dir", target_name="t", relative_file_path="dummy.conf")
+    )
+    fmt_result = run_st2_generate_sample_conf(rule_runner, [tgt])
+    assert fmt_result.output == get_snapshot(
+        rule_runner, {"my_dir/dummy.conf": "AFTER\n"}
+    )
+    assert fmt_result.did_change is False

--- a/pants-plugins/sample_conf/rules_test.py
+++ b/pants-plugins/sample_conf/rules_test.py
@@ -104,7 +104,11 @@ if __name__ == "__main__":
 
 
 def write_files(
-    sample_conf_dir: str, sample_conf_file: str, before: str, after: str, rule_runner: RuleRunner
+    sample_conf_dir: str,
+    sample_conf_file: str,
+    before: str,
+    after: str,
+    rule_runner: RuleRunner,
 ) -> None:
     files = {
         f"{sample_conf_dir}/{sample_conf_file}": before,

--- a/pants-plugins/sample_conf/rules_test.py
+++ b/pants-plugins/sample_conf/rules_test.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from pants.backend.python import target_types_rules

--- a/pants-plugins/sample_conf/target_types.py
+++ b/pants-plugins/sample_conf/target_types.py
@@ -26,7 +26,7 @@ class SampleConfSourceField(OptionalSingleSourceField):
     default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
 
 
-#class SampleConfSourceField(SingleSourceField):
+# class SampleConfSourceField(SingleSourceField):
 #    alias = "output"
 #    required = False
 #    default = "st2.conf.sample"
@@ -35,6 +35,4 @@ class SampleConfSourceField(OptionalSingleSourceField):
 class SampleConf(Target):
     alias = "sample_conf"
     core_fields = (*COMMON_TARGET_FIELDS, Dependencies, SampleConfSourceField)
-    help = (
-        "Generate st2.conf.sample file from python sources."
-    )
+    help = "Generate st2.conf.sample file from python sources."

--- a/pants-plugins/sample_conf/target_types.py
+++ b/pants-plugins/sample_conf/target_types.py
@@ -1,0 +1,40 @@
+# Copyright 2022 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pants.engine.fs import GlobMatchErrorBehavior
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    OptionalSingleSourceField,
+    Target,
+)
+
+
+class SampleConfSourceField(OptionalSingleSourceField):
+    default = "st2.conf.sample"
+
+    default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
+
+
+#class SampleConfSourceField(SingleSourceField):
+#    alias = "output"
+#    required = False
+#    default = "st2.conf.sample"
+
+
+class SampleConf(Target):
+    alias = "sample_conf"
+    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, SampleConfSourceField)
+    help = (
+        "Generate st2.conf.sample file from python sources."
+    )

--- a/pants-plugins/sample_conf/target_types.py
+++ b/pants-plugins/sample_conf/target_types.py
@@ -11,25 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pants.engine.fs import GlobMatchErrorBehavior
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
-    OptionalSingleSourceField,
+    SingleSourceField,
     Target,
 )
 
 
-class SampleConfSourceField(OptionalSingleSourceField):
+class SampleConfSourceField(SingleSourceField):
     default = "st2.conf.sample"
-
-    default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
-
-
-# class SampleConfSourceField(SingleSourceField):
-#    alias = "output"
-#    required = False
-#    default = "st2.conf.sample"
 
 
 class SampleConf(Target):

--- a/pants-plugins/sample_conf/target_types.py
+++ b/pants-plugins/sample_conf/target_types.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The StackStorm Authors.
+# Copyright 2023 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants.toml
+++ b/pants.toml
@@ -25,6 +25,7 @@ backend_packages = [
   # internal plugins in pants-plugins/
   "pants.backend.plugin_development",
   "api_spec",
+  "sample_conf",
   "schemas",
 ]
 # pants ignores files in .gitignore, .*/ directories, /dist/ directory, and __pycache__.

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,27 @@
-python_sources()
+python_sources(
+    overrides={
+        "config_gen.py": {
+            "dependencies": [
+                # the auth backends get listed in the conf file
+                "//:auth_backends",
+                # the following should match CONFIGS in config_gen.py
+                # grep -rl '^def register_opts(ignore_errors=False):' st2*
+                "st2actions/st2actions/scheduler/config.py",
+                "st2actions/st2actions/workflows/config.py",
+                "st2actions/st2actions/notifier/config.py",
+                "st2actions/st2actions/config.py",
+                "st2api/st2api/config.py",
+                "st2auth/st2auth/config.py",
+                "st2common/st2common/config.py",
+                "st2reactor/st2reactor/garbage_collector/config.py",
+                "st2reactor/st2reactor/timer/config.py",
+                "st2reactor/st2reactor/sensor/config.py",
+                "st2reactor/st2reactor/rules/config.py",
+                "st2stream/st2stream/config.py",
+            ]
+        },
+    },
+)
 
 shell_sources(
     name="shell",

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -25,7 +25,7 @@ from oslo_config import cfg
 
 
 CONFIGS = [
-    # this is duplicated in conf/BUILD
+    # this is duplicated in tools/BUILD
     # TODO: replace this with a heuristic that searches for config.py
     #       maybe with an exclude list (eg st2tests.config st2client)
     #       grep -rl 'def register_opts(ignore_errors=False):' st2*

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -25,6 +25,10 @@ from oslo_config import cfg
 
 
 CONFIGS = [
+    # this is duplicated in conf/BUILD
+    # TODO: replace this with a heuristic that searches for config.py
+    #       maybe with an exclude list (eg st2tests.config st2client)
+    #       grep -rl 'def register_opts(ignore_errors=False):' st2*
     "st2actions.config",
     "st2actions.scheduler.config",
     "st2actions.notifier.config",


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR improves the DX (developer experience) by wiring up the `fmt` and `lint` goals to generate `conf/st2.conf.sample` if needed (or for lint, warn that it needs to be done).

This includes creating a `sample_conf` plugin for pants that adds a `sample_conf` target.

### Developer Experience

Today, if someone changes one of the files used to generate `conf/st2.conf.sample`, they will probably forget to run the Makefile target the regenerates them: `make configgen`.

I've missed running that several times. CI complains as part of the `ci-checks` Makefile target, with instructions to `Please run "make configgen"`. This also gets regenerated any time someone runs the `lint` or `tests` Makefile targets, which might be surprising (tests generally shouldn't handle codegen).

With this PR, we add `st2.conf.sample` generation into the `fmt` goal. This also adds it to the `lint` goal which will tell people if `fmt` needs to run to update any code (or in this case, regenerate the sample conf file). Then, we only need simple instructions that say something like:

> Please run `./pants fmt lint ::` before submitting your PR. This will reformat code, if needed, and warn you about any other errors.

### Fine grained results cache

After someone runs `./pants fmt ::` once, they will benefit from the pants' results cache. For the sample_conf plugin, here's what that means:

First, the `sample_conf` target in `conf/` depends on `tools/config_gen.py`:

https://github.com/StackStorm/st2/blob/1faea8f17a9b6b55c21218df8f7d999700338826/conf/BUILD#L6-L9

If the `config_gen` script changes, then pants now knows that the sample conf file need to be regenerated. Or, in other words, the `config_gen.py` file is part of the cache key for `conf/st2.conf.sample`. If that file changes, then pants will re-run the generator.

For many of our scripts, we can depend on pants' python dependency inference to grab the other files. But, this script uses importlib instead of standard imports, so we need to add the dependencies manually (_aside: there is a feature that tries to use strings for dep inference, but it is not enabled by default, and I have not tested to see how many false positives it will find across our repo_). In the future, hopefully we can remove or simplify this.

https://github.com/StackStorm/st2/blob/1faea8f17a9b6b55c21218df8f7d999700338826/tools/BUILD#L1-L24

Please note the explicit dependency on `//:auth_backends`. Nothing in our code base directly imports from the auth backends. But, we ship with a default set of backends, so we need to make sure that their settings are included in the sample conf file's auth section. This is defined here:

https://github.com/StackStorm/st2/blob/1faea8f17a9b6b55c21218df8f7d999700338826/BUILD#L43-L49

Then, I ran into one more dependency issue. `st2-auth-ldap` does not declare a dependency on our `st2auth` module, in part because that is an implicit dep for auth modules. We should probably make that explicit at some point, but that might require publishing more wheels on pypi. That's messy, but pants meets us where we are in this mess. 😄 So, we can tell pants that any time we grab the `st2-auth-ldap` package, it requires something in the `st2auth` module, like this:

https://github.com/StackStorm/st2/blob/1faea8f17a9b6b55c21218df8f7d999700338826/BUILD#L34-L39

Then, once all of those deps that pants can't infer (for now) are recorded, pants is able to invalidate the st2.conf.sample cache if any of the dependency python source files (including all that get imported directly or transitively by `tools/config_gen.py`).

This PR actually only wires up the `fmt` goal and took advantage of the fact that pants also runs formatters whenever it runs linters, which are side-effect free. And because pants runs the formatters in a sandbox, it doesn't have to materialize any changes during lint.

Continuing the example, since pants cached the results when running the `lint` goal, running `fmt` will be very fast. Pants will just materialize the already-generated schemas from its cache.

### Developing pants plugins

Pants has extensive documentation on the plugin API, including how to create targets, how to write rules, and there's even a mini tutorial about how to add a formatter (adding formatters is a very common thing for plugins to do).

- [Plugins overview](https://www.pantsbuild.org/docs/plugins-overview)
- [The Target API](https://www.pantsbuild.org/docs/target-api)
- [The Rules API](https://www.pantsbuild.org/docs/rules-api)
- [Processes](https://www.pantsbuild.org/docs/rules-api-process) (running subprocesses in pants plugins)
- [Add a formatter](https://www.pantsbuild.org/docs/plugins-fmt-goal)
- [Testing Plugins](https://www.pantsbuild.org/docs/rules-api-testing)