### PR TITLE
Pants: reclassify test utils in BUILD metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922
+  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -11,4 +11,6 @@ python_tests(
     ],
 )
 
-python_sources()
+python_test_utils(
+    sources=["*.py", "!test_*.py"],
+)

--- a/st2client/tests/BUILD
+++ b/st2client/tests/BUILD
@@ -4,4 +4,6 @@ __defaults__(
     )
 )
 
-python_sources()
+python_test_utils(
+    sources=["*.py"],
+)

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -12,4 +12,6 @@ python_tests(
     uses=["mongo", "rabbitmq"],
 )
 
-python_sources()
+python_test_utils(
+    sources=["*.py", "!test_*.py"],
+)

--- a/st2tests/integration/orquesta/BUILD
+++ b/st2tests/integration/orquesta/BUILD
@@ -1,6 +1,8 @@
-python_sources()
-
 python_tests(
     name="tests",
     uses=["redis"],
+)
+
+python_test_utils(
+    sources=["*.py", "!test_*.py"],
 )


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

This replaces a 4 `python_sources` targets with `python_test_utils`. I excluded the `test_*.py` files in `tests/unit` directories since those are already covered by `python_tests` targets. I didn't bother to add that exclude in `st2client/tests/BUILD` however, because we keep our actual tests under `tests/unit` or `tests/integration` not directly under `tests/`.

Generally, `python_test_utils` captures things like `conftest.py` for pytest. Eventually, we might be able to replace these files with actual `conftest.py` files once we finish migrating to `pytest`. In any case, this makes more logical sense to me.

This PR does not make any functional changes - to Pants, `python_sources` and `python_test_utils` are functionally equivalent. So, this is a very minor/small PR.

### Pants documentation

- [`python_test_utils` target](https://www.pantsbuild.org/docs/reference-python_test_utils)
- [`python_sources` target](https://www.pantsbuild.org/docs/reference-python_sources)