### PR TITLE
CI: Update ruby 2.4 -> 2.6 to fix CircleCI Packagecloud deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
   deploy:
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.6
     working_directory: /tmp/deploy
     environment:
       - DISTROS: "bionic focal el7 el8"


### PR DESCRIPTION
CircleCI started to fail on `deploy` step (https://app.circleci.com/pipelines/github/StackStorm/st2/4125/workflows/d62a5fd6-42c3-484f-acf7-5ba525ee22b9/jobs/15902)

with the following error:
```
ERROR:  Error installing package_cloud:
        The last version of thor (~> 1.2) to support your Ruby & RubyGems was 1.2.2. Try installing it with `gem install thor -v 1.2.2` and then running the current command again
        thor requires Ruby version >= 2.6.0. The current ruby version is 2.4.10.364.
```

Sync CircleCI config with `st2web` (https://github.com/StackStorm/st2web/blob/ba85bf2a495056ba4e1e22b8727a84baf4493c48/.circleci/config.yml#L153 config) with `ruby:2.6` where deployment worked OK.