### PR TITLE
Pants: add dependencies to the st2* `python_distributions` (except st2common/st2tests)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925
+  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925 #5928
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/pants.toml
+++ b/pants.toml
@@ -136,6 +136,11 @@ st2 = "lockfiles/st2-constraints.txt"
 # Revisit this in pants 2.16 to see if it is feasible to use the default "warning".
 unowned_dependency_behavior = "ignore"
 
+[setup-py-generation]
+# when building the package (with ./pants package ::), pants will,
+# by default, generate a setup.py file for use with setuptools.
+generate_setup_default = true # true by default
+
 [bandit]
 lockfile = "lockfiles/bandit.lock"
 version = "bandit==1.7.0"

--- a/st2actions/BUILD
+++ b/st2actions/BUILD
@@ -7,4 +7,11 @@ st2_component_python_distribution(
         "bin/st2scheduler",
         "bin/runners.sh:shell",  # used by service files installed by st2-packaging
     ],
+    dependencies=[
+        # policies get wired up by metadata in st2common/st2common/policies/meta/*.yaml
+        "st2actions/policies",
+        # backwards compat API:
+        # st2actions.runners.pythonrunner.Action moved to st2common.runners.base_action.Action
+        "st2actions/runners/pythonrunner.py",
+    ],
 )

--- a/st2api/st2api/BUILD
+++ b/st2api/st2api/BUILD
@@ -1,1 +1,12 @@
-python_sources()
+python_sources(
+    overrides={
+        "app.py": dict(
+            dependencies=[
+                # controller routes are wired up via st2common/st2common/openapi.yaml
+                "./controllers",
+                "./controllers/v1",
+                # "./controllers/exp",
+            ],
+        ),
+    },
+)

--- a/st2api/st2api/controllers/BUILD
+++ b/st2api/st2api/controllers/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    overrides={
+        "root.py": dict(
+            dependencies=[
+                "st2api/st2api/public",  # cfg.static_root (has logo images)
+                "st2api/st2api/templates",  # cfg.template_path
+            ],
+        ),
+    },
+)

--- a/st2auth/st2auth/BUILD
+++ b/st2auth/st2auth/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    overrides={
+        "app.py": dict(
+            dependencies=[
+                # controller routes are wired up via st2common/st2common/openapi.yaml
+                "./controllers/v1",
+            ],
+        ),
+    },
+)

--- a/st2auth/st2auth/backends/BUILD
+++ b/st2auth/st2auth/backends/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    overrides={
+        "__init__.py": dict(
+            dependencies=[
+                # Public API classes that cannot be inferred
+                "./base.py",
+            ],
+        ),
+    },
+)

--- a/st2reactor/st2reactor/container/BUILD
+++ b/st2reactor/st2reactor/container/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    overrides={
+        "process_container.py": dict(
+            dependencies=[
+                # This is called in a subprocess using filesystem path
+                "./sensor_wrapper.py",
+            ],
+        ),
+    },
+)

--- a/st2stream/st2stream/BUILD
+++ b/st2stream/st2stream/BUILD
@@ -1,1 +1,10 @@
-python_sources()
+python_sources(
+    overrides={
+        "app.py": dict(
+            dependencies=[
+                # controller routes are wired up via st2common/st2common/openapi.yaml
+                "./controllers/v1",
+            ],
+        ),
+    },
+)


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

Like #5925, which adds dependencies for the `python_distribution` for `st2common`, this PR adds the remaining dependencies for the other `st2*` component `python_distribution` targets. It also skips `st2tests` which requires quite a few more changes in #5929.

It also adds a note to `pants.toml` to make it clear that pants will generate a `setup.py` file for us.

### Pants documentation

- [Building distributions](https://www.pantsbuild.org/docs/python-distributions)
    - see also: [`python_distribution` target](https://www.pantsbuild.org/docs/reference-python_distribution)