### PR TITLE
pants: Add `st2_shell_sources_and_resources()` macro to `pants-plugins/macros.py`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
+  #5890
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/pants-plugins/BUILD
+++ b/pants-plugins/BUILD
@@ -11,3 +11,5 @@ pants_requirements(
     name="pants",
     testutil=True,
 )
+
+python_sources()

--- a/pants-plugins/README.md
+++ b/pants-plugins/README.md
@@ -16,6 +16,7 @@ These StackStorm-specific plugins might be useful in other StackStorm-related re
 
 These StackStorm-specific plugins are probably only useful for the st2 repo.
 - `api_spec`
+- `macros.py` (not a plugin - see pants.toml `[GLOBAL].build_file_prelude_globs`)
 - `release`
 - `sample_conf`
 - `schemas`
@@ -32,6 +33,16 @@ regenerated.
 This plugin also wires up pants so that the `lint` goal runs additional
 api spec validation on `st2common/st2common/openapi.yaml` with something
 like `./pants lint st2common/st2common/openapi.yaml`.
+
+### `macros.py` macros
+
+[Macros](https://www.pantsbuild.org/docs/macros) are a pants feature
+that can reduce "boilerplate"/duplication in BUILD files. The functions
+defined in `macros.py` are available in all the BUILD files, and using
+them looks just like using the normal BUILD targets.
+
+For documentation about our macros, please refer to the function docstrings
+in the `macros.py` file.
 
 ### `pack_metadata` plugin
 

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -1,0 +1,13 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -22,7 +22,7 @@ def st2_shell_sources_and_resources(**kwargs):
     """
     shell_sources(**kwargs)  # noqa: F821
 
-    kwargs.pop("skip_shellcheck")
+    kwargs.pop("skip_shellcheck", None)
 
     kwargs["name"] += "_resources"
     resources(**kwargs)  # noqa: F821

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -20,9 +20,9 @@ def st2_shell_sources_and_resources(**kwargs):
     are silently ignored. So, we also need the resources target
     to allow depending on them.
     """
-    shell_sources(**kwargs)
+    shell_sources(**kwargs)  # noqa: F821
 
     kwargs.pop("skip_shellcheck")
 
     kwargs["name"] += "_resources"
-    resources(**kwargs)
+    resources(**kwargs)  # noqa: F821

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -11,3 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+def st2_shell_sources_and_resources(**kwargs):
+    """This creates a shell_sources and a resources target.
+
+    This is needed because python_sources dependencies on shell_sources
+    are silently ignored. So, we also need the resources target
+    to allow depending on them.
+    """
+    shell_sources(**kwargs)
+
+    kwargs.pop("skip_shellcheck")
+
+    kwargs["name"] += "_resources"
+    resources(**kwargs)

--- a/pants.toml
+++ b/pants.toml
@@ -8,6 +8,7 @@ repo_id = "de0dea7a-9f6a-4c6e-aa20-6ba5ad969b8a"
 [GLOBAL]
 pants_version = "2.14.0"
 pythonpath = ["%(buildroot)s/pants-plugins"]
+build_file_prelude_globs = ["pants-plugins/macros.py"]
 backend_packages = [
   # python
   "pants.backend.python",

--- a/st2actions/bin/BUILD
+++ b/st2actions/bin/BUILD
@@ -5,7 +5,8 @@ python_sources(
     skip_pylint=True,
 )
 
-shell_sources(
+st2_shell_sources_and_resources(
     name="shell",
+    sources=["*.sh"],
     skip_shellcheck=True,
 )

--- a/st2common/bin/BUILD
+++ b/st2common/bin/BUILD
@@ -5,7 +5,7 @@ python_sources(
     skip_pylint=True,
 )
 
-shell_sources(
+st2_shell_sources_and_resources(
     name="shell",
     sources=["st2ctl", "st2-self-check", "st2-run-pack-tests"],
     skip_shellcheck=True,

--- a/st2tests/st2tests/fixtures/generic/BUILD
+++ b/st2tests/st2tests/fixtures/generic/BUILD
@@ -1,5 +1,9 @@
 pack_metadata(
     name="metadata",
+    dependencies=[
+        "./actions:shell",
+        "./actions:shell_resources",
+    ],
 )
 
 python_sources(

--- a/st2tests/st2tests/fixtures/generic/actions/BUILD
+++ b/st2tests/st2tests/fixtures/generic/actions/BUILD
@@ -1,1 +1,4 @@
-shell_sources()
+st2_shell_sources_and_resources(
+    name="shell",
+    sources=["*.sh"],
+)

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -13,7 +13,7 @@ pack_metadata_in_git_submodule(
     ],
 )
 
-shell_sources(
+st2_shell_sources_and_resources(
     name="test_content_version_shell",
     # do not check across git submodule boundary
     skip_shellcheck=True,
@@ -29,6 +29,7 @@ python_sources(
     dependencies=[
         ":test_content_version_metadata",
         ":test_content_version_shell",
+        ":test_content_version_shell_resources",
     ],
     sources=[
         "test_content_version/**/*.py",


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR adds our first pants macro: `st2_shell_sources_and_resources()`

I'm planning to add 3 more macros to help with building our `python_distribution` targets (for buildling wheels) in future PRs. This just introduces the concept of macros.

### Macros

> Macros are useful to reduce boilerplate in BUILD files.
> ...
> Macros are defined in Python files that act like a normal BUILD file. They have access to all the symbols you normally have registered in a BUILD file, such as all of your target types.
>
> Macros cannot import other modules, just like BUILD files cannot have import statements.

https://www.pantsbuild.org/docs/macros

Our macro file is `pants-plugins/macros.py`, and we tell pants about it with `[GLOBAL].build_file_prelude_globs` in `pants.toml`:

https://github.com/StackStorm/st2/blob/eb6902f341f1cda9a4dc83be442ccabb38a4c2a1/pants.toml#L11

This PR only introduces one macro. The key parts of this macro function are `shell_sources(...)` and `resources(...)` - ie, that's where our macro adds the normal pants targets using the kwargs passed to it.

https://github.com/StackStorm/st2/blob/eb6902f341f1cda9a4dc83be442ccabb38a4c2a1/pants-plugins/macros.py#L16-L28

And then we use the macro just like a regular target in a BUILD file:

https://github.com/StackStorm/st2/blob/eb6902f341f1cda9a4dc83be442ccabb38a4c2a1/st2actions/bin/BUILD#L8-L12