### PR TITLE
Open pywinrm shell sessions with UTF-8 codepage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 * Restore Pack integration testing (it was inadvertently skipped) and stop testing against `bionic` and `el7`. #6135
 * Fix Popen.pid typo in st2tests. #6184
 * Bump tooz package to `6.2.0` to fix TLS. #6220 (@jk464)
+* Shells via `pywinrm` are initialized with the 65001 codepage to ensure raw string responses are UTF-8. #6034 (@stealthii)
 
 Changed
 ~~~~~~~

--- a/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
+++ b/contrib/runners/winrm_runner/tests/unit/test_winrm_base.py
@@ -304,7 +304,9 @@ class WinRmBaseTestCase(RunnerTestCase):
 
         self.assertEqual(result.__dict__, expected_response.__dict__)
         mock_protocol.open_shell.assert_called_with(
-            env_vars={"PATH": "C:\\st2\\bin"}, working_directory="C:\\st2"
+            working_directory="C:\\st2",
+            env_vars={"PATH": "C:\\st2\\bin"},
+            codepage=65001,
         )
         mock_protocol.run_command.assert_called_with(
             123, "fake-command", ["arg1", "arg2"]
@@ -336,7 +338,9 @@ class WinRmBaseTestCase(RunnerTestCase):
 
         self.assertEqual(result.__dict__, expected_response.__dict__)
         mock_protocol.open_shell.assert_called_with(
-            env_vars={"PATH": "C:\\st2\\bin"}, working_directory="C:\\st2"
+            working_directory="C:\\st2",
+            env_vars={"PATH": "C:\\st2\\bin"},
+            codepage=65001,
         )
         mock_protocol.run_command.assert_called_with(
             123, "fake-command", ["arg1", "arg2"]

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -193,11 +193,18 @@ class WinRmBaseRunner(ActionRunner):
         return b"".join(stdout_buffer), b"".join(stderr_buffer), return_code
 
     def _winrm_run_cmd(self, session, command, args=(), env=None, cwd=None):
-        # NOTE: this is copied from pywinrm because it doesn't support
-        # passing env and working_directory from the Session.run_cmd.
-        # It also doesn't support timeouts. All of these things have been
-        # added
-        shell_id = session.protocol.open_shell(env_vars=env, working_directory=cwd)
+        """Run a command on the remote host and return the standard output and
+        error as a tuple.
+
+        Extended from pywinrm to support passing env and cwd to open_shell,
+        as well as enforcing the UTF-8 codepage. Also supports timeouts.
+
+        """
+        shell_id = session.protocol.open_shell(
+            working_directory=cwd,
+            env_vars=env,
+            codepage=65001,
+        )
         command_id = session.protocol.run_command(shell_id, command, args)
         # try/catch is for custom timeout handing (StackStorm custom)
         try:

--- a/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
+++ b/contrib/runners/winrm_runner/winrm_runner/winrm_base.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import base64
 import os
 import re
-import six
 import time
 
 from base64 import b64encode
@@ -257,10 +256,10 @@ class WinRmBaseRunner(ActionRunner):
         }
 
         # Ensure stdout and stderr is always a string
-        if isinstance(result["stdout"], six.binary_type):
+        if isinstance(result["stdout"], bytes):
             result["stdout"] = result["stdout"].decode("utf-8")
 
-        if isinstance(result["stderr"], six.binary_type):
+        if isinstance(result["stderr"], bytes):
             result["stderr"] = result["stderr"].decode("utf-8")
 
         # automatically convert result stdout/stderr from JSON strings to
@@ -316,7 +315,7 @@ $path""".format(
 
     def _upload_chunk(self, dst_path, src_data):
         # adapted from https://github.com/diyan/pywinrm/issues/18
-        if not isinstance(src_data, six.binary_type):
+        if not isinstance(src_data, bytes):
             src_data = src_data.encode("utf-8")
 
         ps = """$filePath = "{dst_path}"
@@ -446,7 +445,7 @@ Add-Content -value $data -encoding byte -path $filePath
         ps_str = ""
         if param is None:
             ps_str = "$null"
-        elif isinstance(param, six.string_types):
+        elif isinstance(param, str):
             ps_str = '"' + self._multireplace(param, PS_ESCAPE_SEQUENCES) + '"'
         elif isinstance(param, bool):
             ps_str = "$true" if param else "$false"
@@ -459,7 +458,7 @@ Add-Content -value $data -encoding byte -path $filePath
             ps_str += "; ".join(
                 [
                     (self._param_to_ps(k) + " = " + self._param_to_ps(v))
-                    for k, v in six.iteritems(param)
+                    for k, v in param.items()
                 ]
             )
             ps_str += "}"
@@ -473,7 +472,7 @@ Add-Content -value $data -encoding byte -path $filePath
                 positional_args[i] = self._param_to_ps(arg)
 
         if named_args:
-            for key, value in six.iteritems(named_args):
+            for key, value in named_args.items():
                 named_args[key] = self._param_to_ps(value)
 
         return positional_args, named_args
@@ -486,9 +485,7 @@ Add-Content -value $data -encoding byte -path $filePath
         # concatenate them into a long string
         ps_params_str = ""
         if named_args:
-            ps_params_str += " ".join(
-                [(k + " " + v) for k, v in six.iteritems(named_args)]
-            )
+            ps_params_str += " ".join([(k + " " + v) for k, v in named_args.items()])
             ps_params_str += " "
         if positional_args:
             ps_params_str += " ".join(positional_args)


### PR DESCRIPTION
This PR implements a change to the shell initialisation process with pywinrm, utilizing the 65001 codepage, ensuring raw string responses are UTF-8 encoded.

Potential fix for #6034.