### PR TITLE
Fix st2 cli client auth in st2auth proxy mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ in development
 
 Fixed
 ~~~~~
-* Additional fixes for st2 client auth when proxy auth mode enabled
+* Additional fixes for st2 client auth when proxy auth mode enabled #6049
   Contributed by @floatingstatic
 
 * Fix issue with linux pack actions failed to run remotely due to incorrect python shebang. #5983 #6042

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ in development
 
 Fixed
 ~~~~~
+* Additional fixes for st2 client auth when proxy auth mode enabled
+  Contributed by @floatingstatic
+
 * Fix issue with linux pack actions failed to run remotely due to incorrect python shebang. #5983 #6042
   Contributed by Ronnie Hoffmann (@ZoeLeah Schwarz IT KG)
 

--- a/st2auth/st2auth/handlers.py
+++ b/st2auth/st2auth/handlers.py
@@ -130,6 +130,25 @@ class ProxyAuthHandler(AuthHandlerBase):
         remote_addr = headers.get("x-forwarded-for", remote_addr)
         extra = {"remote_addr": remote_addr}
 
+        # Needed to support st2client which does not connect via st2web
+        if authorization and not remote_user:
+            try:
+                auth_value = base64.b64decode(authorization[1])
+            except Exception:
+                LOG.audit("Invalid authorization header", extra=extra)
+                abort_request()
+                return
+
+            split = auth_value.split(b":", 1)
+            if len(split) != 2:
+                LOG.audit("Invalid authorization header", extra=extra)
+                abort_request()
+                return
+
+            remote_user = split[0]
+            if six.PY3 and isinstance(remote_user, six.binary_type):
+                remote_user = remote_user.decode("utf-8")
+
         if remote_user:
             ttl = getattr(request, "ttl", None)
             username = self._get_username_for_request(remote_user, request)

--- a/st2auth/tests/unit/test_handlers.py
+++ b/st2auth/tests/unit/test_handlers.py
@@ -48,6 +48,31 @@ class AuthHandlerTestCase(CleanDbTestCase):
         )
         self.assertEqual(token.user, "test_proxy_handler")
 
+    def test_proxy_handler_no_remote_user(self):
+        h = handlers.ProxyAuthHandler()
+        request = {}
+        token = h.handle_auth(
+            request,
+            headers={},
+            remote_addr=None,
+            remote_user=None,
+            authorization=("basic", DUMMY_CREDS),
+        )
+        self.assertEqual(token.user, "auser")
+
+    def test_proxy_handler_bad_auth(self):
+        h = handlers.ProxyAuthHandler()
+        request = {}
+
+        with self.assertRaises(exc.HTTPUnauthorized):
+            h.handle_auth(
+                request,
+                headers={},
+                remote_addr=None,
+                remote_user=None,
+                authorization=None,
+            )
+
     def test_standalone_bad_auth_type(self):
         h = handlers.StandaloneAuthHandler()
         request = {}


### PR DESCRIPTION
Adding on to work in #6041 that fixed proxy auth mode for users connecting via st2web, it appears that the `st2` client (`st2client` container in the HA helm chart) connects directly to `st2auth` instead of connecting through nginx. As a result it is unable to authenticate with `st2auth` is in proxy mode as headers required for this to work are not present. We see `401 Client Error: Unauthorized` in this scenario. The `st2` client does however use basic auth and we can extract the username from that in this scenario to resolve the issue.

This change modifies the proxy auth handler to use the username from the `Authorization` header only in the case where proxy auth mode is enabled and when `remote_user` is not passed to the proxy auth handler function.