### PR TITLE
Pants: add some missing external dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926
+  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -21,6 +21,7 @@
 //     "flex",
 //     "gitdb",
 //     "gitpython",
+//     "graphviz",
 //     "greenlet",
 //     "gunicorn",
 //     "jinja2",
@@ -37,6 +38,7 @@
 //     "orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0",
 //     "oslo.config<1.13,>=1.12.1",
 //     "paramiko",
+//     "pika",
 //     "prance",
 //     "prettytable",
 //     "prompt-toolkit<2",
@@ -44,6 +46,7 @@
 //     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
 //     "pymongo",
 //     "pyrabbit",
+//     "pysocks",
 //     "pytest",
 //     "python-dateutil",
 //     "python-editor",
@@ -133,13 +136,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "575299f20073c60a2cc9d4fa5906024cdde33c5c0ce6087c4e3c14be3b50fdd4",
-              "url": "https://files.pythonhosted.org/packages/0a/82/e8b6e7e2dfea46bd649ecaf8771fb6552232394fc9adf5c7f10655a87b95/APScheduler-3.10.0-py3-none-any.whl"
+              "hash": "e813ad5ada7aff36fb08cdda746b520531eaac7757832abc204868ba78e0c8f6",
+              "url": "https://files.pythonhosted.org/packages/d0/08/952d9570f4897dc2b30166fca5afd3a2cd19b3d408abdb470978484e8a09/APScheduler-3.10.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a49fc23269218416f0e41890eea7a75ed6b284f10630dcfe866ab659621a3696",
-              "url": "https://files.pythonhosted.org/packages/c7/17/dcdd450038f9b3888acf462ce778532c26c683fa2d6343ba1c7b2a383ae2/APScheduler-3.10.0.tar.gz"
+              "hash": "0293937d8f6051a0f493359440c1a1b93e882c57daf0197afeff0e727777b96e",
+              "url": "https://files.pythonhosted.org/packages/ea/ed/f1ad88e88208c24db80dcaae7a5a339bb283956984f8fa59933d2806413a/APScheduler-3.10.1.tar.gz"
             }
           ],
           "project_name": "apscheduler",
@@ -164,32 +167,35 @@
             "tzlocal!=3.*,>=2.0"
           ],
           "requires_python": ">=3.6",
-          "version": "3.10.0"
+          "version": "3.10.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cffa11ea77999bb0dd27bb25ff6dc142a6796142f68d45b1a26b11f58724561e",
-              "url": "https://files.pythonhosted.org/packages/d3/e5/c5509683462e51b070df9e83e7f72c1ccfe3f733f328b4a0f06804c27278/argcomplete-2.0.0-py2.py3-none-any.whl"
+              "hash": "17041f55b8c45099428df6ce6d0d282b892471a78c71375d24f227e21c13f8c5",
+              "url": "https://files.pythonhosted.org/packages/d9/40/13aea82bbe95c0f9f3c4ba21bdaf3ff12f405353b640d347cda55a23778a/argcomplete-2.1.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20",
-              "url": "https://files.pythonhosted.org/packages/05/f8/67851ae4fe5396ba6868c5d84219b81ea6a5d53991a6853616095c30adc0/argcomplete-2.0.0.tar.gz"
+              "hash": "72e08340852d32544459c0c19aad1b48aa2c3a96de8c6e5742456b4f538ca52f",
+              "url": "https://files.pythonhosted.org/packages/ac/43/b4ac2e533f86b96414a471589948da660925b95b50b1296bd25cd50c0e3e/argcomplete-2.1.1.tar.gz"
             }
           ],
           "project_name": "argcomplete",
           "requires_dists": [
             "coverage; extra == \"test\"",
+            "flake8; extra == \"lint\"",
             "flake8; extra == \"test\"",
-            "importlib-metadata<5,>=0.23; python_version == \"3.6\"",
-            "importlib-metadata<5,>=0.23; python_version == \"3.7\"",
+            "importlib-metadata<6,>=0.23; python_version == \"3.6\"",
+            "importlib-metadata<6,>=0.23; python_version == \"3.7\"",
+            "mypy; extra == \"lint\"",
+            "mypy; extra == \"test\"",
             "pexpect; extra == \"test\"",
             "wheel; extra == \"test\""
           ],
           "requires_python": ">=3.6",
