### PR TITLE
Update gitpython (security)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Fixed
 * Bumped `eventlet` to `0.33.3` and `gunicorn` to `21.2.0` to fix `RecursionError` bug in setting `SSLContext` `minimum_version` property. #6061
   Contributed by @jk464
 
+* Update version 3.1.15 of ``gitpython`` to 3.1.18 for py3.6 and to 3.1.37 for py3.8 (security). #6063
+
 Added
 ~~~~~
 

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,7 +12,7 @@ cryptography==39.0.1
 # depend on rely
 eventlet==0.33.3
 flex==6.14.1
-gitpython==3.1.15
+gitpython<=3.1.37
 # Needed by gitpython, old versions used to bundle it
 gitdb==4.0.2
 # Note: greenlet is used by eventlet

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -12,6 +12,8 @@ cryptography==39.0.1
 # depend on rely
 eventlet==0.33.3
 flex==6.14.1
+# Note: installs gitpython==3.1.37 (security fixed) under py3.8 and gitpython==3.1.18 (latest available, vulnerable) under py3.6
+# TODO: Pin to 3.1.37 or higher after dropping python3.6 support
 gitpython<=3.1.37
 # Needed by gitpython, old versions used to bundle it
 gitdb==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ dnspython>=1.16.0,<2.0.0
 eventlet==0.33.3
 flex==6.14.1
 gitdb==4.0.2
-gitpython==3.1.15
+gitpython<=3.1.37
 greenlet==1.0.0
 gunicorn==21.2.0
 importlib-metadata==3.10.1

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -9,7 +9,7 @@ MarkupSafe<2.1.0,>=0.23
 apscheduler==3.7.0
 chardet<3.1.0
 eventlet==0.33.3
-gitpython==3.1.15
+gitpython<=3.1.37
 jinja2==2.11.3
 kombu==5.0.2
 lockfile==0.12.2

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -17,7 +17,7 @@ dnspython>=1.16.0,<2.0.0
 eventlet==0.33.3
 flex==6.14.1
 gitdb==4.0.2
-gitpython==3.1.15
+gitpython<=3.1.37
 greenlet==1.0.0
 jinja2==2.11.3
 jsonpath-rw==1.4.0


### PR DESCRIPTION
Taking one dependency at a time into a separated PRs from https://github.com/StackStorm/st2/pull/6062 to see what could be merged safely ASAP.

This updates `gitpython==3.1.37` (security fixed) under py3.8 and `gitpython==3.1.18` (latest installable, but vulnerable) under py3.6

Checking the build artifacts for shipped gitpython versions:
- U18 (py3.6) - `gitpython==3.1.18`  [(build)](https://app.circleci.com/pipelines/github/StackStorm/st2/4214/workflows/b4932a80-0076-40da-8ab8-393998fbcf6f/jobs/16002?invite=true#step-109-835718_90)
- U20 (py3.8) - `gitpython==3.1.37` ([build](https://app.circleci.com/pipelines/github/StackStorm/st2/4214/workflows/b4932a80-0076-40da-8ab8-393998fbcf6f/jobs/16002/parallel-runs/1?filterBy=ALL&invite=true#step-109-834745_90))
- EL7 (py3.6) - `gitpython==3.1.18` ([build](https://app.circleci.com/pipelines/github/StackStorm/st2/4214/workflows/b4932a80-0076-40da-8ab8-393998fbcf6f/jobs/16002/parallel-runs/2?filterBy=ALL&invite=true#step-109-835226_90))
- EL8 (py3.8) - `gitpython==3.1.37` ([build](https://app.circleci.com/pipelines/github/StackStorm/st2/4214/workflows/b4932a80-0076-40da-8ab8-393998fbcf6f/jobs/16002/parallel-runs/3?filterBy=ALL&invite=true#step-109-851189_90))

We should drop the Python 3.6 support after the `3.8.1` patch release and pin githpython explicitly.