### PR TITLE
Pants: add dependencies to the st2tests `python_distributions`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925 #5928
+  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925 #5928 #5929
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/st2actions/tests/unit/test_actions_registrar.py
+++ b/st2actions/tests/unit/test_actions_registrar.py
@@ -29,6 +29,7 @@ import st2tests.base as tests_base
 from st2tests.fixtures.generic.fixture import (
     PACK_NAME as GENERIC_PACK,
     PACK_PATH as GENERIC_PACK_PATH,
+    PACK_BASE_PATH as PACKS_BASE_PATH,
 )
 import st2tests.fixturesloader as fixtures_loader
 
@@ -52,9 +53,8 @@ class ActionsRegistrarTest(tests_base.DbTestCase):
     )
     def test_register_all_actions(self):
         try:
-            packs_base_path = fixtures_loader.get_fixtures_base_path()
             all_actions_in_db = Action.get_all()
-            actions_registrar.register_actions(packs_base_paths=[packs_base_path])
+            actions_registrar.register_actions(packs_base_paths=[PACKS_BASE_PATH])
         except Exception as e:
             print(six.text_type(e))
             self.fail("All actions must be registered without exceptions.")

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -14,7 +14,7 @@ python_tests(
         "test_util_file_system.py": dict(
             dependencies=[
                 "st2tests/st2tests/policies",
-                "st2tests/st2tests/policies/meta:policies_meta",
+                "st2tests/st2tests/policies/meta",
             ],
         ),
     },

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -10,6 +10,14 @@ python_tests(
         "st2common/tests/unit/base.py",
     ],
     uses=["mongo", "rabbitmq"],
