### PR TITLE
Bump ruby 2.6 -> 2.7 to fix packagecloud deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
   deploy:
     docker:
       # The primary container is an instance of the first list image listed. Your build commands run in this container.
-      - image: circleci/ruby:2.6
+      - image: circleci/ruby:2.7
     working_directory: /tmp/deploy
     environment:
       - DISTROS: "bionic focal el7 el8"


### PR DESCRIPTION
CircleCI deployment step on `master` started to fail with the following error (https://app.circleci.com/pipelines/github/StackStorm/st2/4225/workflows/9b0b5829-0bd5-4cd4-ad97-32f3b11a65bf/jobs/16016)

```
Fetching package_cloud-0.3.14.gem
Building native extensions. This could take a while...
Successfully installed rainbow-2.2.2
Successfully installed json_pure-2.3.1
Successfully installed netrc-0.11.0
Successfully installed mime-types-data-3.2023.1003
Successfully installed mime-types-3.5.1
ERROR:  Error installing package_cloud:
        The last version of domain_name (~> 0.5) to support your Ruby & RubyGems was 0.5.20190701. Try installing it with `gem install domain_name -v 0.5.20190701` and then running the current command again
        domain_name requires Ruby version >= 2.7.0. The current ruby version is 2.6.9.207.

Exited with code exit status 1
```

Update ruby to `2.7` trying to fix the `package_cloud` gem install.

