### PR TITLE
Update `pants-plugins/uses_services` to support checking for redis

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,19 @@ jobs:
           - 5672:5672/tcp   # AMQP standard port
           - 15672:15672/tcp # Management: HTTP, CLI
 
+      redis:
+         # Docker Hub image
+         image: redis
+         # Set health checks to wait until redis has started
+         options: >-
+           --name "redis"
+           --health-cmd "redis-cli ping"
+           --health-interval 10s
+           --health-timeout 5s
+           --health-retries 5
+         ports:
+           - 6379:6379/tcp
+
     env:
       COLUMNS: '120'
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
-  #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884
+  #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -5,4 +5,5 @@ __defaults__(
 
 python_tests(
     name="tests",
+    uses=["redis"],
 )

--- a/pants-plugins/uses_services/BUILD
+++ b/pants-plugins/uses_services/BUILD
@@ -16,5 +16,6 @@ python_tests(
     # overrides={
     #    "mongo_rules_test.py": {"uses": ["mongo"]},
     #    "rabbitmq_rules_test.py": {"uses": ["rabbitmq"]},
+    #    "redis_rules_test.py": {"uses": ["redis"]},
     # },
 )

--- a/pants-plugins/uses_services/redis_rules.py
+++ b/pants-plugins/uses_services/redis_rules.py
@@ -1,0 +1,168 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+
+from pants.backend.python.goals.pytest_runner import (
+    PytestPluginSetupRequest,
+    PytestPluginSetup,
+)
+from pants.backend.python.util_rules.pex import (
+    PexRequest,
+    PexRequirements,
+    VenvPex,
+    VenvPexProcess,
+    rules as pex_rules,
+)
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.rules import collect_rules, Get, MultiGet, rule
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope
+from pants.engine.target import Target
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from uses_services.exceptions import ServiceMissingError, ServiceSpecificMessages
+from uses_services.platform_rules import Platform
+from uses_services.scripts.is_redis_running import (
+    __file__ as is_redis_running_full_path,
+)
+from uses_services.target_types import UsesServicesField
+
+
+@dataclass(frozen=True)
+class UsesRedisRequest:
+    """One or more targets need a running redis service using these settings.
+
+    The coord_* attributes represent the coordination settings from st2.conf.
+    In st2 code, they come from:
+        oslo_config.cfg.CONF.coordination.url
+    """
+
+    # These config opts for integration tests are in:
+    #   conf/st2.dev.conf (copied to conf/st2.ci.conf)
+    # TODO: for int tests: set url by either modifying st2.{dev,ci}.conf on the fly or via env vars.
+
+    #   with our version of oslo.config (newer are slower) we can't directly override opts w/ environment variables.
+
+    coord_url: str = "redis://127.0.0.1:6379"
+
+
+@dataclass(frozen=True)
+class RedisIsRunning:
+    pass
+
+
+class PytestUsesRedisRequest(PytestPluginSetupRequest):
+    @classmethod
+    def is_applicable(cls, target: Target) -> bool:
+        if not target.has_field(UsesServicesField):
+            return False
+        uses = target.get(UsesServicesField).value
+        return uses is not None and "redis" in uses
+
+
+@rule(
+    desc="Ensure redis is running and accessible before running tests.",
+    level=LogLevel.DEBUG,
+)
+async def redis_is_running_for_pytest(
+    request: PytestUsesRedisRequest,
+) -> PytestPluginSetup:
+    # this will raise an error if redis is not running
+    _ = await Get(RedisIsRunning, UsesRedisRequest())
+
+    return PytestPluginSetup()
+
+
+@rule(
+    desc="Test to see if redis is running and accessible.",
+    level=LogLevel.DEBUG,
+)
+async def redis_is_running(
+    request: UsesRedisRequest, platform: Platform
+) -> RedisIsRunning:
+    script_path = "./is_redis_running.py"
+
+    # pants is already watching this directory as it is under a source root.
+    # So, we don't need to double watch with PathGlobs, just open it.
+    with open(is_redis_running_full_path, "rb") as script_file:
+        script_contents = script_file.read()
+
+    script_digest, tooz_pex = await MultiGet(
+        Get(Digest, CreateDigest([FileContent(script_path, script_contents)])),
+        Get(
+            VenvPex,
+            PexRequest(
+                output_filename="tooz.pex",
+                internal_only=True,
+                requirements=PexRequirements({"tooz", "redis"}),
+            ),
+        ),
+    )
+
+    result = await Get(
+        FallibleProcessResult,
+        VenvPexProcess(
+            tooz_pex,
+            argv=(
+                script_path,
+                request.coord_url,
+            ),
+            input_digest=script_digest,
+            description="Checking to see if Redis is up and accessible.",
+            # this can change from run to run, so don't cache results.
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            level=LogLevel.DEBUG,
+        ),
+    )
+    is_running = result.exit_code == 0
+
+    if is_running:
+        return RedisIsRunning()
+
+    # redis is not running, so raise an error with instructions.
+    raise ServiceMissingError.generate(
+        platform=platform,
+        messages=ServiceSpecificMessages(
+            service="redis",
+            service_start_cmd_el_7="service redis start",
+            service_start_cmd_el="systemctl start redis",
+            not_installed_clause_el="this is one way to install it:",
+            install_instructions_el=dedent(
+                """\
+                sudo yum -y install redis
+                # Don't forget to start redis.
+                """
+            ),
+            service_start_cmd_deb="systemctl start redis",
+            not_installed_clause_deb="this is one way to install it:",
+            install_instructions_deb=dedent(
+                """\
+                sudo apt-get install -y mongodb redis
+                # Don't forget to start redis.
+                """
+            ),
+            service_start_cmd_generic="systemctl start redis",
+        ),
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(PytestPluginSetupRequest, PytestUsesRedisRequest),
+        *pex_rules(),
+    ]

