### PR TITLE
Promote Carlos (@nzlosh) to Senior Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -19,6 +19,8 @@ Senior [@StackStorm/maintainers](https://github.com/orgs/StackStorm/teams/mainta
 Have deep platform knowledge & experience and demonstrate technical leadership as well as driving the project forward.
 * Amanda McGuinness ([@amanda11](https://github.com/amanda11)), _intive_ <<amanda.mcguinness@intive.com>>
   - Ansible, Core, deb/rpm packages, CI/CD, Deployments, Release Engineering, Infrastructure, Documentation.
+* Carlos ([@nzlosh](https://github.com/nzlosh)) <<nzlosh@yahoo.com>>
+  - Packaging, Systems, Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Eugen Cusmaunsa ([@armab](https://github.com/armab)) <<armab@stackstorm.com>>
   - Systems, Deployments, Docker, K8s, HA, Ansible, Chef, Vagrant, deb/rpm, CI/CD, Infrastructure, Release Engineering, Community.
 * Jacob Floyd ([@cognifloyd](https://github.com/cognifloyd/)), _Copart_ <<cognifloyd@gmail.com>>
@@ -37,8 +39,6 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - Community, Puppet, Workflows, HA.
 * Bradley Bishop ([@bishopbm1](https://github.com/bishopbm1)), _Encore_ <<bishopbm1@gmail.com>>
   - Puppet, StackStorm Exchange.
-* Carlos ([@nzlosh](https://github.com/nzlosh)) <<nzlosh@yahoo.com>>
-  - Packaging, Systems, Chatops, Errbot, Community, Discussions, StackStorm Exchange.
 * Khushboo Bhatia ([@khushboobhatia01](https://github.com/khushboobhatia01)), _VMware_ <<khushb99@gmail.com>>
   - StackStorm Core, Workflows.
 * Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>


### PR DESCRIPTION
Carlos (@nzlosh) is a StackStorm maintainer for years, was a release assistant for `v3.7.0`, fully led a `v3.8.0` and now helping with the `v3.8.1` patch release. In a meantime, he already participates in coordinating needs for the future `v3.9.0` release like Python deprecation and adding new versions and initiatives to support the different OS flavors.

- https://github.com/StackStorm/community/issues/110
  - https://github.com/StackStorm/community/issues/68
  - https://github.com/StackStorm/st2-packages/pull/700
  - coordinating and implementing complex multi-step/multi-level projects
- https://github.com/StackStorm/community/issues/124
- https://github.com/StackStorm/community/issues/126
- https://github.com/StackStorm/st2/pull/6022
- [**StackStorm v3.9.0 Project Board**](https://github.com/orgs/StackStorm/projects/31)

He's one of the most experienced StackStorm Maintainers and currently the most active TSC member in Slack, Github Issues, reviewing core stackstorm/st2 Pull Requests, helping not only newcomers to get started but also with the hard questions and workflow cases in the [Github Q/A and Discussions](https://github.com/StackStorm/st2/discussions), making the community alive and keeping it afloat when others are away.

He's also an author of https://github.com/nzlosh/err-stackstorm, a st2chatops errbot implementation written in Python.

Being an active member of the TSC meetings, he's asking the right questions and prioritizing what's important for the project and eventually is one of the drivers to implement these initiatives. Today's StackStorm OpenSource operation wouldn't be possible without Carlos involvement.

Thank you for all the hardest maintenance work and StackStorm is lucky to have you @nzlosh onboard!