### PR TITLE
Update sensor wrapper to make `list_values()` method congruent with regular datastore method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ in development
 
 Added
 ~~~~~
+* Add support for `limit` and `offset` parameters in sensor wrapper `list_items()`
+  method to make congruent with regular datastore method. #5913
+
 * Move `git clone` to `user_home/.st2packs` #5845
 
 * Error on `st2ctl status` when running in Kubernetes. #5851

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -141,8 +141,10 @@ class SensorService(object):
     # Methods for datastore management
     ##################################
 
-    def list_values(self, local=True, prefix=None):
-        return self.datastore_service.list_values(local=local, prefix=prefix)
+    def list_values(self, local=True, prefix=None, limit=None, offset=0):
+        return self.datastore_service.list_values(
+            local=local, prefix=prefix, limit=limit, offset=offset
+        )
 
     def get_value(self, name, local=True, scope=SYSTEM_SCOPE, decrypt=False):
         return self.datastore_service.get_value(


### PR DESCRIPTION
Specifically, support use of `limit` and `offset` parameters.