### PR TITLE
add a Executions method to get the api endpoint /result

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Added
   #6118
   Contributed by @cognifloyd
 
+* Added a `get_result` method to the `ExecutionResourceManager` Class for st2client
+  Contributed by @skiedude
+
 3.8.1 - December 13, 2023
 -------------------------
 Fixed

--- a/st2client/st2client/models/core.py
+++ b/st2client/st2client/models/core.py
@@ -548,6 +548,16 @@ class ExecutionResourceManager(ResourceManager):
         return response.text
 
     @add_auth_token_to_kwargs_from_env
+    def get_result(self, execution_id, **kwargs):
+        url = "/%s/%s/result" % (self.resource.get_url_path_name(), execution_id)
+
+        response = self.client.get(url, **kwargs)
+        if response.status_code != http_client.OK:
+            self.handle_error(response)
+
+        return orjson.loads(response.text)
+
+    @add_auth_token_to_kwargs_from_env
     def pause(self, execution_id, **kwargs):
         url = "/%s/%s" % (self.resource.get_url_path_name(), execution_id)
         data = {"status": "pausing"}


### PR DESCRIPTION
In order to check the results of a given execution, this endpoint is invaluable. The `get_output` method can sometimes return the information, but not always. 

This method will be pulling information from the `/api/v1/executions/{id}/result` endpoint and returns a json response