### PR TITLE
Add Sravanthi Konduru(sravs-dev) to the Contributors

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -59,6 +59,7 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Rick Kauffman ([@xod442](https://github.com/xod442)), _HPE_ - Community, HOWTOs, Blogs, Publications, Docker.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.
+* Sravanthi Konduru ([@sravs-dev](https://github.com/sravs-dev)), _Salesforce_, - Core, StackStorm Exchange.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 * Yuri Dubler ([@lm-ydubler](https://github.com/lm-ydubler)) - _LogicMonitor_ - StackStorm Exchange, CI.
 


### PR DESCRIPTION
Sravanthi is doing StackStorm automation at @Salesforce and they started helping StackStorm opensource. Just added multiple Python versions support matrix for StackStorm Exchange, removing python3.6 so all the packs are tested under `py3.8` and `py3.9` now which will help with the upcoming `v3.9.0` release:

- https://github.com/StackStorm-Exchange/ci/pull/145
- https://github.com/StackStorm-Exchange/stackstorm-git/pull/15
and other fixes and discussions:
- https://github.com/StackStorm/st2/pull/5536 closing https://github.com/StackStorm/st2/issues/5525


I hope it's just a beginning and looking forward to see more ongoing involvement from @sravs-dev and the group in  [StackStorm development and maintenance](https://github.com/StackStorm/st2/blob/master/GOVERNANCE.md#how-to-become-a-maintainer) to become part of the TSC.