### PR TITLE
Restore Pack integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     # 'machine' executor runs Unit tests ~x1.5 faster, comparing to 'docker' executor
     # but the fastest is still ~x1.5-2 slower, comparing to Travis
     machine: true
-    parallelism: 4
+    parallelism: 2
     working_directory: ~/st2
     steps:
       - checkout
@@ -107,7 +107,7 @@ jobs:
 
   # Build & Test st2 packages
   packages:
-    parallelism: 4
+    parallelism: 2
     # 4CPUs & 8GB RAM CircleCI machine
     # sadly, it doesn't work with 'setup_remote_docker'
     resource_class: large
@@ -116,7 +116,7 @@ jobs:
       - image: circleci/python:3.6
     working_directory: ~/st2
     environment:
-      - DISTROS: "bionic focal el7 el8"
+      - DISTROS: "focal el8"
       - ST2_PACKAGES_REPO: https://github.com/StackStorm/st2-packages
       - ST2_PACKAGES: "st2"
       - ST2_CHECKOUT: 0
@@ -222,7 +222,7 @@ jobs:
       - image: circleci/ruby:2.7
     working_directory: /tmp/deploy
     environment:
-      - DISTROS: "bionic focal el7 el8"
+      - DISTROS: "focal el8"
     steps:
       - attach_workspace:
           at: .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -665,7 +665,6 @@ jobs:
 
           ./scripts/ci/print-versions.sh
       - name: make
-        if: "${{ env.TASK == 'ci-integration' }}"
         #timeout-minutes: 7
         # TODO: Use dynamic timeout value based on the branch - for master we
         # need to use timeout x2 due to coverage overhead

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -189,7 +189,7 @@ jobs:
         run: |
           ./scripts/ci/print-versions.sh
       - name: make
-        timeout-minutes: 31
+        timeout-minutes: 41
         env:
           MAX_ATTEMPTS: 3
           RETRY_DELAY: 5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Python 3.6 is no longer supported; Stackstorm requires at least Python 3.8.
 
 Fixed
 ~~~~~
+* Restore Pack integration testing (it was inadvertently skipped) and stop testing against `bionic` and `el7`. #6135
 
 Changed
 ~~~~~~~

--- a/contrib/linux/tests/test_action_dig.py
+++ b/contrib/linux/tests/test_action_dig.py
@@ -28,7 +28,12 @@ class DigActionTestCase(BaseActionTestCase):
 
         # Use the defaults from dig.yaml
         result = action.run(
-            rand=False, count=0, nameserver=None, hostname="", queryopts="short"
+            rand=False,
+            count=0,
+            nameserver=None,
+            hostname="",
+            queryopts="short",
+            querytype="",
         )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 0)
@@ -37,7 +42,12 @@ class DigActionTestCase(BaseActionTestCase):
         action = self.get_action_instance()
 
         results = action.run(
-            rand=False, count=0, nameserver=None, hostname="google.com", queryopts=""
+            rand=False,
+            count=0,
+            nameserver=None,
+            hostname="google.com",
+            queryopts="",
+            querytype="",
         )
         self.assertIsInstance(results, list)
 

--- a/contrib/packs/tests/test_action_download.py
+++ b/contrib/packs/tests/test_action_download.py
@@ -159,7 +159,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.assertEqual(result, {"test": "Success."})
         self.clone_from.assert_called_once_with(
             PACK_INDEX["test"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dir),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dir),
         )
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, "test/pack.yaml")))
 
@@ -182,11 +182,11 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.assertEqual(result, {"test2": "Success.", "test4": "Success."})
         self.clone_from.assert_any_call(
             PACK_INDEX["test2"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dirs[0]),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dirs[0]),
         )
         self.clone_from.assert_any_call(
             PACK_INDEX["test4"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dirs[1]),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dirs[1]),
         )
         self.assertEqual(self.clone_from.call_count, 2)
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, "test2/pack.yaml")))
@@ -212,11 +212,11 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.assertEqual(result, {"test": "Success.", "test2": "Success."})
         self.clone_from.assert_any_call(
             PACK_INDEX["test"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dirs[0]),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dirs[0]),
         )
         self.clone_from.assert_any_call(
             PACK_INDEX["test2"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dirs[1]),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dirs[1]),
         )
         self.assertEqual(self.clone_from.call_count, 2)
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, "test/pack.yaml")))
@@ -687,7 +687,7 @@ class DownloadGitRepoActionTestCase(BaseActionTestCase):
         self.assertEqual(result, {"test": "Success."})
         self.clone_from.assert_called_once_with(
             PACK_INDEX["test"]["repo_url"],
-            os.path.join(os.path.expanduser("~"), temp_dir),
+            os.path.join(os.path.expanduser("~"), ".st2packs", temp_dir),
         )
         self.assertTrue(os.path.isfile(os.path.join(self.repo_base, "test/pack.yaml")))
 

--- a/contrib/packs/tests/test_action_unload.py
+++ b/contrib/packs/tests/test_action_unload.py
@@ -85,7 +85,7 @@ class UnloadActionTestCase(BaseActionTestCase, CleanDbTestCase):
         config_dbs = Config.query(pack=pack)
 
         self.assertEqual(len(pack_dbs), 1)
-        self.assertEqual(len(action_dbs), 1)
+        self.assertEqual(len(action_dbs), 3)
         self.assertEqual(len(alias_dbs), 3)
         self.assertEqual(len(rule_dbs), 1)
         self.assertEqual(len(sensor_dbs), 3)


### PR DESCRIPTION
Restore Pack integration testing (it was inadvertently skipped) and stop testing against `bionic` and `el7`.

Fixes #6135.