### PR TITLE
For "local-shell-script" runner, on readonly filesystems, don't attempt to run chmod +x on script_action.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,9 @@ Fixed
 * Update importlib-metadata from 3.10.1 to 4.8.3 for py3.6 and to 4.10.1 for py3.8 (security). #6072
   Contributed by @jk464
 
+* For "local-shell-script" runner, on readonly filesystems, don't attempt to run chmod +x on script_action. Fixes #5591
+  Contributed by @jk464
+
 Added
 ~~~~~
 * Move `git clone` to `user_home/.st2packs` #5845

--- a/contrib/runners/local_runner/local_runner/base.py
+++ b/contrib/runners/local_runner/local_runner/base.py
@@ -116,7 +116,10 @@ class BaseLocalShellRunner(ActionRunner, ShellRunnerMixin):
         sanitized_args = action.get_sanitized_full_command_string()
 
         # For consistency with the old Fabric based runner, make sure the file is executable
-        if script_action:
+        # Also check to ensure not Read-only file system
+        if script_action and not bool(
+            os.statvfs(self.entry_point).f_flag & os.ST_RDONLY
+        ):
             script_local_path_abs = self.entry_point
             args = "chmod +x %s ; %s" % (script_local_path_abs, args)
             sanitized_args = "chmod +x %s ; %s" % (


### PR DESCRIPTION
Fixes #5591.

For `local-shell-script` runners, the runner tries to ensure the `script_action` is executable by running: 

```
        if script_action:
            script_local_path_abs = self.entry_point
            args = "chmod +x %s ; %s" % (script_local_path_abs, args)
            sanitized_args = "chmod +x %s ; %s" % (
                script_local_path_abs,
                sanitized_args,
            )
```

On readonly filesystems, such as when StackStorm is deployed in HA on Kubernetes - this `chmod +x` command fails:

```
stderr: "chmod: changing permissions of '/opt/stackstorm/packs/ansible/actions/ansible.py': Read-only file system
```

(Note since this command isn't `&&` with the actual action, that still runs fine - there's just an error logged in the action output)

This is fixed, by only running this block if the filesystem is read-writeable - by adding the following to the conditional check:

```
bool(os.statvfs(self.entry_point).f_flag & os.ST_RDONLY)
```

Which returns `True` if the filesystem that `self.entry_point` (which is the script that will attemped to be `chmod +x`'ed) is on is readonly, and `False` otherwise.

This fix maintains functionally where there this worked previously (read-writeable fs), while fixing the bug on readonly fs. As per my comment on #5591, I think we should just drop this block all together - but that could be a change in `3.9.0` - for now this fixes the bug without changing anything else. :)