### PR TITLE
Update st2-auth-ldap sha in pants lock to fix CI

### DIFF
--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -4009,7 +4009,7 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c521a3dfc6948a6a57da4dcaa48e0b3390fadcf00d36e3948510cd1c32a10d96",
+              "hash": "29c6ff480b24e4bc316ed69eac5503c71f4700ed17649ae5c5ca8cd745e5852f",
               "url": "git+https://github.com/StackStorm/st2-auth-ldap.git@master"
             }
           ],


### PR DESCRIPTION
Update pants.lock following the StackStorm/st2-auth-ldap#111 update. This should fix CI failing:
https://github.com/StackStorm/st2/actions/runs/7168518561/job/19516889545?pr=6091#step:5:169
