### PR TITLE
TSC: Promote Mark Mercado (@mamercad) from Contributors to Maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -43,6 +43,8 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - StackStorm Core, Workflows.
 * Marcel Weinberg ([@winem](https://github.com/winem)), _CoreMedia_ <<mweinberg-os@email.de>>
   - Systems, Core, CI/CD, Docker, Community.
+* Mark Mercado ([@mamercad](https://github.com/mamercad)), _DigitalOcean_ <<mmercado@digitalocean.com>>
+  - Ansible, Docker, K8s, StackStorm Exchange. [StackStorm Adoption](https://github.com/StackStorm/st2/pull/5836)
 * Mick McGrath ([@mickmcgrath13](https://github.com/mickmcgrath13)), _Bitovi_ <<mick@bitovi.com>>
   - Systems, ST2 Exchange. [Case Study](https://stackstorm.com/case-study-bitovi/).
 
@@ -55,7 +57,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Anand Patel ([@arms11](https://github.com/arms11)), _VMware_ - Docker, Kubernetes.
 * Harsh Nanchahal ([@hnanchahal](https://github.com/hnanchahal)), _Starbucks_ - Core, Docker, Kubernetes.
 * Hiroyasu Ohyama ([@userlocalhost](https://github.com/userlocalhost)) - Orquesta, Workflows, st2 Japan Community. [Case Study](https://stackstorm.com/case-study-dmm/).
-* Mark Mercado ([@mamercad](https://github.com/mamercad)), _DigitalOcean_ - Ansible, Docker, K8s, StackStorm Exchange. [StackStorm Adoption](https://github.com/StackStorm/st2/pull/5836).
 * Rick Kauffman ([@xod442](https://github.com/xod442)), _HPE_ - Community, HOWTOs, Blogs, Publications, Docker.
 * Sheshagiri Rao Mallipedhi ([@sheshagiri](https://github.com/sheshagiri)) - Docker, Core, StackStorm Exchange.
 * Shital Raut ([@shital-orchestral](https://github.com/shital-orchestral)), _Orchestral.ai_ - Web UI.


### PR DESCRIPTION
We were amazed by @mamercad code contributions during the last year when he while leading the StackStorm adoption at @DigitalOcean created ~20 (!) Pull Requests, improving many repositories and CI/CD processes. See 👉 [Add Mark Mercado (@mamercad) to the StackStorm Contributors #5852](https://github.com/StackStorm/st2/pull/5852).

There was more development since that, refactoring, fixing things and working towards the project needs. Some of that work landed in the `v3.8.1` release and will be useful for the `v3.9.0`:

- https://github.com/StackStorm/st2packaging-dockerfiles/pull/111
- https://github.com/StackStorm/st2packaging-dockerfiles/pull/112
- https://github.com/StackStorm/st2/pull/5851
- https://github.com/StackStorm/stackstorm-k8s/pull/358
- https://github.com/StackStorm/st2/pull/6029
- https://github.com/StackStorm/st2-docker/issues/257
- https://github.com/StackStorm/packer-st2/pull/64 - heavy work refactoring Packer build pipeline from paid/broken system to free Github Actions

DigitalOcean is interested and involved in StackStorm success (see [DigitalOcean adoption story #5836](https://github.com/StackStorm/st2/pull/5836)), they're relying on StackStorm heavily, planning to upgrade their st2 infrastructure to Ubuntu22 Jammy next year, so expecting even more development in the upcoming `v3.9.0` release and project life.

Mark is your Ansible, K8s, Docker, CI/CD and Linux guy and StackStorm is lucky to have such community experts!

I invite @StackStorm/tsc to vote and add @mamercad as an official StackStorm Maintainer.