### PR TITLE
pants: Add `st2_*_python_distribution()` macros to `pants-plugins/macros.py`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -52,3 +52,8 @@ python_test_utils(
     name="test_utils",
     skip_pylint=True,
 )
+
+file(
+    name="license",
+    source="LICENSE",
+)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898
+  #5890 #5898 #5901
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -13,6 +13,79 @@
 # limitations under the License.
 
 
+def st2_runner_python_distribution(**kwargs):
+    runner_name = kwargs.pop("runner_name")
+    description = kwargs.pop("description")
+
+    kwargs["provides"] = python_artifact(  # noqa: F821
+        name=f"stackstorm-runner-{runner_name.replace('_', '-')}",
+        description=description,
+        version_file=f"{runner_name}_runner/__init__.py",  # custom for our release plugin
+        # test_suite="tests",
+        zip_safe=kwargs.pop(
+            "zip_safe", True
+        ),  # most runners are safe to run from a zipapp
+    )
+
+    dependencies = kwargs.pop("dependencies", [])
+    for dep in [f"./{runner_name}_runner"]:
+        if dep not in dependencies:
+            dependencies.append(dep)
+    kwargs["dependencies"] = dependencies
+
+    repositories = kwargs.pop("repositories", [])
+    for repo in ["@pypi"]:
+        if repo not in repositories:
+            repositories.append(repo)
+    kwargs["repositories"] = repositories
+
+    python_distribution(**kwargs)  # noqa: F821
+
+
+def st2_component_python_distribution(**kwargs):
+    st2_component = kwargs.pop("component_name")
+
+    description = (
+        f"{st2_component} StackStorm event-driven automation platform component"
+    )
+
+    scripts = kwargs.pop("scripts", [])
+
+    kwargs["provides"] = python_artifact(  # noqa: F821
+        name=st2_component,
+        description=description,
+        scripts=[
+            script[:-6] if script.endswith(":shell") else script for script in scripts
+        ],
+        version_file=f"{st2_component}/__init__.py",  # custom for our release plugin
+        # test_suite=st2_component,
+        zip_safe=False,  # We rely on __file__ to load many things, so st2 should not run from a zipapp
+    )
+
+    dependencies = kwargs.pop("dependencies", [])
+
+    for dep in [st2_component] + scripts:
+        dep = f"./{dep}" if dep[0] != ":" else dep
+        if dep not in dependencies:
+            dependencies.append(dep)
+
+        # see st2_shell_sources_and_resources below
+        if dep.endswith(":shell"):
+            dep_res = f"{dep}_resources"
+            if dep_res not in dependencies:
+                dependencies.append(dep_res)
+
+    kwargs["dependencies"] = dependencies
+
+    repositories = kwargs.pop("repositories", [])
+    for repo in ["@pypi"]:
+        if repo not in repositories:
+            repositories.append(repo)
+    kwargs["repositories"] = repositories
+
+    python_distribution(**kwargs)  # noqa: F821
+
+
 def st2_shell_sources_and_resources(**kwargs):
     """This creates a shell_sources and a resources target.
 

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -25,12 +25,12 @@ def st2_publish_repos():
     Credentials for pypi should be in ~/.pypirc or in TWINE_* env vars.
     """
     # TODO: switch from hard-coded to env() once we upgrade to pants 2.16
-    # return [env("ST2_PUBLISH_REPO", "@pypi")]
+    # return [env("ST2_PUBLISH_REPO", "@pypi")]  # noqa: F821
     return ["@pypi"]
 
 
 def st2_license(**kwargs):
-    """copy the LICENSE file into each wheel.
+    """Copy the LICENSE file into each wheel.
 
     As long as the file is in the src root when building the sdist/wheel,
     setuptools automatically includes the LICENSE file in the dist-info.
@@ -46,6 +46,7 @@ def st2_license(**kwargs):
 
 
 def st2_runner_python_distribution(**kwargs):
+    """Create a python_distribution (wheel/sdist) for a StackStorm runner."""
     runner_name = kwargs.pop("runner_name")
     description = kwargs.pop("description")
 
@@ -73,15 +74,14 @@ def st2_runner_python_distribution(**kwargs):
 
 
 def st2_component_python_distribution(**kwargs):
+    """Create a python_distribution (wheel/sdist) for a core StackStorm component."""
     st2_component = kwargs.pop("component_name")
-
-    st2_license(dest=st2_component)
-
     description = (
         f"{st2_component} StackStorm event-driven automation platform component"
     )
-
     scripts = kwargs.pop("scripts", [])
+
+    st2_license(dest=st2_component)
 
     kwargs["provides"] = python_artifact(  # noqa: F821
         name=st2_component,
@@ -95,7 +95,6 @@ def st2_component_python_distribution(**kwargs):
     )
 
     dependencies = kwargs.pop("dependencies", [])