-          "version": "2.0.0"
+          "version": "2.1.1"
         },
         {
           "artifacts": [
@@ -726,73 +732,73 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
-              "url": "https://files.pythonhosted.org/packages/a5/72/d723898ad2c4f974e760226934444f063cd6ee4cc107c6c9ec3470f50ab8/cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "103e8f7155f3ce2ffa0049fe60169878d47a4364b277906386f8de21c9234aa1",
+              "url": "https://files.pythonhosted.org/packages/1e/85/d5b768b45e564a66fc5ba6344145334208f01d64939adcb8c4032545d164/cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
-              "url": "https://files.pythonhosted.org/packages/14/61/c64c064ffaf1a52c7ee4a29caf3ed88755b016cb0523d841e63eb33a4976/cryptography-39.0.1-cp36-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97",
+              "url": "https://files.pythonhosted.org/packages/26/d2/85480f4e754375c6d8e4a18cc8d2f28ef1984cf2843395c4d1ea396331d3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106",
-              "url": "https://files.pythonhosted.org/packages/1b/90/3c06f3f7a74dad0955536088c3b743a74e8c57c265f2c7a4b61cebb369c1/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7",
+              "url": "https://files.pythonhosted.org/packages/3c/0c/ac188ca210fbc02102d34ad8dba6956fe16fc566e5c5110a7f7bdbd30138/cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
-              "url": "https://files.pythonhosted.org/packages/2f/c7/06087b04cd870f5acfdc10f8ba252f7985b32c82d4ff96cba05e5f034bf3/cryptography-39.0.1-cp36-abi3-manylinux_2_24_x86_64.whl"
+              "hash": "eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612",
+              "url": "https://files.pythonhosted.org/packages/3c/5a/6c180b745336f989e9b298e1790af0ef5b37640edb861fc536b5663726e3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505",
-              "url": "https://files.pythonhosted.org/packages/3f/e9/78f7ca03dff233ca976ed3d40d0376a57f37033be2a90f18dfe090943c97/cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "d15809e0dbdad486f4ad0979753518f47980020b7a34e9fc56e8be4f60702fac",
+              "url": "https://files.pythonhosted.org/packages/6d/5b/516dc11fa0a638cb707293ad44cc1cb93924bb4b5ba03881dfdb819e23b0/cryptography-39.0.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c",
-              "url": "https://files.pythonhosted.org/packages/67/db/8bf23a46eb3d428514ce83a8047bab4304338548bbd891fded615551b032/cryptography-39.0.1-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "50cadb9b2f961757e712a9737ef33d89b8190c3ea34d0fb6675e00edbe35d074",
+              "url": "https://files.pythonhosted.org/packages/77/19/47d55b3f609fc03b6f80c63820996671dfccb28e1d07427dd81319d514d5/cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
-              "url": "https://files.pythonhosted.org/packages/6a/f5/a729774d087e50fffd1438b3877a91e9281294f985bda0fd15bf99016c78/cryptography-39.0.1.tar.gz"
+              "hash": "8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011",
+              "url": "https://files.pythonhosted.org/packages/9c/30/e787edf59f35192799d340a0a36976870ce487ba32948f086c29dc5d54ab/cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
-              "url": "https://files.pythonhosted.org/packages/98/51/1c0cedac9ac405adc5da60f5c9884c0ff6af8ccb8caa8173b807baa5bd4a/cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+              "hash": "2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06",
+              "url": "https://files.pythonhosted.org/packages/c5/8a/6dcd53c995506d4ff0de3a7da2202715654493fd12d7875f2a43b3a44150/cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
-              "url": "https://files.pythonhosted.org/packages/bb/03/20b85e10571c919fd4862465c53ae40b6494fa7f82fd74131f401ce504f6/cryptography-39.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5",
+              "url": "https://files.pythonhosted.org/packages/d3/26/da69282ae3b350ee869536994e6816ac77057a7b5970068fabe56c644624/cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad",
-              "url": "https://files.pythonhosted.org/packages/c4/dc/dff464036da4903e08b4626c579420eaad591a13fe630638b9aacd9205cd/cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl"
+              "hash": "bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a",
+              "url": "https://files.pythonhosted.org/packages/d6/99/12d3b9c8df83b52799f9994da17bb67bb4565c418b3a8284ed1f79b692e1/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
-              "url": "https://files.pythonhosted.org/packages/c8/bb/eeae3f97861fc2553fff4f96287344233dfcf4fb94ef5e51cea8d4ee0133/cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl"
+              "hash": "d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0",
+              "url": "https://files.pythonhosted.org/packages/e8/5c/9e47aac90fb5923d09c413909af6bf6ad4af2bfeeff707a2485c3f2af8be/cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc",
-              "url": "https://files.pythonhosted.org/packages/cd/e0/f531855bda1e5c4d782518ab9b03b2e26370a5996d5b81aea2130a6582f7/cryptography-39.0.1-cp36-abi3-macosx_10_12_x86_64.whl"
+              "hash": "b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536",
+              "url": "https://files.pythonhosted.org/packages/f4/6d/1afb19efbe093f0b1af7a788bb8a693e495dc6c1d2139316b05b40f5e1dd/cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
-              "url": "https://files.pythonhosted.org/packages/ce/cf/678181421aa1506c7669c1ccbe8737203fb628406b2cd7e24b6eb0e12429/cryptography-39.0.1-cp36-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828",
+              "url": "https://files.pythonhosted.org/packages/f7/c0/daaeedc40e3385f01bb1af8c001ac214dcea6716b61efebabf9066b6f619/cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
-              "url": "https://files.pythonhosted.org/packages/d6/af/14bcaf14195de7855612dd79d5e04a6d0b88bebc2cb3a6544110065ea8d4/cryptography-39.0.1-cp36-abi3-macosx_10_12_universal2.whl"
+              "hash": "bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f",
+              "url": "https://files.pythonhosted.org/packages/fa/f3/f4b8c175ea9a1de650b0085858059050b7953a93d66c97ed89b93b232996/cryptography-39.0.2.tar.gz"
             }
           ],
           "project_name": "cryptography",
@@ -825,7 +831,7 @@
             "types-requests; extra == \"pep8test\""
           ],
           "requires_python": ">=3.6",
