### PR TITLE
Update importlib-metadata (security)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ in development
 
 Fixed
 ~~~~~
-* ‎Fix Snyk Security Finding Cross-site Scripting (XSS) in contrib/examples/sensors/echo_flask_app.py
+* Fix Snyk Security Finding Cross-site Scripting (XSS) in contrib/examples/sensors/echo_flask_app.py
   Contributed by (@philipphomberger Schwarz IT KG)
 
 * Additional fixes for st2 client auth when proxy auth mode enabled #6049
@@ -40,6 +40,9 @@ Fixed
 * Fix KV value lookup in actions when RBAC is enabled #5934
 
 * Update version 3.1.15 of ``gitpython`` to 3.1.18 for py3.6 and to 3.1.37 for py3.8 (security). #6063
+
+* Update importlib-metadata from 3.10.1 to 4.8.3 for py3.6 and to 4.10.1 for py3.8 (security).
+  Contributed by @jk464
 
 Added
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Fixed
 
 * Update version 3.1.15 of ``gitpython`` to 3.1.18 for py3.6 and to 3.1.37 for py3.8 (security). #6063
 
-* Update importlib-metadata from 3.10.1 to 4.8.3 for py3.6 and to 4.10.1 for py3.8 (security).
+* Update importlib-metadata from 3.10.1 to 4.8.3 for py3.6 and to 4.10.1 for py3.8 (security). #6072
   Contributed by @jk464
 
 Added

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -60,9 +60,12 @@ routes==2.4.1
 semver==2.13.0
 six==1.13.0
 argparse==1.12.2
-argcomplete==1.12.2
+# Note: argcomplete 1.12.3 supports importlib-metadata<5
+argcomplete==1.12.3
 prettytable==2.1.0
-importlib-metadata==3.10.1
+# Note: installs importlib-metadata==4.10.1 (security fixed) under py3.8 and importlib-metadata==4.8.3 (latest available, vulnerable) under py3.6
+# TODO: Pin to 4.10.1 or higher after dropping python3.6 support
+importlib-metadata>=4.8.3,<=4.10.1
 # importlib-metadata requires typing-extensions but v4.2.0 requires py3.7+
 typing-extensions<4.2
 # NOTE: sseclient has various issues which sometimes hang the connection for a long time, etc.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ MarkupSafe<2.1.0,>=0.23
 RandomWords
 amqp==5.0.6
 apscheduler==3.7.0
-argcomplete==1.12.2
+argcomplete==1.12.3
 bcrypt==3.2.0
 cffi<1.15.0
 chardet<3.1.0
@@ -23,7 +23,7 @@ gitdb==4.0.2
 gitpython<=3.1.37
 greenlet==1.0.0
 gunicorn==21.2.0
-importlib-metadata==3.10.1
+importlib-metadata>=4.8.3,<=4.10.1
 jinja2==2.11.3
 jsonpath-rw==1.4.0
 jsonschema==2.6.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -5,11 +5,11 @@
 # If you want to update depdencies for a single component, modify the
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
-argcomplete==1.12.2
+argcomplete==1.12.3
 cffi<1.15.0
 chardet<3.1.0
 cryptography==39.0.1
-importlib-metadata==3.10.1
+importlib-metadata>=4.8.3,<=4.10.1
 jsonpath-rw==1.4.0
 jsonschema==2.6.0
 orjson==3.5.2


### PR DESCRIPTION
Extract from #6062 by @jk464 changes to update a single `importlib-metadata` dependency in this PR, as the other change related to `requests` in the beforementioned PR fails to build.

This will install importlib-metadata==4.10.1 (security fixed) under py3.8 and importlib-metadata==4.8.3 (latest available, vulnerable) under py3.6.

Address https://github.com/python/importlib_metadata/issues/361 under py3.8.

We should drop py3.6 support ASAP after v3.8.1 patch release.