### PR TITLE
Bump eventlet to fix setting SSLContext minimum_version property that results in RecursionErrors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Fixed
 
 * Update cryptography 3.4.7 -> 39.0.1, pyOpenSSL 21.0.0 -> 23.1.0, paramiko 2.10.5 -> 2.11.0 (security). #6055
 
+* Bumped `eventlet` to `0.33.3` and `gunicorn` to `21.2.0` to fix `RecursionError` bug in setting `SSLContext` `minimum_version` property. #6061
+  Contributed by @jk464
+
 Added
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -10,14 +10,14 @@ dnspython>=1.16.0,<2.0.0
 cryptography==39.0.1
 # Note: 0.20.0 removed select.poll() on which some of our code and libraries we
 # depend on rely
-eventlet==0.30.2
+eventlet==0.33.3
 flex==6.14.1
 gitpython==3.1.15
 # Needed by gitpython, old versions used to bundle it
 gitdb==4.0.2
 # Note: greenlet is used by eventlet
 greenlet==1.0.0
-gunicorn==20.1.0
+gunicorn==21.2.0
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==5.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,12 @@ ciso8601
 cryptography==39.0.1
 decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
-eventlet==0.30.2
+eventlet==0.33.3
 flex==6.14.1
 gitdb==4.0.2
 gitpython==3.1.15
 greenlet==1.0.0
-gunicorn==20.1.0
+gunicorn==21.2.0
 importlib-metadata==3.10.1
 jinja2==2.11.3
 jsonpath-rw==1.4.0

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -8,7 +8,7 @@
 MarkupSafe<2.1.0,>=0.23
 apscheduler==3.7.0
 chardet<3.1.0
-eventlet==0.30.2
+eventlet==0.33.3
 gitpython==3.1.15
 jinja2==2.11.3
 kombu==5.0.2

--- a/st2api/requirements.txt
+++ b/st2api/requirements.txt
@@ -5,8 +5,8 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.30.2
-gunicorn==20.1.0
+eventlet==0.33.3
+gunicorn==21.2.0
 jsonschema==2.6.0
 kombu==5.0.2
 mongoengine==0.23.0

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -6,8 +6,8 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 bcrypt==3.2.0
-eventlet==0.30.2
-gunicorn==20.1.0
+eventlet==0.33.3
+gunicorn==21.2.0
 oslo.config>=1.12.1,<1.13
 passlib==1.7.4
 pymongo==3.11.3

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -14,7 +14,7 @@ ciso8601
 cryptography==39.0.1
 decorator==4.4.2
 dnspython>=1.16.0,<2.0.0
-eventlet==0.30.2
+eventlet==0.33.3
 flex==6.14.1
 gitdb==4.0.2
 gitpython==3.1.15

--- a/st2reactor/requirements.txt
+++ b/st2reactor/requirements.txt
@@ -6,7 +6,7 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 apscheduler==3.7.0
-eventlet==0.30.2
+eventlet==0.33.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 kombu==5.0.2

--- a/st2stream/requirements.txt
+++ b/st2stream/requirements.txt
@@ -5,8 +5,8 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-eventlet==0.30.2
-gunicorn==20.1.0
+eventlet==0.33.3
+gunicorn==21.2.0
 jsonschema==2.6.0
 kombu==5.0.2
 mongoengine==0.23.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -23,7 +23,7 @@ nose-parallel==0.4.0
 # Required by st2client tests
 pyyaml==5.4.1
 RandomWords
-gunicorn==20.1.0
+gunicorn==21.2.0
 psutil==5.8.0
 webtest==2.0.35
 rstcheck>=3.3.1,<3.4


### PR DESCRIPTION
While writing a sensor for st2 - we hit this error:

```
stackstorm-docker-compose-st2sensorcontainer-1  | 2023-10-24 14:23:28,648 WARNING [-] Sensor "PollPagerDuty" run method raised an exception: maximum recursion depth exceeded while calling a Python object.
stackstorm-docker-compose-st2sensorcontainer-1  | Traceback (most recent call last):
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/st2reactor/container/sensor_wrapper.py", line 285, in run
stackstorm-docker-compose-st2sensorcontainer-1  |     self._sensor_instance.run()
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/st2reactor/sensor/base.py", line 121, in run
stackstorm-docker-compose-st2sensorcontainer-1  |     self.poll()
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/packs/****_pagerduty/sensors/poll_pagerduty.py", line 27, in poll
stackstorm-docker-compose-st2sensorcontainer-1  |     self._detect_triggered_incidents()
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/packs/****_pagerduty/sensors/poll_pagerduty.py", line 42, in _detect_triggered_incidents
stackstorm-docker-compose-st2sensorcontainer-1  |     incidents = self.pagerduty.list_all(
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/virtualenvs/****_pagerduty/lib/python3.8/site-packages/pdpyras.py", line 1911, in list_all
stackstorm-docker-compose-st2sensorcontainer-1  |     return list(self.iter_all(url, **kw))
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/virtualenvs/****_pagerduty/lib/python3.8/site-packages/pdpyras.py", line 1788, in iter_all
stackstorm-docker-compose-st2sensorcontainer-1  |     self.get(url, params=data.copy()),
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/requests/sessions.py", line 602, in get
stackstorm-docker-compose-st2sensorcontainer-1  |     return self.request("GET", url, **kwargs)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/virtualenvs/****_pagerduty/lib/python3.8/site-packages/pdpyras.py", line 1121, in request
stackstorm-docker-compose-st2sensorcontainer-1  |     response = self.parent.request(method, full_url, **req_kw)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
stackstorm-docker-compose-st2sensorcontainer-1  |     resp = self.send(prep, **send_kwargs)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
stackstorm-docker-compose-st2sensorcontainer-1  |     r = adapter.send(request, **kwargs)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
stackstorm-docker-compose-st2sensorcontainer-1  |     resp = conn.urlopen(
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/connectionpool.py", line 790, in urlopen
stackstorm-docker-compose-st2sensorcontainer-1  |     response = self._make_request(
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/connectionpool.py", line 467, in _make_request
stackstorm-docker-compose-st2sensorcontainer-1  |     self._validate_conn(conn)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/connectionpool.py", line 1092, in _validate_conn
stackstorm-docker-compose-st2sensorcontainer-1  |     conn.connect()
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/connection.py", line 642, in connect
stackstorm-docker-compose-st2sensorcontainer-1  |     sock_and_verified = _ssl_wrap_socket_and_match_hostname(
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/connection.py", line 735, in _ssl_wrap_socket_and_match_hostname
stackstorm-docker-compose-st2sensorcontainer-1  |     context = create_urllib3_context(
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/opt/stackstorm/st2/lib/python3.8/site-packages/urllib3/util/ssl_.py", line 292, in create_urllib3_context
stackstorm-docker-compose-st2sensorcontainer-1  |     context.minimum_version = TLSVersion.TLSv1_2
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/usr/lib/python3.8/ssl.py", line 586, in minimum_version
stackstorm-docker-compose-st2sensorcontainer-1  |     super(SSLContext, SSLContext).minimum_version.__set__(self, value)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/usr/lib/python3.8/ssl.py", line 586, in minimum_version
stackstorm-docker-compose-st2sensorcontainer-1  |     super(SSLContext, SSLContext).minimum_version.__set__(self, value)
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/usr/lib/python3.8/ssl.py", line 586, in minimum_version
stackstorm-docker-compose-st2sensorcontainer-1  |     super(SSLContext, SSLContext).minimum_version.__set__(self, value)
stackstorm-docker-compose-st2sensorcontainer-1  |   [Previous line repeated 487 more times]
stackstorm-docker-compose-st2sensorcontainer-1  |   File "/usr/lib/python3.8/ssl.py", line 584, in minimum_version
stackstorm-docker-compose-st2sensorcontainer-1  |     if value == TLSVersion.SSLv3:
stackstorm-docker-compose-st2sensorcontainer-1  | RecursionError: maximum recursion depth exceeded while calling a Python object
```

Which after some digging seems to be this issue here for eventlet - https://github.com/eventlet/eventlet/issues/726

Bumping `evenlet` to `0.33.3` fixes this (and requires bumping `gunicorn` to `21.2.0` to support the new version of `eventlet`)

This supersedes https://github.com/StackStorm/st2/pull/5257.

It also has the added benefit of resolving - [CVE-2021-21419](https://nvd.nist.gov/vuln/detail/cve-2021-21419) (see [Improper Handling of Highly Compressed Data (Data Amplification) and Memory Allocation with Excessive Size Value in eventlet ](https://github.com/eventlet/eventlet/security/advisories/GHSA-9p9m-jm8w-94p2))