-          "version": "39.0.1"
+          "version": "39.0.2"
         },
         {
           "artifacts": [
@@ -1097,6 +1103,38 @@
           ],
           "requires_python": ">=3.6",
           "version": "3.1.18"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f34088c08be2ec16279dfa9c3b4ff3d1453c5c67597a33e2819b000e18d4c546",
+              "url": "https://files.pythonhosted.org/packages/9d/fb/886e8ec7862989afc0c35d15813b6c665fe134cc6027cdde2fa300abe9a2/graphviz-0.19.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "09ed0cde452d015fe77c4845a210eb642f28d245f5bc250d4b97808cb8f49078",
+              "url": "https://files.pythonhosted.org/packages/f6/14/aa3ec10e4ab1524ba69f4742ef9cfa01fd668d0840afe5d5e6f708a95031/graphviz-0.19.1.zip"
+            }
+          ],
+          "project_name": "graphviz",
+          "requires_dists": [
+            "coverage; extra == \"test\"",
+            "flake8; extra == \"dev\"",
+            "mock>=4; extra == \"test\"",
+            "pep8-naming; extra == \"dev\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-mock>=3; extra == \"test\"",
+            "pytest>=6; extra == \"test\"",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinx-rtd-theme; extra == \"docs\"",
+            "sphinx>=1.8; extra == \"docs\"",
+            "tox>=3; extra == \"dev\"",
+            "twine; extra == \"dev\"",
+            "wheel; extra == \"dev\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "0.19.1"
         },
         {
           "artifacts": [
@@ -1890,129 +1928,129 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b17be2478b622939e39b816e0aa8242611cc8d3583d1cd8ec31b249f04623243",
-              "url": "https://files.pythonhosted.org/packages/0b/2b/fd152d4a63dee8cee780efeec7b2679f6de6433ff2c9786ee1b4849aaf5c/msgpack-1.0.4-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "821c7e677cc6acf0fd3f7ac664c98803827ae6de594a9f99563e48c5a2f27eb0",
+              "url": "https://files.pythonhosted.org/packages/56/50/bfcc0fad07067b6f1b09d940272ec749d5fe82570d938c2348c3ad0babf7/msgpack-1.0.5-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "449e57cc1ff18d3b444eb554e44613cffcccb32805d16726a5494038c3b93dab",
-              "url": "https://files.pythonhosted.org/packages/01/9c/26a337b8d4a7cb5b1058bec7f187936bf749e78cd519c497e845e965d2e5/msgpack-1.0.4-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "a9985b214f33311df47e274eb788a5893a761d025e2b92c723ba4c63936b69b1",
+              "url": "https://files.pythonhosted.org/packages/0a/04/bc319ba061f6dc9077745988be288705b3f9f18c5a209772a3e8fcd419fd/msgpack-1.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e91d641d2bfe91ba4c52039adc5bccf27c335356055825c7f88742c8bb900dd",
-              "url": "https://files.pythonhosted.org/packages/05/67/89809468cd7e4e6dbc29c3c15a65e1e9582f9ef391b794039996ce7a136e/msgpack-1.0.4-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "916723458c25dfb77ff07f4c66aed34e47503b2eb3188b3adbec8d8aa6e00f48",
+              "url": "https://files.pythonhosted.org/packages/0d/90/44edef4a8c6f035b054c4b017c5adcb22a35ec377e17e50dd5dced279a6b/msgpack-1.0.5-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ac5bd7901487c4a1dd51a8c58f2632b15d838d07ceedaa5e4c080f7190925bff",
-              "url": "https://files.pythonhosted.org/packages/09/ea/7db5df39aa59e25c1a14471dd5215981083f231f42a77b7ae1ee0ec99649/msgpack-1.0.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "476a8fe8fae289fdf273d6d2a6cb6e35b5a58541693e8f9f019bfe990a51e4ba",
+              "url": "https://files.pythonhosted.org/packages/19/0c/2c3b443df88f5d400f2e19a3d867564d004b26e137f18c2f2663913987bc/msgpack-1.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9667bdfdf523c40d2511f0e98a6c9d3603be6b371ae9a238b7ef2dc4e7a427b0",
-              "url": "https://files.pythonhosted.org/packages/10/28/bf6b683f594f7172f13dfb8a3416ce4d1beaf198f14197d138abf1254d81/msgpack-1.0.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "b72d0698f86e8d9ddf9442bdedec15b71df3598199ba33322d9711a19f08145c",
+              "url": "https://files.pythonhosted.org/packages/1a/f7/df5814697c25bdebb14ea97d27ddca04f5d4c6e249f096d086fea521c139/msgpack-1.0.5-cp38-cp38-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f",
-              "url": "https://files.pythonhosted.org/packages/22/44/0829b19ac243211d1d2bd759999aa92196c546518b0be91de9cacc98122a/msgpack-1.0.4.tar.gz"
+              "hash": "addab7e2e1fcc04bd08e4eb631c2a90960c340e40dfc4a5e24d2ff0d5a3b3edb",
+              "url": "https://files.pythonhosted.org/packages/28/8f/c58c53c884217cc572c19349c7e1129b5a6eae36df0a017aae3a8f3d7aa8/msgpack-1.0.5-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2a2df1b55a78eb5f5b7d2a4bb221cd8363913830145fad05374a80bf0877cb1e",
-              "url": "https://files.pythonhosted.org/packages/39/b1/51731fcf638bc5d8b842c0b1905c72ff1207841571f4d5db32d1d8afb814/msgpack-1.0.4-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "56a62ec00b636583e5cb6ad313bbed36bb7ead5fa3a3e38938503142c72cba4f",
+              "url": "https://files.pythonhosted.org/packages/2b/c4/f2c8695ae69d1425eddc5e2f849c525b562dc8409bc2979e525f3dd4fecd/msgpack-1.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1276e8f34e139aeff1c77a3cefb295598b504ac5314d32c8c3d54d24fadb94c9",
-              "url": "https://files.pythonhosted.org/packages/3d/2c/fcd9d62ae5a3b0bbb931803591f8612f008c73015846650cee01d4f47d35/msgpack-1.0.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "a2b031c2e9b9af485d5e3c4520f4220d74f4d222a5b8dc8c1a3ab9448ca79c57",
+              "url": "https://files.pythonhosted.org/packages/2b/d4/9165cf113f9b86ce55e36f36bc6cd9e0c5601b0ade02741b2ead8b5dc254/msgpack-1.0.5-cp36-cp36m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "76ee788122de3a68a02ed6f3a16bbcd97bc7c2e39bd4d94be2f1821e7c4a64e6",
-              "url": "https://files.pythonhosted.org/packages/3d/aa/1778b6d209921ba399fe1f259806348dec6239d470e0b895022c12b1b399/msgpack-1.0.4-cp36-cp36m-musllinux_1_1_i686.whl"
+              "hash": "48296af57cdb1d885843afd73c4656be5c76c0c6328db3440c9601a98f303d87",
+              "url": "https://files.pythonhosted.org/packages/2f/21/e488871f8e498efe14821b0c870eb95af52cfafb9b8dd41d83fad85b383b/msgpack-1.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "77ccd2af37f3db0ea59fb280fa2165bf1b096510ba9fe0cc2bf8fa92a22fdb43",
-              "url": "https://files.pythonhosted.org/packages/4b/49/5db0a9d7dd5c02041a2feade0848a770624c8c847fa01fa974625b3fc233/msgpack-1.0.4-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "379026812e49258016dd84ad79ac8446922234d498058ae1d415f04b522d5b2d",
+              "url": "https://files.pythonhosted.org/packages/33/52/099f0dde1283bac7bf267ab941dfa3b7c89ee701e4252973f8d3c10e68d6/msgpack-1.0.5-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fcb8a47f43acc113e24e910399376f7277cf8508b27e5b88499f053de6b115a8",
-              "url": "https://files.pythonhosted.org/packages/51/6a/e1a3bbe7dff8032fdf41a78bb7e9a3fb86b053a9897c61f93c00187ec6a9/msgpack-1.0.4-cp36-cp36m-musllinux_1_1_aarch64.whl"
+              "hash": "b1d46dfe3832660f53b13b925d4e0fa1432b00f5f7210eb3ad3bb9a13c6204a6",
+              "url": "https://files.pythonhosted.org/packages/45/e1/6408389bd2cf0c339ea317926beb64d100f60bc8d236ac59f1c1162be2e4/msgpack-1.0.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7760f85956c415578c17edb39eed99f9181a48375b0d4a94076d84148cf67b2d",
-              "url": "https://files.pythonhosted.org/packages/5e/f7/05760eb8fd1ee1d8080f42b95c268629f13239c9b675063b27213631d604/msgpack-1.0.4-cp38-cp38-macosx_10_9_universal2.whl"
+              "hash": "f933bbda5a3ee63b8834179096923b094b76f0c7a73c1cfe8f07ad608c58844b",
+              "url": "https://files.pythonhosted.org/packages/60/bc/af94acdebc26b8d92d5673d20529438aa225698dc23338fb43c875c8968e/msgpack-1.0.5-cp36-cp36m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c9566f2c39ccced0a38d37c26cc3570983b97833c365a6044edef3574a00c08",
-              "url": "https://files.pythonhosted.org/packages/61/da/974ffe02a4d16d704efd3a7b36126782544f7abf7d506b4209ddaa3bd987/msgpack-1.0.4-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0c05a4a96585525916b109bb85f8cb6511db1c6f5b9d9cbcbc940dc6b4be944b",
+              "url": "https://files.pythonhosted.org/packages/62/57/170af6c6fccd2d950ea01e1faa58cae9643226fa8705baded11eca3aa8b5/msgpack-1.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0a68d3ac0104e2d3510de90a1091720157c319ceeb90d74f7b5295a6bee51bae",
-              "url": "https://files.pythonhosted.org/packages/71/15/6fb5c834fab52a12cab92036f2138aa1a5c5fd55d5a17c26741de0c02cfb/msgpack-1.0.4-cp36-cp36m-musllinux_1_1_x86_64.whl"
+              "hash": "ef8108f8dedf204bb7b42994abf93882da1159728a2d4c5e82012edd92c9da9f",
+              "url": "https://files.pythonhosted.org/packages/62/5c/9c7fed4ca0235a2d7b8d15b4047c328976b97d2b227719e54cad1e47c244/msgpack-1.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5b5b962221fa2c5d3a7f8133f9abffc114fe218eb4365e40f17732ade576c8e",
-              "url": "https://files.pythonhosted.org/packages/7f/fc/b2ad599613c448a9c9b8d86e59612dbd36e5debef6c18dbb5dd930c9442c/msgpack-1.0.4-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "e57916ef1bd0fee4f21c4600e9d1da352d8816b52a599c46460e93a6e9f17086",
+              "url": "https://files.pythonhosted.org/packages/72/ac/2eda5af7cd1450c52d031e48c76b280eac5bb2e588678876612f95be34ab/msgpack-1.0.5-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d603de2b8d2ea3f3bcb2efe286849aa7a81531abc52d8454da12f46235092bcb",
-              "url": "https://files.pythonhosted.org/packages/a4/e2/ca6c95d06e68e499208976b0513da3d41e0049f21663f869889a065ba442/msgpack-1.0.4-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "36961b0568c36027c76e2ae3ca1132e35123dcec0706c4b7992683cc26c1320c",
+              "url": "https://files.pythonhosted.org/packages/9a/0b/ea8a49d24654f9e8604ea78b80a4d7b0cc31817d8fb6987001223ae7feaf/msgpack-1.0.5-cp36-cp36m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a75dfb03f8b06f4ab093dafe3ddcc2d633259e6c3f74bb1b01996f5d8aa5868c",
-              "url": "https://files.pythonhosted.org/packages/a6/65/5b283e66b89d3b41f1b30fd42da70a609b5432b764f5cd6fed23d3b4699b/msgpack-1.0.4-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "4c075728a1095efd0634a7dccb06204919a2f67d1893b6aa8e00497258bf926c",
+              "url": "https://files.pythonhosted.org/packages/a2/e0/f3d5dd7809cf5728bb1bae683032ce50547d009be6551054815a8bf2a2da/msgpack-1.0.5-cp36-cp36m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6916c78f33602ecf0509cc40379271ba0f9ab572b066bd4bdafd7434dee4bc6e",
-              "url": "https://files.pythonhosted.org/packages/ad/07/f20fd312f7b0c698d1ed49f1780aedb7dee8e3127663b4de0e20c0b016f5/msgpack-1.0.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "137850656634abddfb88236008339fdaba3178f4751b28f270d2ebe77a563b6c",
+              "url": "https://files.pythonhosted.org/packages/c5/c1/1b591574ba71481fbf38359a8fca5108e4ad130a6dbb9b2acb3e9277d0fe/msgpack-1.0.5-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3c11a48cf5e59026ad7cb0dc29e29a01b5a66a3e333dc11c04f7e991fc5510a9",
-              "url": "https://files.pythonhosted.org/packages/b1/05/504f5564e8c01d37ff672ee2b47ff258503df31ed4ac59cb26cb2bb72fdf/msgpack-1.0.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "366c9a7b9057e1547f4ad51d8facad8b406bab69c7d72c0eb6f529cf76d4b85f",
+              "url": "https://files.pythonhosted.org/packages/d3/32/9b7a2dba9485dd7d201e4e00638fbf86e0d535a91653889c5b4dc813efdf/msgpack-1.0.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "11184bc7e56fd74c00ead4f9cc9a3091d62ecb96e97653add7a879a14b003227",
-              "url": "https://files.pythonhosted.org/packages/d4/d5/18808999054f3c633bf3ff808a652b329a26083dea6bd2386e2aec4ffee0/msgpack-1.0.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c075544284eadc5cddc70f4757331d99dcbc16b2bbd4849d15f8aae4cf36d31c",
+              "url": "https://files.pythonhosted.org/packages/dc/a1/eba11a0d4b764bc62966a565b470f8c6f38242723ba3057e9b5098678c30/msgpack-1.0.5.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "48f5d88c99f64c456413d74a975bd605a9b0526293218a3b77220a2c15458ba9",
-              "url": "https://files.pythonhosted.org/packages/dc/83/654d85d318cccabcc82d03fab9b2f5a3706278bf6242d6daefbb3d29ca2c/msgpack-1.0.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "17358523b85973e5f242ad74aa4712b7ee560715562554aa2134d96e7aa4cbbf",
+              "url": "https://files.pythonhosted.org/packages/e8/60/78906f564804aae23eb1102eca8b8830f1e08a649c179774c05fa7dc0aad/msgpack-1.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e83f80a7fec1a62cf4e6c9a660e39c7f878f603737a0cdac8c13131d11d97f52",
-              "url": "https://files.pythonhosted.org/packages/dd/fc/d21b74be6671bada90129696db21703016214aaa47bd9a5dcdc928e7f1b6/msgpack-1.0.4-cp36-cp36m-macosx_10_9_x86_64.whl"
+              "hash": "1835c84d65f46900920b3708f5ba829fb19b1096c1800ad60bae8418652a951d",
+              "url": "https://files.pythonhosted.org/packages/ef/13/c110d89d5079169354394dc226e6f84d818722939bc1fe3f9c25f982e903/msgpack-1.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "81fc7ba725464651190b196f3cd848e8553d4d510114a954681fd0b9c479d7e1",
-              "url": "https://files.pythonhosted.org/packages/ec/ff/92af8194c12fc46da6dd56e4e22bdb7bdd297c451bd76183b0ec496196ab/msgpack-1.0.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "332360ff25469c346a1c5e47cbe2a725517919892eda5cfaffe6046656f0b7bb",
+              "url": "https://files.pythonhosted.org/packages/f1/1f/cc3e8274934c8323f6106dae22cba8bad413166f4efb3819573de58c215c/msgpack-1.0.5-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "545e3cf0cf74f3e48b470f68ed19551ae6f9722814ea969305794645da091236",
-              "url": "https://files.pythonhosted.org/packages/f4/f8/225ca22971690c8b530a2f5344e8cf4d13d601c3817eded87ecbb3e644b8/msgpack-1.0.4-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "4f837b93669ce4336e24d08286c38761132bc7ab29782727f8557e1eb21b2080",
+              "url": "https://files.pythonhosted.org/packages/f5/80/ef9c31210ac580163c0de2db4fb3179c6a3f1228c18fd366280e01d9e5d2/msgpack-1.0.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "msgpack",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.0.4"
+          "version": "1.0.5"
         },
         {
           "artifacts": [
@@ -3093,6 +3131,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5",
+              "url": "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0",
+              "url": "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz"
+            }
+          ],
+          "project_name": "pysocks",
+          "requires_dists": [],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
+          "version": "1.7.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
               "url": "https://files.pythonhosted.org/packages/38/93/c7c0bd1e932b287fb948eb9ce5a3d6307c9fc619db1e199f8c8bc5dad95f/pytest-7.0.1-py3-none-any.whl"
             },