+    overrides={
+        "test_util_file_system.py": dict(
+            dependencies=[
+                "st2tests/st2tests/policies",
+                "st2tests/st2tests/policies/meta:policies_meta",
+            ],
+        ),
+    },
 )
 
 python_test_utils(

--- a/st2tests/BUILD
+++ b/st2tests/BUILD
@@ -6,7 +6,8 @@ st2_component_python_distribution(
         "./st2tests/mocks",
         "./st2tests/mocks/runners",
         # fixture packs
-        "./st2tests/fixtures:rbac_fixtures",
+        "./st2tests/fixtures/generic",
+        "./st2tests/fixtures/localrunner_pack",
         "./st2tests/fixtures/packs:all_packs",
         "./st2tests/fixtures/packs_1:all_packs",
         "./st2tests/fixtures/packs_invalid:all_packs",
@@ -14,6 +15,14 @@ st2_component_python_distribution(
         "./st2tests/fixtures/packs/executions",
         "./st2tests/fixtures/packs/runners",
         "./st2tests/fixtures/packs/test_content_version_fixture",  # provides fixture const
+        # fixture db resources (eg yaml dump of db resources)
+        "./st2tests/fixtures/aliases",
+        "./st2tests/fixtures/backstop",
+        "./st2tests/fixtures/descendants",
+        "./st2tests/fixtures:rbac_fixtures",
+        "./st2tests/fixtures/rule_enforcements",
+        "./st2tests/fixtures/timers",
+        "./st2tests/fixtures/traces",
         # fixture etc
         "./st2tests/fixtures/conf",
         "./st2tests/fixtures/history_views",

--- a/st2tests/BUILD
+++ b/st2tests/BUILD
@@ -7,6 +7,9 @@ st2_component_python_distribution(
         "./st2tests/mocks/runners",
         # fixture packs
         "./st2tests/fixtures:rbac_fixtures",
+        "./st2tests/fixtures/packs:all_packs",
+        "./st2tests/fixtures/packs_1:all_packs",
+        "./st2tests/fixtures/packs_invalid:all_packs",
         # fixtures in packs that are not (directly) packs
         "./st2tests/fixtures/packs/executions",
         "./st2tests/fixtures/packs/runners",

--- a/st2tests/BUILD
+++ b/st2tests/BUILD
@@ -1,3 +1,21 @@
 st2_component_python_distribution(
     component_name="st2tests",
+    dependencies=[
+        "./st2tests/policies",
+        "./st2tests/policies/meta",
+        "./st2tests/mocks",
+        "./st2tests/mocks/runners",
+        # fixture packs
+        "./st2tests/fixtures:rbac_fixtures",
+        # fixtures in packs that are not (directly) packs
+        "./st2tests/fixtures/packs/executions",
+        "./st2tests/fixtures/packs/runners",
+        "./st2tests/fixtures/packs/test_content_version_fixture",  # provides fixture const
+        # fixture etc
+        "./st2tests/fixtures/conf",
+        "./st2tests/fixtures/history_views",
+        "./st2tests/fixtures/keyczar_keys",
+        "./st2tests/fixtures/specs",
+        "./st2tests/fixtures/ssl_certs",
+    ],
 )

--- a/st2tests/st2tests/BUILD
+++ b/st2tests/st2tests/BUILD
@@ -3,6 +3,7 @@ python_sources(
         "st2tests/conf:st2.conf",
         "st2tests/conf:st2_kvstore_tests.crypto.key.json",
         "st2tests/conf:logging.conf",
+        # These are for base.py, but do not use overrides because __init__ import base.
         "./resources:ssh",
         "./resources:packs",
     ],

--- a/st2tests/st2tests/fixtures/generic/fixture.py
+++ b/st2tests/st2tests/fixtures/generic/fixture.py
@@ -14,3 +14,4 @@
 from st2tests import fixturesloader
 
 PACK_NAME, PACK_PATH = fixturesloader.get_fixture_name_and_path(__file__)
+PACK_BASE_PATH = fixturesloader.get_fixtures_base_path()

--- a/st2tests/st2tests/fixtures/localrunner_pack/BUILD
+++ b/st2tests/st2tests/fixtures/localrunner_pack/BUILD
@@ -3,5 +3,8 @@ pack_metadata(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+    ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
@@ -5,6 +5,8 @@ pack_metadata(
 python_sources(
     dependencies=[
         ":metadata",
+        "./actions",
+        "./sensors",
         "st2tests/st2tests/fixtures/packs/configs/dummy_pack_1.yaml",
     ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/BUILD
@@ -7,6 +7,7 @@ python_sources(
         ":metadata",
         "./actions",
         "./sensors",
+        "./etc",  # extra binary files for st2api/tests/unit/controllers/v1/test_packs_views.py
         "st2tests/st2tests/fixtures/packs/configs/dummy_pack_1.yaml",
     ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_1/etc/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_1/etc/BUILD
@@ -1,0 +1,3 @@
+resources(
+    sources=["*.png"],
+)

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
@@ -8,5 +8,9 @@ resource(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+        "./sensors",
+    ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_2/BUILD
@@ -1,5 +1,6 @@
 pack_metadata(
     name="metadata",
+    dependencies=[":pack_requirements"],
 )
 
 resource(

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_3/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_3/BUILD
@@ -3,5 +3,9 @@ pack_metadata(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+        "./sensors",
+    ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_7/BUILD
@@ -5,6 +5,7 @@ pack_metadata(
 python_sources(
     dependencies=[
         ":metadata",
+        "./actions",
         "st2tests/st2tests/fixtures/packs/configs/dummy_pack_7.yaml",
     ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/BUILD
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/BUILD
@@ -3,5 +3,8 @@ pack_metadata(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+    ],
 )

--- a/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
+++ b/st2tests/st2tests/fixtures/packs/dummy_pack_9/actions/invalid_syntax.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from invalid import Invalid  # noqa
+from invalid import Invalid  # noqa # pants: no-infer-dep
 
 
 class Foo:

--- a/st2tests/st2tests/fixtures/packs/orquesta_tests/BUILD
+++ b/st2tests/st2tests/fixtures/packs/orquesta_tests/BUILD
@@ -3,5 +3,8 @@ pack_metadata(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+    ],
 )

--- a/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
+++ b/st2tests/st2tests/fixtures/packs/pack_invalid_requirements/BUILD
@@ -1,5 +1,6 @@
 pack_metadata(
     name="metadata",
+    dependencies=[":pack_requirements"],
 )
 
 resource(

--- a/st2tests/st2tests/fixtures/packs/runners/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/BUILD
@@ -1,1 +1,6 @@
-python_sources()
+python_sources(
+    dependencies=[
+        "./test_async_runner",
+        "./test_polling_async_runner",
+    ],
+)

--- a/st2tests/st2tests/fixtures/packs/runners/test_async_runner/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/test_async_runner/BUILD
@@ -1,3 +1,3 @@
-python_tests(
-    name="tests",
+python_sources(
+    sources=["*.py"],
 )

--- a/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/BUILD
+++ b/st2tests/st2tests/fixtures/packs/runners/test_polling_async_runner/BUILD
@@ -1,3 +1,3 @@
-python_tests(
-    name="tests",
+python_sources(
+    sources=["*.py"],
 )

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
@@ -1,5 +1,6 @@
 pack_metadata(
     name="metadata",
+    dependencies=[":pack_requirements"],
 )
 
 resource(

--- a/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
+++ b/st2tests/st2tests/fixtures/packs/test_library_dependencies/BUILD
@@ -8,5 +8,8 @@ resource(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+    ],
 )

--- a/st2tests/st2tests/fixtures/specs/BUILD
+++ b/st2tests/st2tests/fixtures/specs/BUILD
@@ -2,3 +2,9 @@ resource(
     name="openapi_specs",
     source="openapi.yaml.j2",
 )
+
+# This is for an empty __init__.py file.
+# Tests will import __package__ from it to tell dep inference it is needed.
+python_sources(
+    dependencies=[":openapi_specs"],
+)

--- a/st2tests/st2tests/fixtures/ssl_certs/BUILD
+++ b/st2tests/st2tests/fixtures/ssl_certs/BUILD
@@ -7,6 +7,7 @@ resources(
         "**/*.pem",
         "ca/index.txt*",
         "ca/serial*",
+        "README.md",
     ],
 )
 

--- a/st2tests/st2tests/policies/meta/BUILD
+++ b/st2tests/st2tests/policies/meta/BUILD
@@ -1,4 +1,3 @@
 resources(
-    name="policies_meta",
     sources=["*.yaml"],
 )


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

Like #5925, which adds dependencies for the `python_distribution` for `st2common`, this PR adds the remaining dependencies for the `st2tests` component `python_distribution` targets. The remaining distributions deps are covered by #5928.

Thanks to the nature of `st2tests` the changes vary quite a bit between the BUILD files (ie each fixture is slightly different, so its deps are also a bit different). Also, since these are test fixtures, once I decided how to model the metadata, a few of the changes spilled over into the tests that use the fixtures (in st2actions and st2common).

Also, similar to `st2common` in #5925, I tried to minimize the deps on the `st2tests` `python_distribution`, but the contents are so varied, the list is much longer than I would prefer. Again, we can't use globs in `dependencies` because of how the pants caching works.

### Pants documentation

- [Building distributions](https://www.pantsbuild.org/docs/python-distributions)
    - see also: [`python_distribution` target](https://www.pantsbuild.org/docs/reference-python_distribution)