### PR TITLE
Pants: Misc `pants-plugins/uses_services` improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890
+  #5890 #5898
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/pants-plugins/uses_services/mongo_rules_test.py
+++ b/pants-plugins/uses_services/mongo_rules_test.py
@@ -75,6 +75,7 @@ def test_mongo_not_running(rule_runner: RuleRunner, mock_platform: Platform) -> 
     request = UsesMongoRequest(
         db_host="127.100.20.7",
         db_port=10,  # unassigned port, unlikely to be used
+        db_connection_timeout=10,  # ms # very short as it should fail anyway
     )
 
     with pytest.raises(ExecutionError) as exception_info:

--- a/pants-plugins/uses_services/register.py
+++ b/pants-plugins/uses_services/register.py
@@ -16,7 +16,7 @@ from pants.backend.python.target_types import (
     PythonTestsGeneratorTarget,
 )
 
-from uses_services import mongo_rules, platform_rules
+from uses_services import mongo_rules, platform_rules, rabbitmq_rules, redis_rules
 from uses_services.target_types import UsesServicesField
 
 
@@ -26,4 +26,6 @@ def rules():
         PythonTestTarget.register_plugin_field(UsesServicesField),
         *platform_rules.rules(),
         *mongo_rules.rules(),
+        *rabbitmq_rules.rules(),
+        *redis_rules.rules(),
     ]


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

2 quick fixes for issues I noticed with the pants-plugins:

1. Shorten the timeout for `pants-plugins/uses_services` mongo tests where we expect the check to fail so that the tests go faster.
2. I forgot to register the rabbitmq and redis rules in `pants-plugins/uses_services` added in #5884 and #5893.