@@ -3166,19 +3222,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f389ccb0a8fd26f84c294dc627a999daf58f759b457ee022f698098f6547288d",
-              "url": "https://files.pythonhosted.org/packages/86/3b/fc7b3bff77b7e493bab923caf1f7dff3ef30198b0a79fbd46a09557c17f9/python_json_logger-2.0.5-py3-none-any.whl"
+              "hash": "f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd",
+              "url": "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3853e0b73e6c1ba4b1f2543066b24950bf1c21ed104f297a7bff8c74532a6ab2",
-              "url": "https://files.pythonhosted.org/packages/4d/f7/8fe192d2535567deecc12d8b8e6c71230adebb4b0db407d852fff8e0b0cf/python-json-logger-2.0.5.tar.gz"
+              "hash": "23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c",
+              "url": "https://files.pythonhosted.org/packages/4f/da/95963cebfc578dabd323d7263958dfb68898617912bb09327dd30e9c8d13/python-json-logger-2.0.7.tar.gz"
             }
           ],
           "project_name": "python-json-logger",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2.0.5"
+          "version": "2.0.7"
         },
         {
           "artifacts": [
@@ -4570,124 +4626,129 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
-              "url": "https://files.pythonhosted.org/packages/da/f4/7af9e01b6c1126b2daef72d5ba2cbf59a7229fd57c5b23166f694d758a8f/wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640",
+              "url": "https://files.pythonhosted.org/packages/f8/f8/e068dafbb844c1447c55b23c921f3d338cddaba4ea53187a7dd0058452d9/wrapt-1.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
-              "url": "https://files.pythonhosted.org/packages/00/61/04422b7469534650b622d5baa1dd335c4b91d35c8d33548b272f33060519/wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034",
+              "url": "https://files.pythonhosted.org/packages/18/f6/659d7c431a57da9c9a86945834ab2bf512f1d9ebefacea49135a0135ef1a/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
-              "url": "https://files.pythonhosted.org/packages/03/c6/d864b8da8afa57a638b12596c3a58dfe3471acda900961c02a904010e0e9/wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl"
+              "hash": "63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd",
+              "url": "https://files.pythonhosted.org/packages/29/41/f05bf85417473cf6fe4eec7396c63762e5a457a42102bd1b8af059af6586/wrapt-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
-              "url": "https://files.pythonhosted.org/packages/0d/dc/3f588e42e09fb5170349924366587319e1e49d50a1a58dbe78d6046ca812/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7",
+              "url": "https://files.pythonhosted.org/packages/2d/47/16303c59a890696e1a6fd82ba055fc4e0f793fb4815b5003f1f85f7202ce/wrapt-1.15.0-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
-              "url": "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
+              "hash": "b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2",
+              "url": "https://files.pythonhosted.org/packages/2e/ce/90dcde9ff9238689f111f07b46da2db570252445a781ea147ff668f651b0/wrapt-1.15.0-cp36-cp36m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
-              "url": "https://files.pythonhosted.org/packages/12/cd/da6611401655ac2b8496b316ad9e21a3fd4f8e62e2c3b3e3c50207770517/wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317",
+              "url": "https://files.pythonhosted.org/packages/47/dd/bee4d33058656c0b2e045530224fcddd9492c354af5d20499e5261148dcb/wrapt-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
-              "url": "https://files.pythonhosted.org/packages/23/8b/e4de40ac2fa6d53e694310c576e160bec3db8a282fbdcd5596544f6bc69e/wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653",
+              "url": "https://files.pythonhosted.org/packages/4a/7b/c63103817bd2f3b0145608ef642ce90d8b6d1e5780d218bce92e93045e06/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
-              "url": "https://files.pythonhosted.org/packages/2a/86/c9ef2fa4899ec069c8efe43fc92ca2ba0c5a7921cfaf83090030cf7b1487/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e",
+              "url": "https://files.pythonhosted.org/packages/65/be/3ae5afe9d78d97595b28914fa7e375ebc6329549d98f02768d5a08f34937/wrapt-1.15.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
-              "url": "https://files.pythonhosted.org/packages/33/cd/7335d8b82ff0a442581ab37a8d275ad76b4c1f33ace63c1a4d7c23791eee/wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba",
+              "url": "https://files.pythonhosted.org/packages/81/1e/0bb8f01c6ac5baba66ef1ab65f4644bede856c3c7aede18c896be222151c/wrapt-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af",
-              "url": "https://files.pythonhosted.org/packages/36/ee/944dc7e5462662270e8a379755bcc543fc8f09029866288060dc163ed5b4/wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0",
+              "url": "https://files.pythonhosted.org/packages/a2/3e/ee671ac60945154dfa3a406b8cb5cef2e3b4fa31c7d04edeb92716342026/wrapt-1.15.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
-              "url": "https://files.pythonhosted.org/packages/49/a8/528295a24655f901148177355edb6a22b84abb2abfadacc1675643c1434a/wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f",
+              "url": "https://files.pythonhosted.org/packages/af/7f/25913aacbe0c2c68e7354222bdefe4e840489725eb835e311c581396f91f/wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
-              "url": "https://files.pythonhosted.org/packages/5c/46/b91791db2ac7cc4c186408b7aed37b994463970f2397d0548f38b2b47aca/wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl"
+              "hash": "38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364",
+              "url": "https://files.pythonhosted.org/packages/b6/0c/435198dbe6961c2343ca725be26b99c8aee615e32c45bc1cb2a960b06183/wrapt-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
-              "url": "https://files.pythonhosted.org/packages/5e/d3/bd44864e0274b7e162e2a68c71fffbd8b3a7b620efd23320fd0f70333cff/wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6",
+              "url": "https://files.pythonhosted.org/packages/bd/47/57ffe222af59fae1eb56bca7d458b704a9b59380c47f0921efb94dc4786a/wrapt-1.15.0-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
-              "url": "https://files.pythonhosted.org/packages/72/24/490a0bbc67135f737d2eb4b270bfc91e54cc3f0b5e97b4ceec91a44bb898/wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl"
+              "hash": "230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f",
+              "url": "https://files.pythonhosted.org/packages/cd/a0/84b8fe24af8d7f7374d15e0da1cd5502fff59964bbbf34982df0ca2c9047/wrapt-1.15.0-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
-              "url": "https://files.pythonhosted.org/packages/93/12/b20ae4dbefa94ef5d667ba71324763d870b86064a944c8ec9533042a41fc/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475",
+              "url": "https://files.pythonhosted.org/packages/cf/b1/3c24fc0f6b589ad8c99cfd1cd3e586ef144e16aaf9381ed952d047a7ee54/wrapt-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
-              "url": "https://files.pythonhosted.org/packages/93/8c/1bbba9357142e6f9bcf55c79e2aa6fd5f4066c331e731376705777a0077f/wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752",
+              "url": "https://files.pythonhosted.org/packages/d1/74/3c99ce16947f7af901f6203ab4a3d0908c4db06e800571dabfe8525fa925/wrapt-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
-              "url": "https://files.pythonhosted.org/packages/94/4b/ff8d58aee32ed91744f1ff4970e590f0c8fdda3fa6d702dc82281e0309bd/wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e",
+              "url": "https://files.pythonhosted.org/packages/d2/60/9fe25f4cd910ae94e75a1fd4772b058545e107a82629a5ca0f2cd7cc34d5/wrapt-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
-              "url": "https://files.pythonhosted.org/packages/94/59/60b2fe919ffb190cf8cae0307bafdaf1695eac8655921f59768ce3bf1084/wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8",
+              "url": "https://files.pythonhosted.org/packages/d7/4b/1bd4837362d31d402b9bc1a27cdd405baf994dbf9942696f291d2f7eeb73/wrapt-1.15.0-cp36-cp36m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
-              "url": "https://files.pythonhosted.org/packages/a7/0d/a52a0268c98a687785c5452324e10f9462d289e850066e281aa327505aa7/wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094",
+              "url": "https://files.pythonhosted.org/packages/de/77/e2ebfa2f46c19094888a364fdb59aeab9d3336a3ad7ccdf542de572d2a35/wrapt-1.15.0-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
-              "url": "https://files.pythonhosted.org/packages/e0/80/af9da7379ee6df583875d0aeb80f9d5f0bd5f081dd1ee5ce06587d8bfec7/wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b",
+              "url": "https://files.pythonhosted.org/packages/f8/49/10013abe31f6892ae57c5cc260f71b7e08f1cc00f0d7b2bcfa482ea74349/wrapt-1.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
-              "url": "https://files.pythonhosted.org/packages/e8/f6/7e30a8c53d27ef8c1ff872dc4fb75247c99eb73d834c91a49a55d046c127/wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/73e4e3cdb2c780e13f9d87dc10488d7566d8fd77f8d68f0e416bfbd144c7/wrapt-1.15.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
-              "url": "https://files.pythonhosted.org/packages/f1/96/d22461ba08d61a859c45cda5064b878f2baa61f142d3acfa8adabd82bf07/wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl"
+              "hash": "af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418",
+              "url": "https://files.pythonhosted.org/packages/fb/2d/b6fd53b7dbf94d542866cbf1021b9a62595177fc8405fd75e0a5bf3fa3b8/wrapt-1.15.0-cp36-cp36m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
-              "url": "https://files.pythonhosted.org/packages/f8/c4/3f8130d646bfc89382966adfb3d6428f26d0f752543a7e2fd92c1e493be6/wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145",
+              "url": "https://files.pythonhosted.org/packages/fd/8a/db55250ad0b536901173d737781e3b5a7cc7063c46b232c2e3a82a33c032/wrapt-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019",
+              "url": "https://files.pythonhosted.org/packages/ff/f6/c044dec6bec4ce64fbc92614c5238dd432780b06293d2efbcab1a349629c/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
             }
           ],
           "project_name": "wrapt",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.14.1"
