### PR TITLE
expose action parameter debug to all actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Added
 
 * Added publisher to ActionAlias to enable streaming ActionAlias create/update/delete events. #5763
   Contributed by @ubaumann
-  
+
 * Expose environment variable ST2_ACTION_DEBUG to all StackStorm actions.
   Contributed by @maxfactor1
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ Added
 
 * Added publisher to ActionAlias to enable streaming ActionAlias create/update/delete events. #5763
   Contributed by @ubaumann
+  
+* Expose environment variable ST2_ACTION_DEBUG to all StackStorm actions.
+  Contributed by @maxfactor1
 
 
 3.8.0 - November 18, 2022

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -233,6 +233,7 @@ class ActionRunner(object):
         result["ST2_ACTION_PACK_NAME"] = self.get_pack_ref()
         result["ST2_ACTION_EXECUTION_ID"] = str(self.execution_id)
         result["ST2_ACTION_API_URL"] = get_full_public_api_url()
+        result["ST2_ACTION_DEBUG"] = str(self._debug)
 
         if self.auth_token:
             result["ST2_ACTION_AUTH_TOKEN"] = self.auth_token.token

--- a/st2common/st2common/runners/base.py
+++ b/st2common/st2common/runners/base.py
@@ -155,6 +155,7 @@ class ActionRunner(object):
         self.context = None
         self.auth_token = None
         self.rerun_ex_ref = None
+        self._debug = None
 
     def pre_run(self):
         # Handle runner "enabled" attribute


### PR DESCRIPTION
### Background
This is a minor feature request to expose the runner parameter 'debug' to all StackStorm actions as an environment variable. Feature request was discussed briefly in Slack.

### Overview of this PR
This feature request allows the runner parameter 'debug' to be passed as an environment variable named ST2_ACTION_DEBUG to all st2 actions.