### PR TITLE
Update Orquesta to v1.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ in development
 
 Fixed
 ~~~~~
+* Update orquesta to v1.6.0 to fix outdated dependencies (security). #6050
+
 * Fix issue with linux pack actions failed to run remotely due to incorrect python shebang. #5983 #6042
   Contributed by Ronnie Hoffmann (@ZoeLeah Schwarz IT KG)
 

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,1 @@
-orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -5,4 +5,4 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -27,11 +27,12 @@ lockfile==0.12.2
 MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
 # networkx v2.6 does not support Python3.6.  Update networkx to match orquesta
-networkx>=2.5.1,<2.6
+networkx>=2.5.1,<2.6; python_version < '3.7'
+networkx>=2.6<3; python_version >= '3.7'
 # networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
 # but the wheel on pypi does not say it supports python3.8, so pip gets
 # confused. For now, pin decorator to work around pip's confusion.
-decorator==4.4.2
+decorator==4.4.2; python_version < '3.7'
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -26,14 +26,6 @@ lockfile==0.12.2
 # >=0.23 was from jinja2
 MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
-# networkx v2.6 does not support Python3.6.  Update networkx to match orquesta
-networkx>=2.5.1,<2.6; python_version < '3.7'
-# use patched v2.6 networkx for Python3.8 to match orquesta 
-networkx>=2.6<3; python_version >= '3.7'
-# networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
-# but the wheel on pypi does not say it supports python3.8, so pip gets
-# confused. For now, pin decorator to work around pip's confusion.
-decorator==4.4.2; python_version < '3.7'
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -28,6 +28,7 @@ MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
 # networkx v2.6 does not support Python3.6.  Update networkx to match orquesta
 networkx>=2.5.1,<2.6; python_version < '3.7'
+# use patched v2.6 networkx for Python3.8 to match orquesta 
 networkx>=2.6<3; python_version >= '3.7'
 # networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
 # but the wheel on pypi does not say it supports python3.8, so pip gets

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -26,8 +26,12 @@ lockfile==0.12.2
 # >=0.23 was from jinja2
 MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
-# required by orquesta
+# required by orquesta (networkx<2.6 for py3.6, networkx<3 for py3.8)
 networkx<3
+# networkx requires decorator>=4.3,<5 which should resolve to version 4.4.2
+# but the wheel on pypi does not say it supports python3.8, so pip gets
+# confused. For now, pin decorator to work around pip's confusion.
+decorator==4.4.2
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -26,6 +26,8 @@ lockfile==0.12.2
 # >=0.23 was from jinja2
 MarkupSafe<2.1.0,>=0.23
 mongoengine==0.23.0
+# required by orquesta
+networkx<3
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -29,7 +29,7 @@ mock
 mongoengine
 # Note: networkx v2.6 dropped support for Python3.6
 # networkx version is constrained in orquesta.
-networkx
+networkx<3
 orjson
 orquesta @ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 # NOTE: Recent version substantially affect the performance and add big import time overhead

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -31,7 +31,7 @@ mongoengine
 # networkx version is constrained in orquesta.
 networkx
 orjson
-orquesta @ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta @ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 # NOTE: Recent version substantially affect the performance and add big import time overhead
 # See https://github.com/StackStorm/st2/issues/4160#issuecomment-394386433 for details
 oslo.config>=1.12.1,<1.13

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -29,7 +29,7 @@ mock
 mongoengine
 # Note: networkx v2.6 dropped support for Python3.6
 # networkx version is constrained in orquesta.
-networkx<3
+networkx
 orjson
 orquesta @ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 # NOTE: Recent version substantially affect the performance and add big import time overhead

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ lockfile==0.12.2
 logshipper@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched ; platform_system=="Linux"
 mock==4.0.3
 mongoengine==0.23.0
-networkx
+networkx<3
 nose
 nose-parallel==0.4.0
 nose-timer==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator==4.4.2; python_version < '3.7'
+decorator
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1
@@ -32,8 +32,7 @@ lockfile==0.12.2
 logshipper@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched ; platform_system=="Linux"
 mock==4.0.3
 mongoengine==0.23.0
-networkx>=2.5.1,<2.6; python_version < '3.7'
-networkx>=2.6<3; python_version >= '3.7'
+networkx
 nose
 nose-parallel==0.4.0
 nose-timer==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator
+decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator==4.4.2
+decorator==4.4.2; python_version < '3.7'
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1
@@ -32,7 +32,8 @@ lockfile==0.12.2
 logshipper@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched ; platform_system=="Linux"
 mock==4.0.3
 mongoengine==0.23.0
-networkx>=2.5.1,<2.6
+networkx>=2.5.1,<2.6; python_version < '3.7'
+networkx>=2.6<3; python_version >= '3.7'
 nose
 nose-parallel==0.4.0
 nose-timer==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ nose
 nose-parallel==0.4.0
 nose-timer==1.0.1
 orjson==3.5.2
-orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 oslo.config>=1.12.1,<1.13
 oslo.utils<5.0,>=4.0.0
 paramiko==2.10.5

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -136,8 +136,8 @@ def merge_source_requirements(sources):
                 # Requirements starting with project name "project ..."
                 parsedreq = parse_req_from_line(req.requirement, req.line_source)
                 if parsedreq.requirement:
-                    # Skip already added project name
-                    if parsedreq.requirement.name in projects:
+                    # Skip already added project name, unless it has markers
+                    if parsedreq.requirement.name in projects and not parsedreq.markers:
                         continue
                     projects.add(parsedreq.requirement.name)
                     merged_requirements.append(req)
@@ -181,6 +181,9 @@ def write_requirements(
         if hasattr(req, "requirement"):
             parsedreq = parse_req_from_line(req.requirement, req.line_source)
             project_name = parsedreq.requirement.name
+            # consider requirements with markers as unique
+            if parsedreq.markers:
+                project_name = f"{project_name};{parsedreq.markers}"
 
             if not req.requirement:
                 continue
@@ -228,6 +231,8 @@ def write_requirements(
                 rline = "-e %s" % (rline)
         elif hasattr(req, "requirement") and req.requirement:
             project = parsedreq.requirement.name
+            if parsedreq.markers:
+                project = f"{project};{parsedreq.markers}"
             req_obj = fixedreq_hash.get(project, req)
 
             rline = str(req_obj.requirement)

--- a/scripts/fixate-requirements.py
+++ b/scripts/fixate-requirements.py
@@ -136,8 +136,8 @@ def merge_source_requirements(sources):
                 # Requirements starting with project name "project ..."
                 parsedreq = parse_req_from_line(req.requirement, req.line_source)
                 if parsedreq.requirement:
-                    # Skip already added project name, unless it has markers
-                    if parsedreq.requirement.name in projects and not parsedreq.markers:
+                    # Skip already added project name
+                    if parsedreq.requirement.name in projects:
                         continue
                     projects.add(parsedreq.requirement.name)
                     merged_requirements.append(req)
@@ -181,9 +181,6 @@ def write_requirements(
         if hasattr(req, "requirement"):
             parsedreq = parse_req_from_line(req.requirement, req.line_source)
             project_name = parsedreq.requirement.name
-            # consider requirements with markers as unique
-            if parsedreq.markers:
-                project_name = f"{project_name};{parsedreq.markers}"
 
             if not req.requirement:
                 continue
@@ -231,8 +228,6 @@ def write_requirements(
                 rline = "-e %s" % (rline)
         elif hasattr(req, "requirement") and req.requirement:
             project = parsedreq.requirement.name
-            if parsedreq.markers:
-                project = f"{project};{parsedreq.markers}"
             req_obj = fixedreq_hash.get(project, req)
 
             rline = str(req_obj.requirement)

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -14,7 +14,7 @@ mongoengine
 networkx
 # used by networkx
 decorator
-orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 oslo.config
 paramiko

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -25,7 +25,7 @@ jsonschema==2.6.0
 kombu==5.0.2
 lockfile==0.12.2
 mongoengine==0.23.0
-networkx
+networkx<3
 orjson==3.5.2
 orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 oslo.config>=1.12.1,<1.13

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -12,7 +12,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator
+decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -12,7 +12,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator==4.4.2
+decorator==4.4.2; python_version < '3.7'
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1
@@ -25,9 +25,10 @@ jsonschema==2.6.0
 kombu==5.0.2
 lockfile==0.12.2
 mongoengine==0.23.0
-networkx>=2.5.1,<2.6
+networkx>=2.5.1,<2.6; python_version < '3.7'
+networkx>=2.6<3; python_version >= '3.7'
 orjson==3.5.2
-orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.5.0
+orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 oslo.config>=1.12.1,<1.13
 paramiko==2.10.5
 pyOpenSSL<=21.0.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -12,7 +12,7 @@ cffi<1.15.0
 chardet<3.1.0
 ciso8601
 cryptography==3.4.7
-decorator==4.4.2; python_version < '3.7'
+decorator
 dnspython>=1.16.0,<2.0.0
 eventlet==0.30.2
 flex==6.14.1
@@ -25,8 +25,7 @@ jsonschema==2.6.0
 kombu==5.0.2
 lockfile==0.12.2
 mongoengine==0.23.0
-networkx>=2.5.1,<2.6; python_version < '3.7'
-networkx>=2.6<3; python_version >= '3.7'
+networkx
 orjson==3.5.2
 orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0
 oslo.config>=1.12.1,<1.13


### PR DESCRIPTION
Update Orquesta to v1.6.0 to be included in the next st2 release.
Orquesta v1.6.0 comes with some updated dependencies.