+          "version": "1.15.0"
         },
         {
           "artifacts": [
@@ -4785,103 +4846,103 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d777d239036815e9b3a093fa9208ad314c040c26d7246617e70e23025b60083a",
-              "url": "https://files.pythonhosted.org/packages/40/52/54465d4b5202b401b49497428e1cd013cc1be99f4aa806db9f48bd5561b2/zstandard-0.19.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "c28c7441638c472bfb794f424bd560a22c7afce764cd99196e8d70fbc4d14e85",
+              "url": "https://files.pythonhosted.org/packages/37/e9/e9aa530447cb4482fdc972e69c6f73424f2edb4088e8eb806459c60c0665/zstandard-0.20.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ccc4727300f223184520a6064c161a90b5d0283accd72d1455bcd85ec44dd0d",
-              "url": "https://files.pythonhosted.org/packages/01/ac/06105f599bef71ccb814b1c6a26ea12be0508b565a50892147ccc0b54b40/zstandard-0.19.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "613daadd72c71b1488742cafb2c3b381c39d0c9bb8c6cc157aa2d5ea45cc2efc",
+              "url": "https://files.pythonhosted.org/packages/02/f8/9ee010452d7be18c699ddc598237b52215966220401289c66b7897c7ecfb/zstandard-0.20.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4514b19abe6dbd36d6c5d75c54faca24b1ceb3999193c5b1f4b685abeabde3d0",
-              "url": "https://files.pythonhosted.org/packages/07/ca/acedb452ad136517a81e7932fc0e6413cb96eca1d9b233b92b7063b4fe1e/zstandard-0.19.0-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "dc47cec184e66953f635254e5381df8a22012a2308168c069230b1a95079ccd0",
+              "url": "https://files.pythonhosted.org/packages/1b/de/4f72bf001d60c3527fde7b78af85cbead1f7765871eb6691f7adbd698672/zstandard-0.20.0-cp36-cp36m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "879411d04068bd489db57dcf6b82ffad3c5fb2a1fdd30817c566d8b7bedee442",
-              "url": "https://files.pythonhosted.org/packages/0a/38/cd5be2ac0aea0aa5e4ef427ca3e2e6f2641efd5a1ca63f9011d01fd8d48d/zstandard-0.19.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "489959e2d52f7f1fe8ea275fecde6911d454df465265bf3ec51b3e755e769a5e",
+              "url": "https://files.pythonhosted.org/packages/37/84/02163a56672658bdb50dd707379454ebd0810883ef7d66ab4f3cc5b76f58/zstandard-0.20.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67710d220af405f5ce22712fa741d85e8b3ada7a457ea419b038469ba379837c",
-              "url": "https://files.pythonhosted.org/packages/1e/fc/732d02af725141dabc6526b064a9fdae12eb839d715ea020f5d560bf6ac3/zstandard-0.19.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "059316f07e39b7214cd9eed565d26ab239035d2c76835deeff381995f7a27ba8",
+              "url": "https://files.pythonhosted.org/packages/52/95/0afa649179a4562faff8c12845137ba5f752b9c73280b83f484b606a3379/zstandard-0.20.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "898500957ae5e7f31b7271ace4e6f3625b38c0ac84e8cedde8de3a77a7fdae5e",
-              "url": "https://files.pythonhosted.org/packages/32/f2/c5463c42e11adf915e7a79a300c3aa1af2b03d60182ac1bca4ad8d23ff23/zstandard-0.19.0-cp36-cp36m-macosx_10_9_x86_64.whl"
+              "hash": "40466adfa071f58bfa448d90f9623d6aff67c6d86de6fc60be47a26388f6c74d",
+              "url": "https://files.pythonhosted.org/packages/55/69/59b688f5b0e600d3b0ad089917f9b6736f949d35a21a0f6336b693472d7d/zstandard-0.20.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c9ca56345b0c5574db47560603de9d05f63cce5dfeb3a456eb60f3fec737ff2",
-              "url": "https://files.pythonhosted.org/packages/46/35/b83919c16349fc1bfd0653ae0e3766592805fc874abbb444cb89a20d3b96/zstandard-0.19.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "7041efe3a93d0975d2ad16451720932e8a3d164be8521bfd0873b27ac917b77a",
+              "url": "https://files.pythonhosted.org/packages/5a/5a/0de6371f926f548b8d577c31fb0d0a7ce6796fbf8c6f471ead4f3604217d/zstandard-0.20.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "909bdd4e19ea437eb9b45d6695d722f6f0fd9d8f493e837d70f92062b9f39faf",
-              "url": "https://files.pythonhosted.org/packages/57/07/c2c36f731863c64484b27467f8d640edf69ae7427bce8f6753719b47073a/zstandard-0.19.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "84c1dae0c0a21eea245b5691286fe6470dc797d5e86e0c26b57a3afd1e750b48",
+              "url": "https://files.pythonhosted.org/packages/6e/71/a4aff8f16b175363e5054b931d3308727db73837f63c0758679a739626d1/zstandard-0.20.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b80f6f6478f9d4ca26daee6c61584499493bf97950cfaa1a02b16bb5c2c17e70",
-              "url": "https://files.pythonhosted.org/packages/71/d8/4f477624c8870d740ea1eb2b149e7397e9568518aa8668aaf032235524fb/zstandard-0.19.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "b671b75ae88139b1dd022fa4aa66ba419abd66f98869af55a342cb9257a1831e",
+              "url": "https://files.pythonhosted.org/packages/78/9e/4208aae4ad0fcb30209e25c6c3238f12d611b833036b4f57f9c63029c3ac/zstandard-0.20.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a4fb8b4ac6772e4d656103ccaf2e43e45bd16b5da324b963d58ef360d09eb73",
-              "url": "https://files.pythonhosted.org/packages/8c/56/a5c593ab1b8fea11e71c42149efa83e8fb53561f5ad0d65a39373b1a1f74/zstandard-0.19.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "2adf65cfce73ce94ef4c482f6cc01f08ddf5e1ca0c1ec95f2b63840f9e4c226c",
+              "url": "https://files.pythonhosted.org/packages/84/95/49e8efe587cad7cef31795b998978d3e1e35e0123f455c038060126c7301/zstandard-0.20.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31d12fcd942dd8dbf52ca5f6b1bbe287f44e5d551a081a983ff3ea2082867863",
-              "url": "https://files.pythonhosted.org/packages/9a/50/1b7f7f710c0dfc1019ec4c7295f67855722c342af82f3132664ca6dc1c07/zstandard-0.19.0.tar.gz"
+              "hash": "9aca916724d0802d3e70dc68adeff893efece01dffe7252ee3ae0053f1f1990f",
+              "url": "https://files.pythonhosted.org/packages/95/de/2ec5f1403ce7de61d89ca75ea6ad321902d86d565aee7b12d6e2609d0f06/zstandard-0.20.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2e4812720582d0803e84aefa2ac48ce1e1e6e200ca3ce1ae2be6d410c1d637ae",
-              "url": "https://files.pythonhosted.org/packages/9a/59/4ed760c57aab1c43caa012c143af5c5fcc14b8d875d2f21c68a7c73efb51/zstandard-0.19.0-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "cc98c8bcaa07150d3f5d7c4bd264eaa4fdd4a4dfb8fd3f9d62565ae5c4aba227",
+              "url": "https://files.pythonhosted.org/packages/97/60/6621fcda81252983a6812ab23e8d25e9d6c06097291a3da91dcf691dcbaf/zstandard-0.20.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6caed86cd47ae93915d9031dc04be5283c275e1a2af2ceff33932071f3eeff4d",
-              "url": "https://files.pythonhosted.org/packages/ad/45/b5c7feab0bed768d9fb448879a6aa859d71d342120c51bf47d675dd914df/zstandard-0.19.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "b07f391fd85e3d07514c05fb40c5573b398d0063ab2bada6eb09949ec6004772",
+              "url": "https://files.pythonhosted.org/packages/a2/fe/4c572a01652c9e7f5b844dbe1312df7c4a48421d6b4a1a53d345a3a364c4/zstandard-0.20.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55b3187e0bed004533149882ef8c24e954321f3be81f8a9ceffe35099b82a0d0",
-              "url": "https://files.pythonhosted.org/packages/b7/89/f19eb166e82d4bfaf4eced7bcd67415374219acc2e486a77a510e2c6de38/zstandard-0.19.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "4af5d1891eebef430038ea4981957d31b1eb70aca14b906660c3ac1c3e7a8612",
+              "url": "https://files.pythonhosted.org/packages/bb/22/ad4fe7312c0edc77edf8f18a13dce2d552c21490df8675d97d90e8b2f546/zstandard-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6d2182e648e79213b3881998b30225b3f4b1f3e681f1c1eaf4cacf19bde1040d",
-              "url": "https://files.pythonhosted.org/packages/b8/b9/06e02ec16cb2ab507468c956088586a9a8342540e9c83572b70ccd97b0c9/zstandard-0.19.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "ba86f931bf925e9561ccd6cb978acb163e38c425990927feb38be10c894fa937",
+              "url": "https://files.pythonhosted.org/packages/bd/c9/06a14d57389aa1c13627890b8973db7cba69ba97817b3cfbe209c1c8e687/zstandard-0.20.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "401508efe02341ae681752a87e8ac9ef76df85ef1a238a7a21786a489d2c983d",
-              "url": "https://files.pythonhosted.org/packages/b9/e4/cd7998faa1c1c16ae04762a7775be9a6811e701791d3fe6f3a18e4c6ee89/zstandard-0.19.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "0b815dec62e2d5a1bf7a373388f2616f21a27047b9b999de328bca7462033708",
+              "url": "https://files.pythonhosted.org/packages/c5/4c/175aeba888025323324da718b92bfea601aa69682880ca8f4bb2b100bc6a/zstandard-0.20.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e9c90a44470f2999779057aeaf33461cbd8bb59d8f15e983150d10bb260e16e0",
-              "url": "https://files.pythonhosted.org/packages/c0/b0/cf372c356110508dad65673ef94312fde7c3c671b07cd479b8d6058454cc/zstandard-0.19.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b0f556c74c6f0f481b61d917e48c341cdfbb80cc3391511345aed4ce6fb52fdc",
+              "url": "https://files.pythonhosted.org/packages/d8/df/fc30aad3b42cce4a9728be5695666e69189991998352964a938597d92e01/zstandard-0.20.0-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "660b91eca10ee1b44c47843894abe3e6cfd80e50c90dee3123befbf7ca486bd3",
-              "url": "https://files.pythonhosted.org/packages/dc/5e/65e6676f31860e3005e5bc1f470f80873b345a246fbaec64a2f1c302d08a/zstandard-0.19.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a56036c08645aa6041d435a50103428f0682effdc67f5038de47cea5e4221d6f",
+              "url": "https://files.pythonhosted.org/packages/da/f8/d7184cb7b63dbb1c0f2e4f80273b2692de8d1eaffee959cc2d2759a0995b/zstandard-0.20.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ec2c146e10b59c376b6bc0369929647fcd95404a503a7aa0990f21c16462248",
-              "url": "https://files.pythonhosted.org/packages/ee/09/86d674b89fe7c80c97562bcbbe0f01b63d8df1531049eeca10d2df75155b/zstandard-0.19.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "862ad0a5c94670f2bd6f64fff671bd2045af5f4ed428a3f2f69fa5e52483f86a",
+              "url": "https://files.pythonhosted.org/packages/e9/cf/e49e9b886a0f466d403402edf67f894a04fdaf8e1c33af7c35da25941c60/zstandard-0.20.0-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "47dfa52bed3097c705451bafd56dac26535545a987b6759fa39da1602349d7ba",
-              "url": "https://files.pythonhosted.org/packages/f9/a0/681e278833b9fb158fe3cb90724d724612c046b21276aa78502126a9a9d1/zstandard-0.19.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "78fb35d07423f25efd0fc90d0d4710ae83cfc86443a32192b0c6cb8475ec79a5",
+              "url": "https://files.pythonhosted.org/packages/f7/c4/9219d9e0636bea8a112080d90d7b7f013eeebbaea3c2ab23b4d43f31a0db/zstandard-0.20.0-cp37-cp37m-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "zstandard",
@@ -4890,7 +4951,7 @@
             "cffi>=1.11; platform_python_implementation == \"PyPy\""
           ],
           "requires_python": ">=3.6",
-          "version": "0.19.0"
+          "version": "0.20.0"
         }
       ],
       "platform_tag": null
