### PR TITLE
Add Scott Swann (jk464) to Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -57,6 +57,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
 * Mark Mercado ([@mamercad](https://github.com/mamercad)), _DigitalOcean_ - Ansible, Docker, K8s, StackStorm Exchange. [StackStorm Adoption](https://github.com/StackStorm/st2/pull/5836).
 * Rick Kauffman ([@xod442](https://github.com/xod442)), _HPE_ - Community, HOWTOs, Blogs, Publications, Docker.
+* Scott Swann ([@jk464](https://github.com/jk464)) - StackStorm core, Security.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.


### PR DESCRIPTION
I'd like to highlight contributions made by Scott (@jk464). They were especially very helpful in the context of `v3.8.1` patch release and fixed lots of security issues:

- https://github.com/StackStorm/st2/pull/6061
- https://github.com/StackStorm/st2/pull/6062
- https://github.com/StackStorm/st2/pull/5994
- https://github.com/StackStorm/st2/pull/5963
- https://github.com/StackStorm/st2/pull/6073
- https://github.com/StackStorm/st2/pull/6017

He's also part of the community, participating in the TSC meetings, Slack and Github discussions and I'm looking forward to see @jk464 more helping with the [StackStorm core maintenance](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-maintainer), security and become part of the TSC.