### PR TITLE
Fix Cert-based SSH Auth Issues in Paramiko

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Fixed
 * Fix CI usses #6015
   Contributed by Amanda McGuinness (@amanda11 intive)
 
+* Bumped `paramiko` to `2.10.5` to fix an issue with SSH Certs - https://github.com/paramiko/paramiko/issues/2017
+  Contributed by @jk464
+
 Added
 ~~~~~
 * Move `git clone` to `user_home/.st2packs` #5845
@@ -33,7 +36,6 @@ Added
 
 * Expose environment variable ST2_ACTION_DEBUG to all StackStorm actions.
   Contributed by @maxfactor1
-
 
 3.8.0 - November 18, 2022
 -------------------------

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -36,7 +36,7 @@ decorator==4.4.2
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13
 oslo.utils<5.0,>=4.0.0
-paramiko==2.10.1
+paramiko==2.10.5
 passlib==1.7.4
 prompt-toolkit==1.0.15
 pyinotify==0.9.6 ; platform_system=="Linux"

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ orjson==3.5.2
 orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
 oslo.config>=1.12.1,<1.13
 oslo.utils<5.0,>=4.0.0
-paramiko==2.10.1
+paramiko==2.10.5
 passlib==1.7.4
 prettytable==2.1.0
 prompt-toolkit==1.0.15

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -29,7 +29,7 @@ networkx>=2.5.1,<2.6
 orjson==3.5.2
 orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
 oslo.config>=1.12.1,<1.13
-paramiko==2.10.1
+paramiko==2.10.5
 pyOpenSSL<=21.0.0
 pymongo==3.11.3
 python-dateutil==2.8.1


### PR DESCRIPTION
Paramiko 2.10.1 is effect by:

https://github.com/paramiko/paramiko/issues/2017

That break cert-based SSH auth when using Paramiko, both are fixed in 2.10.5

This PR bumps Paramiko to 2.10.5 to fix this issue