### PR TITLE
Delete python-keyczar==0.716

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -49,7 +49,6 @@ zstandard==0.15.2
 # pyOpenSSL 23.1.0 supports cryptography up to 40.0.x
 pyOpenSSL==23.1.0
 python-editor==1.0.4
-python-keyczar==0.716
 pytz==2021.1
 pywinrm==0.4.1
 pyyaml==5.4.1


### PR DESCRIPTION
Keyczar is deprecated.
See:
https://github.com/google/keyczar

Critical Vunability:
https://www.cve.org/CVERecord?id=CVE-2013-7459

I checkout the codebase and not find this libary is still in use.
In the  requirements-pants.txt i find that information:
# was in fixed-requirements.txt, but not in requirements-pants.txt
# keyczar is used by a python2-only test.
#python-keyczar

So because Python 2 is not in use I think this can be remove. 
Please let me know if I am wrong. I am happy to learn.
