### PR TITLE
Add pants source roots and a constant for pack common lib directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #5778 #5789 #5817 #5795 #5830 #5833 #5834 #5841 #5840 #5838 #5842 #5837 #5849 #5850
   #5846 #5853 #5848 #5847 #5858 #5857 #5860 #5868 #5871 #5864 #5874 #5884 #5893 #5891
-  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925 #5928 #5929
+  #5890 #5898 #5901 #5906 #5899 #5907 #5909 #5922 #5926 #5927 #5925 #5928 #5929 #5930
   Contributed by @cognifloyd
 
 * Added a joint index to solve the problem of slow mongo queries for scheduled executions. #5805

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -35,6 +35,7 @@ from st2common.constants.action import (
 )
 from st2common.constants.action import LIVEACTION_STATUS_TIMED_OUT
 from st2common.constants.action import MAX_PARAM_LENGTH
+from st2common.constants.pack import COMMON_LIB_DIR
 from st2common.constants.pack import SYSTEM_PACK_NAME
 from st2common.persistence.execution import ActionExecutionOutput
 from python_runner.python_action_wrapper import PythonActionWrapper
@@ -951,7 +952,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
 
         _, call_kwargs = mock_popen.call_args
         actual_env = call_kwargs["env"]
-        pack_common_lib_path = os.path.join(runner.git_worktree_path, "lib")
+        pack_common_lib_path = os.path.join(runner.git_worktree_path, COMMON_LIB_DIR)
         self.assertIn("PYTHONPATH", actual_env)
         self.assertIn(pack_common_lib_path, actual_env["PYTHONPATH"])
 

--- a/pants.toml
+++ b/pants.toml
@@ -85,8 +85,11 @@ root_patterns = [
   "/contrib/packs",
   "/st2tests/testpacks/checks",
   "/st2tests/testpacks/errorcheck",
-  # odd import in examples.isprime
-  "/contrib/examples/lib",
+  # pack common lib directories that ST2 adds to the PATH for actions/sensors
+  "/contrib/*/lib",
+  "/contrib/*/actions/lib",
+  # other special-cased pack directories
+  "/contrib/examples/actions/ubuntu_pkg_info", # python script runs via shell expecting cwd in PYTHONPATH
   # lint plugins
   "/pylint_plugins",
   # pants plugins

--- a/st2common/st2common/constants/pack.py
+++ b/st2common/st2common/constants/pack.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 __all__ = [
+    "COMMON_LIB_DIR",
     "PACKS_PACK_NAME",
     "PACK_REF_WHITELIST_REGEX",
     "RESERVED_PACK_LIST",
@@ -31,6 +32,8 @@ __all__ = [
     "MANIFEST_FILE_NAME",
     "CONFIG_SCHEMA_FILE_NAME",
 ]
+
+COMMON_LIB_DIR = "lib"
 
 # Prefix for render context w/ config
 PACK_CONFIG_CONTEXT_KV_PREFIX = "config_context"

--- a/st2common/st2common/util/pack.py
+++ b/st2common/st2common/util/pack.py
@@ -22,6 +22,7 @@ import six
 
 from collections.abc import Iterable
 from st2common.util import schema as util_schema
+from st2common.constants.pack import COMMON_LIB_DIR
 from st2common.constants.pack import MANIFEST_FILE_NAME
 from st2common.constants.pack import PACK_REF_WHITELIST_REGEX
 from st2common.constants.pack import RESERVED_PACK_LIST
@@ -215,7 +216,7 @@ def get_pack_common_libs_path_for_pack_db(pack_db):
     if not pack_dir:
         return None
 
-    libs_path = os.path.join(pack_dir, "lib")
+    libs_path = os.path.join(pack_dir, COMMON_LIB_DIR)
 
     return libs_path
 

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -27,6 +27,7 @@ from distutils.sysconfig import get_python_lib
 
 from oslo_config import cfg
 
+from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.content.utils import get_pack_base_path
 
@@ -149,7 +150,9 @@ def get_sandbox_python_path_for_python_action(
         ]
 
         # Add the pack's lib directory (lib/python3.x) in front of the PYTHONPATH.
-        pack_actions_lib_paths = os.path.join(pack_base_path, "actions", "lib")
+        pack_actions_lib_paths = os.path.join(
+            pack_base_path, "actions", ACTION_LIBS_DIR
+        )
         pack_virtualenv_lib_path = os.path.join(virtualenv_path, "lib")
         pack_venv_lib_directory = os.path.join(
             pack_virtualenv_lib_path, virtualenv_directories[0]


### PR DESCRIPTION
### Background

This is another part of introducing [pants](https://www.pantsbuild.org/docs), as discussed in various TSC meetings.

Related PRs can be found in:
- [pantsbuild](https://github.com/StackStorm/st2/milestone/47) milestone (which includes PRs since #5713)
- https://github.com/StackStorm/st2/labels/pantsbuild label (which also includes preparatory PRs that came before adding pantsbuild)

### Overview of this PR

I ran into an issue with dependency inference not understanding the "lib" directories. ST2 adds `<pack>/lib` to PYTHONPATH for both actions and sensors, and `<pack>/actions/lib` to PYTHONPATH for actions. Pants uses "source roots" to manage the PYTHONPATH, so we need a way for pants to detect those source roots when needed. So, I adjusted the `[source].root_patterns` setting in `pants.toml` to account for these lib dirs.

While investigating this, I had to dive into the code that defines PYTHONPATH for running pack actions/sensors. I found the `"lib"` string to be rather confusing as only some of them referred to our special common libs directory. So to clarify that code, I added a `COMMON_LIB_DIR` constant to clarify which lib is which (ie to distinguish it from `virtualenv/lib` and `virtualenv/python*/lib`). I also adjusted one other place that was not using the action `LIBS_DIR` constant like everything else that references `<pack>/actions/lib`.

### Pants documentation

- [Source roots](https://www.pantsbuild.org/docs/source-roots)