@@ -4913,6 +4974,7 @@
     "flex",
     "gitdb",
     "gitpython",
+    "graphviz",
     "greenlet",
     "gunicorn",
     "jinja2",
@@ -4929,6 +4991,7 @@
     "orquesta",
     "oslo.config<1.13,>=1.12.1",
     "paramiko",
+    "pika",
     "prance",
     "prettytable",
     "prompt-toolkit<2",
@@ -4936,6 +4999,7 @@
     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
     "pymongo",
     "pyrabbit",
+    "pysocks",
     "pytest",
     "python-dateutil",
     "python-editor",

--- a/st2actions/conf/BUILD
+++ b/st2actions/conf/BUILD
@@ -6,6 +6,13 @@ file(
 files(
     name="logging",
     sources=["logging*.conf"],
+    overrides={
+        "logging.conf": {
+            "dependencies": [
+                "//:reqs#python-json-logger",
+            ],
+        },
+    },
 )
 
 files(

--- a/st2client/BUILD
+++ b/st2client/BUILD
@@ -5,4 +5,13 @@ st2_component_python_distribution(
             "st2": "st2client.shell:main",
         },
     },
+    dependencies=[
+        # required for SOCKS proxy support (HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
+        ":pysocks",
+    ],
+)
+
+python_requirement(
+    name="pysocks",
+    requirements=["pysocks"],
 )