--- a/pants-plugins/uses_services/redis_rules_test.py
+++ b/pants-plugins/uses_services/redis_rules_test.py
@@ -1,0 +1,90 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+from pants.engine.internals.scheduler import ExecutionError
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .data_fixtures import platform, platform_samples
+from .exceptions import ServiceMissingError
+from .redis_rules import (
+    RedisIsRunning,
+    UsesRedisRequest,
+    rules as redis_rules,
+)
+from .platform_rules import Platform
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *redis_rules(),
+            QueryRule(RedisIsRunning, (UsesRedisRequest, Platform)),
+        ],
+        target_types=[],
+    )
+
+
+def run_redis_is_running(
+    rule_runner: RuleRunner,
+    uses_redis_request: UsesRedisRequest,
+    mock_platform: Platform,
+    *,
+    extra_args: list[str] | None = None,
+) -> RedisIsRunning:
+    rule_runner.set_options(
+        [
+            "--backend-packages=uses_services",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    result = rule_runner.request(
+        RedisIsRunning,
+        [uses_redis_request, mock_platform],
+    )
+    return result
+
+
+# Warning this requires that redis be running
+def test_redis_is_running(rule_runner: RuleRunner) -> None:
+    request = UsesRedisRequest()
+    mock_platform = platform(os="TestMock")
+
+    # we are asserting that this does not raise an exception
+    is_running = run_redis_is_running(rule_runner, request, mock_platform)
+    assert is_running
+
+
+@pytest.mark.parametrize("mock_platform", platform_samples)
+def test_redis_not_running(rule_runner: RuleRunner, mock_platform: Platform) -> None:
+    request = UsesRedisRequest(
+        coord_url="redis://127.100.20.7:10",  # 10 is an unassigned port, unlikely to be used
+    )
+
+    with pytest.raises(ExecutionError) as exception_info:
+        run_redis_is_running(rule_runner, request, mock_platform)
+
+    execution_error = exception_info.value
+    assert len(execution_error.wrapped_exceptions) == 1
+
+    exc = execution_error.wrapped_exceptions[0]
+    assert isinstance(exc, ServiceMissingError)
+
+    assert exc.service == "redis"
+    assert "The redis service does not seem to be running" in str(exc)
+    assert exc.instructions != ""

--- a/pants-plugins/uses_services/scripts/is_redis_running.py
+++ b/pants-plugins/uses_services/scripts/is_redis_running.py
@@ -1,0 +1,48 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import sys
+
+
+def _is_redis_running(coord_url: str) -> bool:
+    """Connect to redis with connection logic that mirrors the st2 code.
+
+    In particular, this is based on:
+      - st2common.services.coordination.coordinator_setup()
+
+    This should not import the st2 code as it should be self-contained.
+    """
+    # late import so that __file__ can be imported in the pants plugin without these imports
+    from tooz import ToozError, coordination
+
+    member_id = "pants-uses_services-redis"
+    coordinator = coordination.get_coordinator(coord_url, member_id)
+    try:
+        coordinator.start(start_heart=False)
+    except ToozError:
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    args = dict((k, v) for k, v in enumerate(sys.argv))
+
+    # unit tests do not use redis, they use use an in-memory coordinator: "zake://"
+    # integration tests use this url with a conf file derived from conf/st2.dev.conf
+    coord_url = args.get(1, "redis://127.0.0.1:6379")
+
+    is_running = _is_redis_running(coord_url)
+    exit_code = 0 if is_running else 1
+    sys.exit(exit_code)

--- a/st2tests/integration/orquesta/BUILD
+++ b/st2tests/integration/orquesta/BUILD
@@ -2,4 +2,5 @@ python_sources()
 
 python_tests(
     name="tests",
+    uses=["redis"],
 )


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR builds on #5864 and #5884 to further improve the DX (developer experience) by failing as early as possible if the development (or CI) environment does not have the required services.

This PR adds checks for `redis`, like #5864 added `mongo` checks and #5884 added `rabbitmq` checks.

Please see #5864 for a more detailed description of `pants-plugins/uses_services`.

### `is_redis_running.py` script and the rule that runs it

[`is_redis_running.py`](https://github.com/StackStorm/st2/pull/5893/files#diff-ba1edf54790a4a79ed0a370092f709cc15bf05d65ce0b62473d4d82211ba0839) is the part that checks to see if redis is running.

The pants plugin cannot import anything from our other `st2*` code, so `is_redis_running.py` is a minimal self-contained script that mirrors how st2 connects to redis. It should be as minimal as possible so that keeping it up-to-date with the core st2 code is not onerous.

The `is_redis_running.py` rule gets opened and run in a pex with the same rule logic as `is_mongo_running.py` and `inspect_platform.py` (see #5864).

Redis, like rabbitmq, embeds all auth stuff in the connection url. So, there are not as many settings to worry about as there were with mongo. For now, this only supports the url hard-coded in the tests. Here is where the rule defines the default url:
 
https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L47-L62

Here is the definition of the rule that runs `is_redis_running.py`:
https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L96-L98

So, when another rule Gets `RedisIsRunning` with a `UsesRedisRequest`, pants will also run the rule that generates `Platform` (described in #5864), and then it will run this `is_redis_running` rule.

The `is_redis_running` rule either returns `RedisIsRunning()` if it is running, or raises `ServiceMissingError` if it is not. By raising an error, this actually breaks a convention for pants rules. Exceptions stop everything and get shown to the user right away, and for most goals, pants wants to see some dataclass returned that has something like a `succeeded` boolean instead. But, we want to error as early as possible, so this breaks that convention on purpose.

### wiring up the `test` goal so it runs `is_redis_running` when `pytest` runs on a target with the `uses` field.

The last piece that ties this all together is a rule that makes sure the `is_redis_running` rule runs before `pytest` runs (if pants is running it on a target with the `uses` field). Here is the definition of the `redis_is_running_for_pytest` rule:

https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L83-L85

This rule is very simple. It just triggers running the `is_redis_running` rule:
https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L86-L89

This rule needs the `PytestUsesRedisRequest` which selects targets that have the `uses` field.

https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L70-L76

This request will be made by the pants-internal pytest rules thanks to this `UnionRule`, which is a way to declare that our class "implements" the `PytestPluginSetupRequest`:

https://github.com/StackStorm/st2/blob/06aedfa0a1efa28d17affe6f114a7d6bac631b28/pants-plugins/uses_services/redis_rules.py#L168

If we need to add `uses` support to other targets, we will need to find similar UnionRules where we can inject our rule logic. For now, I've only wired this up so our `uses` rules will run for pytest.