-
     for dep in [st2_component, ":license"] + scripts:
         dep = f"./{dep}" if dep[0] != ":" else dep
         if dep not in dependencies:

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 
+def st2_publish_repos():
+    """Return the list of repos twine should publish to.
+
+    Twine will publish to ALL of these repos when running `./pants publish`.
+
+    We use ST2_PUBLISH_REPO, an env var, To facilitate switching between
+    @testpypi and @pypi. That also means someone could publish to their own
+    private repo by changing this var.
+
+    Credentials for pypi should be in ~/.pypirc or in TWINE_* env vars.
+    """
+    # TODO: switch from hard-coded to env() once we upgrade to pants 2.16
+    # return [env("ST2_PUBLISH_REPO", "@pypi")]
+    return ["@pypi"]
+
+
 def st2_license(**kwargs):
     """copy the LICENSE file into each wheel.
 
@@ -49,13 +65,9 @@ def st2_runner_python_distribution(**kwargs):
     for dep in [f"./{runner_name}_runner", ":license"]:
         if dep not in dependencies:
             dependencies.append(dep)
-    kwargs["dependencies"] = dependencies
 
-    repositories = kwargs.pop("repositories", [])
-    for repo in ["@pypi"]:
-        if repo not in repositories:
-            repositories.append(repo)
-    kwargs["repositories"] = repositories
+    kwargs["dependencies"] = dependencies
+    kwargs["repositories"] = st2_publish_repos()
 
     python_distribution(**kwargs)  # noqa: F821
 
@@ -96,12 +108,7 @@ def st2_component_python_distribution(**kwargs):
                 dependencies.append(dep_res)
 
     kwargs["dependencies"] = dependencies
-
-    repositories = kwargs.pop("repositories", [])
-    for repo in ["@pypi"]:
-        if repo not in repositories:
-            repositories.append(repo)
-    kwargs["repositories"] = repositories
+    kwargs["repositories"] = st2_publish_repos()
 
     python_distribution(**kwargs)  # noqa: F821
 

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -13,9 +13,27 @@
 # limitations under the License.
 
 
+def st2_license(**kwargs):
+    """copy the LICENSE file into each wheel.
+
+    As long as the file is in the src root when building the sdist/wheel,
+    setuptools automatically includes the LICENSE file in the dist-info.
+    """
+    if "dest" not in kwargs:
+        raise ValueError("'dest' path is required for st2_license macro")
+    relocated_files(  # noqa: F821
+        name="license",
+        files_targets=["//:license"],
+        src="",
+        **kwargs,
+    )
+
+
 def st2_runner_python_distribution(**kwargs):
     runner_name = kwargs.pop("runner_name")
     description = kwargs.pop("description")
+
+    st2_license(dest=f"contrib/runners/{runner_name}_runner")
 
     kwargs["provides"] = python_artifact(  # noqa: F821
         name=f"stackstorm-runner-{runner_name.replace('_', '-')}",
@@ -28,7 +46,7 @@ def st2_runner_python_distribution(**kwargs):
     )
 
     dependencies = kwargs.pop("dependencies", [])
-    for dep in [f"./{runner_name}_runner"]:
+    for dep in [f"./{runner_name}_runner", ":license"]:
         if dep not in dependencies:
             dependencies.append(dep)
     kwargs["dependencies"] = dependencies
@@ -44,6 +62,8 @@ def st2_runner_python_distribution(**kwargs):
 
 def st2_component_python_distribution(**kwargs):
     st2_component = kwargs.pop("component_name")
+
+    st2_license(dest=st2_component)
 
     description = (
         f"{st2_component} StackStorm event-driven automation platform component"
@@ -64,7 +84,7 @@ def st2_component_python_distribution(**kwargs):
 
     dependencies = kwargs.pop("dependencies", [])
 
-    for dep in [st2_component] + scripts:
+    for dep in [st2_component, ":license"] + scripts:
         dep = f"./{dep}" if dep[0] != ":" else dep
         if dep not in dependencies:
             dependencies.append(dep)


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This PR adds pants macros that reduce boilerplate around defining `python_distribution()`:
- `st2_license()`
- `st2_component_python_distribution()`
- `st2_runner_python_distribution()`

The next PR will actually add those macros to the relevant BUILD files.

See #5890 for a description of pants macros and what is involved in using them in pants.

### `st2_license()` macro

We need to add a LICENSE file to all of our wheels. When building wheels, we don't have to add any special metadata to the setup.py `setup()` call (or `pyproject.toml` or similar); we only need to put the LICENSE file in the directory that will be the wheel.

https://github.com/StackStorm/st2/blob/7de8f3c3c47392a8841653c590bd209db6546a23/pants-plugins/macros.py#L16-L21

### `st2_*_python_distribution()` macros

These macros create:
- a copy of the LICENSE file using the `st2_license` macro.
- a `python_artifact` object with the details needed to generate the setup.py kwargs. For example, it includes the `version_file` arg which is unique to `pants-plugins/release` which uses this to inject the version based on that file.
- a `python_distribution` target with the metadata for creating the wheel.

Using this macro is like creating a `python_distribution` like this in each of the BUILD files:

```python
python_distribution(
    provides=python_artifact(
        name="...",  # the wheel name
        description="...",
        version="3.9dev",
        zip_safe=...,
        scripts=[...],
    ),
    dependencies=[
        "./....",  # the primary python module
        ":license",
    ],
    repositories=[
        "@pypi",  # we plan to publish this on pypi
    ],
)
```

#### `st2_component_python_distribution()` macro

This is meant for for our primary components: `st2common`, `st2auth`, `st2api`, `st2client`, etc.

For example, in the next PR this is how we'll define the `st2api` distribution:
https://github.com/StackStorm/st2/blob/7032faf17e6a6b1b8bf229e23b7724536e67bc55/st2api/BUILD#L1-L4

#### `st2_runner_python_distribution()` macro

This is meant for our runners: `contrib/runners/*_runner`.

For example, in the next PR this is how we'll define the `noop` runner's distribution:
https://github.com/StackStorm/st2/blob/7032faf17e6a6b1b8bf229e23b7724536e67bc55/contrib/runners/noop_runner/BUILD#L1-L7