### PR TITLE
Fix ST2 Client for Windows Clients

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ in development
 
 Fixed
 ~~~~~
+* ‎Fix ST2 Client for Windows Clients. PWD is a Unix only Libary. 
+  Contributed by (@philipphomberger Schwarz IT KG)
+
 * ‎Fix Snyk Security Finding Cross-site Scripting (XSS) in contrib/examples/sensors/echo_flask_app.py
   Contributed by (@philipphomberger Schwarz IT KG)
 

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -37,11 +37,16 @@ from st2client.client import Client
 from st2client.config import get_config
 from st2client.utils.date import parse as parse_isotime
 from st2client.utils.misc import merge_dicts
+import platform
 
 __all__ = ["BaseCLIApp"]
 
 # Fix for "os.getlogin()) OSError: [Errno 2] No such file or directory"
-os.getlogin = lambda: pwd.getpwuid(os.getuid())[0]
+# Add Plattform Check to fix the Issue that PWD not exist on Windows and so the CLI not working.
+if platform.system() == "Windows":
+    os.getlogin = lambda: os.environ.get("USERNAME")
+else:
+    os.getlogin = lambda: pwd.getpwuid(os.getuid())[0]
 
 # How many seconds before the token actual expiration date we should consider the token as
 # expired. This is used to prevent the operation from failing durig the API request because the

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -16,12 +16,12 @@
 from __future__ import absolute_import
 
 import os
-import pwd
 import json
 import logging
 import time
 import calendar
 import traceback
+import platform
 
 import six
 import requests
@@ -37,7 +37,6 @@ from st2client.client import Client
 from st2client.config import get_config
 from st2client.utils.date import parse as parse_isotime
 from st2client.utils.misc import merge_dicts
-import platform
 
 __all__ = ["BaseCLIApp"]
 
@@ -46,6 +45,7 @@ __all__ = ["BaseCLIApp"]
 if platform.system() == "Windows":
     os.getlogin = lambda: os.environ.get("USERNAME")
 else:
+    import pwd
     os.getlogin = lambda: pwd.getpwuid(os.getuid())[0]
 
 # How many seconds before the token actual expiration date we should consider the token as

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -41,7 +41,9 @@ from st2client.utils.misc import merge_dicts
 __all__ = ["BaseCLIApp"]
 
 # Fix for "os.getlogin()) OSError: [Errno 2] No such file or directory"
-# Add Plattform Check to fix the Issue that PWD not exist on Windows and so the CLI not working.
+# Add Plattform Check to fix the Issue that PWD not exist on Windows and so the ST2 CLI not working.
+# https://docs.python.org/3.8/library/pwd.html
+# Windows Default ENVVARS -> https://www.computerhope.com/issues/ch000088.htm
 if platform.system() == "Windows":
     os.getlogin = lambda: os.environ.get("USERNAME")
 else:


### PR DESCRIPTION
We have try to rollout the st2client on the Windows 10/11 clients of our StackStorm users. But because PWD only exist on Unix Based Operation System it failed. 