--- a/st2common/st2common/util/BUILD
+++ b/st2common/st2common/util/BUILD
@@ -1,1 +1,8 @@
 python_sources()
+
+# st2common.utils.concurrency allows using gevent instead of eventlet.
+# This gevent support is WIP.
+# python_requirement(
+#    name="gevent",
+#    requirements=["gevent"],
+# )

--- a/st2common/st2common/util/concurrency.py
+++ b/st2common/st2common/util/concurrency.py
@@ -26,7 +26,7 @@ except ImportError:
     eventlet = None
 
 try:
-    import gevent  # pylint: disable=import-error
+    import gevent  # pylint: disable=import-error # pants: no-infer-dep
     import gevent.pool
 except ImportError:
     gevent = None

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -56,6 +56,7 @@ def monkey_patch(patch_thread=None):
     if patch_thread is None:
         patch_thread = not is_use_debugger_flag_provided()
 
+    # TODO: support gevent.patch_all if .concurrency.CONCURRENCY_LIBRARY = "gevent"
     eventlet.monkey_patch(
         os=True, select=True, socket=True, thread=patch_thread, time=True
     )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,10 @@
 python_requirement(
+    name="graphviz",
+    requirements=["graphviz"],
+    # used by st2-analyze-links.py and visualize_action_chain.py
+)
+
+python_requirement(
     name="pika",
     requirements=["pika"],
     # used by direct_queue_publisher.py

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,3 +1,9 @@
+python_requirement(
+    name="pika",
+    requirements=["pika"],
+    # used by direct_queue_publisher.py
+)
+
 python_sources(
     overrides={
         "config_gen.py": {

--- a/tools/st2-analyze-links.py
+++ b/tools/st2-analyze-links.py
@@ -152,11 +152,11 @@ class Grapher(object):
             print(rule_link._source_action_ref)
             if rule_link._source_action_ref not in nodes:
                 nodes.add(rule_link._source_action_ref)
-                dot.add_node(rule_link._source_action_ref)
+                dot.node(rule_link._source_action_ref, rule_link._source_action_ref)
             if rule_link._dest_action_ref not in nodes:
                 nodes.add(rule_link._dest_action_ref)
-                dot.add_node(rule_link._dest_action_ref)
-            dot.add_edge(
+                dot.node(rule_link._dest_action_ref, rule_link._dest_action_ref)
+            dot.edge(
                 rule_link._source_action_ref,
                 rule_link._dest_action_ref,
                 constraint="true",

--- a/tools/visualize_action_chain.py
+++ b/tools/visualize_action_chain.py
@@ -71,7 +71,7 @@ def main(metadata_path, output_path, print_source=False):
     # Add all nodes
     node = chain_holder.get_next_node()
     while node:
-        dot.add_node(node.name)
+        dot.node(node.name, node.name)
         node = chain_holder.get_next_node(curr_node_name=node.name)
 
     # Add connections
@@ -89,7 +89,7 @@ def main(metadata_path, output_path, print_source=False):
 
         # Add success node (if any)
         if success_node:
-            dot.add_edge(
+            dot.edge(
                 previous_node.name,
                 success_node.name,
                 constraint="true",
@@ -102,7 +102,7 @@ def main(metadata_path, output_path, print_source=False):
 
         # Add failure node (if any)
         if failure_node:
-            dot.add_edge(
+            dot.edge(
                 previous_node.name,
                 failure_node.name,
                 constraint="true",


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

I noticed a few deps that were not accounted for, so I added them to the BUILD metadata and regenerated the lockfile.

This re-introduces the `pysocks` dep to st2client so that the pants BUILD metadata also has the change introduced in:
- #5469

These deps are for tools that will never end up in a wheel, so pants will only ever use these if it has to run these tools for some reason:
- `pika` is used by `tools/direct_queue_publisher.py`
- `graphviz` is used by `tools/st2-analyze-links.py` and `tools/visualize_action_chain.py`

Adding the `graphviz` dep revealed a bug added in c805e3342f94cfa33932e4ccc0339c017d324b4f where an update meant to fix usage of the networkx library inadvertently also changed usage of the graphviz library. This reverts the graphviz portion of that commit.

I also noted that `st2actions/conf/logging.conf` needs the `python-json-logger` dep (which is already in the lockfile).

Finally, I noticed some code that imports `gevent` in a `try/except ImportError` block. Apparently there was some WIP work to allow using `gevent` instead of `eventlet`. I added a commented-out `python_requirement` for this and a TODO to explain where I think support is still lacking. I left it commented out, because pants does not have a good way to [support optional dependencies](https://github.com/pantsbuild/pants/issues/12336) yet. At some point maybe we can revisit switching (or allow switching) from `eventlet` to `gevent`.

### Pants documentation

- [`python_requirement` target](https://www.pantsbuild.org/docs/reference-python_requirement)
- [`dependencies` field](https://www.pantsbuild.org/docs/targets#dependencies-field)
- [Third-party dependencies](https://www.pantsbuild.org/docs/python-third-party-dependencies)