### PR TITLE
Futureproofing: Removing `distutils` dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ benchmark_histograms/
 [._]sw[a-px]
 [._]*.sw[a-p]x
 [._]sw[a-p]x
+
+**/build/lib/**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 ~~~~~
 * Remove `distutils` dependencies across the project. #5992
   Contributed by @AndroxxTraxxon
-  
+
 * Move `git clone` to `user_home/.st2packs` #5845
 
 * Error on `st2ctl status` when running in Kubernetes. #5851

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,6 @@ Fixed
 
 Added
 ~~~~~
-* Remove `distutils` dependencies across the project. #5992
-  Contributed by @AndroxxTraxxon
 
 * Move `git clone` to `user_home/.st2packs` #5845
 
@@ -39,6 +37,11 @@ Added
 
 * Expose environment variable ST2_ACTION_DEBUG to all StackStorm actions.
   Contributed by @maxfactor1
+
+Changed
+~~~~~~~
+* Remove `distutils` dependencies across the project. #5992
+  Contributed by @AndroxxTraxxon
 
 3.8.0 - November 18, 2022
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ in development
 
 Added
 ~~~~~
+* Remove `distutils` dependencies across the project. #5992
+  Contributed by @AndroxxTraxxon
+  
 * Move `git clone` to `user_home/.st2packs` #5845
 
 * Error on `st2ctl status` when running in Kubernetes. #5851

--- a/Makefile
+++ b/Makefile
@@ -661,7 +661,7 @@ distclean: clean
 
 .PHONY: .requirements
 .requirements: virtualenv
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)" 
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
 	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.

--- a/Makefile
+++ b/Makefile
@@ -661,7 +661,7 @@ distclean: clean
 
 .PHONY: .requirements
 .requirements: virtualenv
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)" 
 	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ REQUIREMENTS := test-requirements.txt requirements.txt
 PIP_VERSION ?= 20.3.3
 SETUPTOOLS_VERSION ?= 51.3.3
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
+PACKAGING_VERSION ?= 23.1
 
 ifndef PYLINT_CONCURRENCY
 	PYLINT_CONCURRENCY := 1
@@ -662,6 +663,7 @@ distclean: clean
 .PHONY: .requirements
 .requirements: virtualenv
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "PACKAGING_VERSION==$(PACKAGING_VERSION)"
 	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.

--- a/Makefile
+++ b/Makefile
@@ -663,7 +663,7 @@ distclean: clean
 .PHONY: .requirements
 .requirements: virtualenv
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "PACKAGING_VERSION==$(PACKAGING_VERSION)"
+	$(VIRTUALENV_DIR)/bin/pip install --upgrade "packaging==$(PACKAGING_VERSION)"
 	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ REQUIREMENTS := test-requirements.txt requirements.txt
 PIP_VERSION ?= 20.3.3
 SETUPTOOLS_VERSION ?= 51.3.3
 PIP_OPTIONS := $(ST2_PIP_OPTIONS)
-PACKAGING_VERSION ?= 23.1
 
 ifndef PYLINT_CONCURRENCY
 	PYLINT_CONCURRENCY := 1
@@ -663,7 +662,6 @@ distclean: clean
 .PHONY: .requirements
 .requirements: virtualenv
 	$(VIRTUALENV_DIR)/bin/pip install --upgrade "pip==$(PIP_VERSION)"
-	$(VIRTUALENV_DIR)/bin/pip install --upgrade "packaging==$(PACKAGING_VERSION)"
 	# Print out pip version
 	$(VIRTUALENV_DIR)/bin/pip --version
 	# Generate all requirements to support current CI pipeline.

--- a/contrib/runners/action_chain_runner/dist_utils.py
+++ b/contrib/runners/action_chain_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/announcement_runner/dist_utils.py
+++ b/contrib/runners/announcement_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/http_runner/dist_utils.py
+++ b/contrib/runners/http_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/inquirer_runner/dist_utils.py
+++ b/contrib/runners/inquirer_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/local_runner/dist_utils.py
+++ b/contrib/runners/local_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/noop_runner/dist_utils.py
+++ b/contrib/runners/noop_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/orquesta_runner/dist_utils.py
+++ b/contrib/runners/orquesta_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/python_runner/dist_utils.py
+++ b/contrib/runners/python_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     # This puts priority on loading virtualenv library in the pack's action. This is necessary
     # for the situation that both st2 and pack require to load same name libraries with different
     # version. Without this statement, action may call library method with unexpected dependencies.
-    sys.path.insert(0, sysconfig.get_path('platlib'))
+    sys.path.insert(0, sysconfig.get_path("platlib"))
 
 import sys
 import argparse

--- a/contrib/runners/python_runner/python_runner/python_action_wrapper.py
+++ b/contrib/runners/python_runner/python_runner/python_action_wrapper.py
@@ -26,7 +26,7 @@ import sys
 import select
 import traceback
 
-import distutils.sysconfig
+import sysconfig
 
 # NOTE: We intentionally use orjson directly here instead of json_encode - orjson.dumps relies
 # on config option which we don't parse for the action wrapper since it speeds things down - action
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     # This puts priority on loading virtualenv library in the pack's action. This is necessary
     # for the situation that both st2 and pack require to load same name libraries with different
     # version. Without this statement, action may call library method with unexpected dependencies.
-    sys.path.insert(0, distutils.sysconfig.get_python_lib())
+    sys.path.insert(0, sysconfig.get_path('platlib'))
 
 import sys
 import argparse

--- a/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
+++ b/contrib/runners/python_runner/tests/integration/test_python_action_process_wrapper.py
@@ -37,7 +37,7 @@ import os
 import json
 
 import unittest2
-from distutils.spawn import find_executable
+from shutil import which as shutil_which
 
 from st2common.util.shell import run_command
 from six.moves import range
@@ -61,7 +61,7 @@ WRAPPER_SCRIPT_PATH = os.path.join(
     BASE_DIR, "../../../python_runner/python_runner/python_action_wrapper.py"
 )
 WRAPPER_SCRIPT_PATH = os.path.abspath(WRAPPER_SCRIPT_PATH)
-TIME_BINARY_PATH = find_executable("time")
+TIME_BINARY_PATH = shutil_which("time")
 TIME_BINARY_AVAILABLE = TIME_BINARY_PATH is not None
 
 

--- a/contrib/runners/remote_runner/dist_utils.py
+++ b/contrib/runners/remote_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/contrib/runners/winrm_runner/dist_utils.py
+++ b/contrib/runners/winrm_runner/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/scripts/dist_utils.py
+++ b/scripts/dist_utils.py
@@ -20,8 +20,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # // NOTE: After you update this script, please run:
 # //
 # //       make .sdist-requirements
@@ -52,48 +50,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/scripts/dist_utils_old.py
+++ b/scripts/dist_utils_old.py
@@ -38,7 +38,6 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 try:
-    import pip
     from pip import __version__ as pip_version
 except ImportError as e:
     print("Failed to import pip: %s" % (text_type(e)))

--- a/scripts/dist_utils_old.py
+++ b/scripts/dist_utils_old.py
@@ -27,8 +27,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 PY3 = sys.version_info[0] == 3
 
@@ -62,26 +60,11 @@ except ImportError:
         sys.exit(1)
 
 __all__ = [
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
 
 
 def fetch_requirements(requirements_file_path):

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -271,7 +271,6 @@ def write_requirements(
 
 
 if __name__ == "__main__":
-    check_pip_version()
     args = parse_args()
 
     if args["skip"]:

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -34,8 +34,6 @@ import os
 import os.path
 import sys
 
-from packaging.version import Version
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -113,15 +111,6 @@ def parse_args():
         parser.print_help()
         sys.exit(1)
     return vars(parser.parse_args())
-
-
-def check_pip_version():
-    if Version(pip.__version__) < Version("6.1.0"):
-        print(
-            "Upgrade pip, your version `{0}' " "is outdated:\n".format(pip.__version__),
-            GET_PIP,
-        )
-        sys.exit(1)
 
 
 def load_requirements(file_path):

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -34,7 +34,7 @@ import os
 import os.path
 import sys
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 PY2 = sys.version_info[0] == 2
@@ -116,7 +116,7 @@ def parse_args():
 
 
 def check_pip_version():
-    if StrictVersion(pip.__version__) < StrictVersion("6.1.0"):
+    if Version(pip.__version__) < Version("6.1.0"):
         print(
             "Upgrade pip, your version `{0}' " "is outdated:\n".format(pip.__version__),
             GET_PIP,

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -47,7 +47,6 @@ OSCWD = os.path.abspath(os.curdir)
 GET_PIP = "    curl https://bootstrap.pypa.io/get-pip.py | python"
 
 try:
-    import pip
     from pip import __version__ as pip_version
 except ImportError as e:
     print("Failed to import pip: %s" % (text_type(e)))

--- a/st2actions/dist_utils.py
+++ b/st2actions/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2api/dist_utils.py
+++ b/st2api/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2auth/dist_utils.py
+++ b/st2auth/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2client/dist_utils.py
+++ b/st2client/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2client/setup.py
+++ b/st2client/setup.py
@@ -18,13 +18,10 @@ import os.path
 
 from setuptools import setup, find_packages
 
-from dist_utils import check_pip_version
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 
 from st2client import __version__
-
-check_pip_version()
 
 ST2_COMPONENT = "st2client"
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/st2common/dist_utils.py
+++ b/st2common/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2common/st2common/util/pack_management.py
+++ b/st2common/st2common/util/pack_management.py
@@ -35,7 +35,7 @@ import six
 from git.repo import Repo
 from gitdb.exc import BadName, BadObject
 from lockfile import LockFile
-from distutils.spawn import find_executable
+from shutil import which as shutil_which
 
 from st2common import log as logging
 from st2common.content import utils
@@ -67,7 +67,7 @@ CONFIG_FILE = "config.yaml"
 CURRENT_STACKSTORM_VERSION = get_stackstorm_version()
 CURRENT_PYTHON_VERSION = get_python_version()
 
-SUDO_BINARY = find_executable("sudo")
+SUDO_BINARY = shutil_which("sudo")
 
 
 def download_pack(

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import fnmatch
 import os
 import sys
-from distutils.sysconfig import get_python_lib
+import sysconfig
 
 from oslo_config import cfg
 
@@ -108,7 +108,7 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 
     if inherit_parent_virtualenv and is_in_virtualenv():
         # We are running inside virtualenv
-        site_packages_dir = get_python_lib()
+        site_packages_dir = sysconfig.get_path('platlib')
 
         sys_prefix = os.path.abspath(sys.prefix)
         if sys_prefix not in site_packages_dir:

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -23,13 +23,17 @@ from __future__ import absolute_import
 import fnmatch
 import os
 import sys
-import sysconfig
+from sysconfig import get_path 
 
 from oslo_config import cfg
 
 from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.content.utils import get_pack_base_path
+
+def get_python_lib():
+    """Replacement for distutil.sysconfig.get_python_lib, returns a string with the python platform lib path (to site-packages)"""
+    return get_path('platlib')
 
 __all__ = [
     "get_sandbox_python_binary_path",
@@ -108,7 +112,7 @@ def get_sandbox_python_path(inherit_from_parent=True, inherit_parent_virtualenv=
 
     if inherit_parent_virtualenv and is_in_virtualenv():
         # We are running inside virtualenv
-        site_packages_dir = sysconfig.get_path('platlib')
+        site_packages_dir = get_python_lib()
 
         sys_prefix = os.path.abspath(sys.prefix)
         if sys_prefix not in site_packages_dir:

--- a/st2common/st2common/util/sandboxing.py
+++ b/st2common/st2common/util/sandboxing.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import fnmatch
 import os
 import sys
-from sysconfig import get_path 
+from sysconfig import get_path
 
 from oslo_config import cfg
 
@@ -31,9 +31,11 @@ from st2common.constants.action import LIBS_DIR as ACTION_LIBS_DIR
 from st2common.constants.pack import SYSTEM_PACK_NAMES
 from st2common.content.utils import get_pack_base_path
 
+
 def get_python_lib():
     """Replacement for distutil.sysconfig.get_python_lib, returns a string with the python platform lib path (to site-packages)"""
-    return get_path('platlib')
+    return get_path("platlib")
+
 
 __all__ = [
     "get_sandbox_python_binary_path",

--- a/st2common/st2common/util/virtualenvs.py
+++ b/st2common/st2common/util/virtualenvs.py
@@ -67,7 +67,7 @@ def setup_pack_virtualenv(
                    level logger.
 
     :param no_download: Do not download and install latest version of pre-installed packages such
-                        as pip and distutils.
+                        as pip and setuptools.
     :type no_download: ``bool``
     """
     logger = logger or LOG
@@ -170,7 +170,7 @@ def create_virtualenv(
     :type include_wheel : ``bool``
 
     :param no_download: Do not download and install latest version of pre-installed packages such
-                        as pip and distutils.
+                        as pip and setuptools.
     :type no_download: ``bool``
     """
 

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -16,7 +16,6 @@
 import os
 import sys
 
-import six
 import mock
 import unittest2
 

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -26,8 +26,6 @@ SCRIPTS_PATH = os.path.join(BASE_DIR, "../../../scripts/")
 # Add scripts/ which contain main dist_utils.py to PYTHONPATH
 sys.path.insert(0, SCRIPTS_PATH)
 
-from dist_utils import check_pip_is_installed
-from dist_utils import check_pip_version
 from dist_utils import fetch_requirements
 from dist_utils import apply_vagrant_workaround
 from dist_utils import get_version_string
@@ -50,39 +48,6 @@ class DistUtilsTestCase(unittest2.TestCase):
 
     def tearDown(self):
         super(DistUtilsTestCase, self).tearDown()
-
-    def test_check_pip_is_installed_success(self):
-        self.assertTrue(check_pip_is_installed())
-
-    @mock.patch("sys.exit")
-    def test_check_pip_is_installed_failure(self, mock_sys_exit):
-        if six.PY3:
-            module_name = "builtins.__import__"
-        else:
-            module_name = "__builtin__.__import__"
-
-        with mock.patch(module_name) as mock_import:
-            mock_import.side_effect = ImportError("not found")
-
-            self.assertEqual(mock_sys_exit.call_count, 0)
-            check_pip_is_installed()
-            self.assertEqual(mock_sys_exit.call_count, 1)
-            self.assertEqual(mock_sys_exit.call_args_list[0][0], (1,))
-
-    def test_check_pip_version_success(self):
-        self.assertTrue(check_pip_version())
-
-    @mock.patch("sys.exit")
-    def test_check_pip_version_failure(self, mock_sys_exit):
-
-        mock_pip = mock.Mock()
-        mock_pip.__version__ = "0.0.0"
-        sys.modules["pip"] = mock_pip
-
-        self.assertEqual(mock_sys_exit.call_count, 0)
-        check_pip_version()
-        self.assertEqual(mock_sys_exit.call_count, 1)
-        self.assertEqual(mock_sys_exit.call_args_list[0][0], (1,))
 
     def test_get_version_string(self):
         version = get_version_string(VERSION_FILE_PATH)

--- a/st2reactor/dist_utils.py
+++ b/st2reactor/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2stream/dist_utils.py
+++ b/st2stream/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):

--- a/st2tests/dist_utils.py
+++ b/st2tests/dist_utils.py
@@ -24,8 +24,6 @@ import os
 import re
 import sys
 
-from distutils.version import StrictVersion
-
 # NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
 #
 # TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
@@ -48,48 +46,11 @@ else:
 GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
 
 __all__ = [
-    "check_pip_is_installed",
-    "check_pip_version",
     "fetch_requirements",
     "apply_vagrant_workaround",
     "get_version_string",
     "parse_version_string",
 ]
-
-
-def check_pip_is_installed():
-    """
-    Ensure that pip is installed.
-    """
-    try:
-        import pip  # NOQA
-    except ImportError as e:
-        print("Failed to import pip: %s" % (text_type(e)))
-        print("")
-        print("Download pip:\n%s" % (GET_PIP))
-        sys.exit(1)
-
-    return True
-
-
-def check_pip_version(min_version="6.0.0"):
-    """
-    Ensure that a minimum supported version of pip is installed.
-    """
-    check_pip_is_installed()
-
-    import pip
-
-    if StrictVersion(pip.__version__) < StrictVersion(min_version):
-        print(
-            "Upgrade pip, your version '{0}' "
-            "is outdated. Minimum required version is '{1}':\n{2}".format(
-                pip.__version__, min_version, GET_PIP
-            )
-        )
-        sys.exit(1)
-
-    return True
 
 
 def fetch_requirements(requirements_file_path):


### PR DESCRIPTION
Python has been warning that distutils will be removed for a while now, and the retirement is official in Python3.12, so this is my attempt at removing/replacing distutils functionality.

I opted to not replace the pip version check in the `st2client` package because Pip 6.1.0 (April 2015) was released before Python 3.6 (Dec. 2016, already EOL) existed, and we specify the pip version in the Makefile. I'm sure we can find a way to get `packaging` installed for the version check, or to replace it with a custom-rolled replacement comparison if the community deems it necessary.

I could also see the argument for removing that check from the `fixate-requirements.py` script as well, but I wanted to show the most commonly recommended replacement for distutils.version.

This change is similar to the one made for the Orquesta package here, basically just removing functionality that's been deprecated for a while and is officially removed in an upcoming version of Python: https://github.com/StackStorm/orquesta/pull/253