### PR TITLE
Pantsbuild: Make exported venv useful for running nose

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118
+  #6118 #6141
   Contributed by @cognifloyd
 
 3.8.1 - December 13, 2023

--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -34,6 +34,9 @@
 //     "mock",
 //     "mongoengine",
 //     "networkx",
+//     "nose",
+//     "nose-parallel",
+//     "nose-timer",
 //     "orjson",
 //     "orquesta@ git+https://github.com/StackStorm/orquesta.git@v1.6.0",
 //     "oslo.config<1.13,>=1.12.1",
@@ -56,6 +59,7 @@
 //     "pytz",
 //     "pywinrm",
 //     "redis",
+//     "rednose",
 //     "requests[security]",
 //     "retrying",
 //     "routes",
@@ -405,19 +409,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474",
-              "url": "https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl"
+              "hash": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1",
+              "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-              "url": "https://files.pythonhosted.org/packages/d4/91/c89518dd4fe1f3a4e3f6ab7ff23cb00ef2e8c9adf99dacc618ad5e068e28/certifi-2023.11.17.tar.gz"
+              "hash": "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+              "url": "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2023.11.17"
+          "version": "2024.2.2"
         },
         {
           "artifacts": [
@@ -768,118 +772,136 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d3902c779a92151f134f68e555dd0b17c658e13429f270d8a847399b99235a3f",
-              "url": "https://files.pythonhosted.org/packages/aa/de/d0da052ab06312a42391d2d069babbac07d5b9442d939f38732f8fcfab8e/cryptography-42.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4d84673c012aa698555d4710dcfe5f8a0ad76ea9dde8ef803128cc669640a2e0",
-              "url": "https://files.pythonhosted.org/packages/15/41/34c4513070982a6bfa7d33ee7b1c69d3cfcb50817f1d11601497f2f8128b/cryptography-42.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+              "url": "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+            }
+          ],
+          "project_name": "colorama",
+          "requires_dists": [],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7",
+          "version": "0.4.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a",
+              "url": "https://files.pythonhosted.org/packages/e1/2b/73e7a235e5f52cb003ceff06d57d6c70257b9d406fb83b35833537b70eb1/cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ac8924085ed8287545cba89dc472fc224c10cc634cdf2c3e2866fe868108e77",
-              "url": "https://files.pythonhosted.org/packages/27/27/362c4c4b5fcfabe49dc0f4c1569101606ef9cbfc6852600a15369b2c3938/cryptography-42.0.1-cp39-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1",
+              "url": "https://files.pythonhosted.org/packages/02/87/555b8e1b44386da3eacf5cf5a67c75e46224ca4c6213e4af152ac5941963/cryptography-42.0.2-cp37-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "430100abed6d3652208ae1dd410c8396213baee2e01a003a4449357db7dc9e14",
-              "url": "https://files.pythonhosted.org/packages/35/e6/3e5ad3b588c7f454fdb870a6580a921e62bb5ddd318edc26a8e090470c59/cryptography-42.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2",
+              "url": "https://files.pythonhosted.org/packages/0b/9a/4957ac93763929e0b5ea2222114ee86fcfcdacf915447978b3a1e5ac7323/cryptography-42.0.2-cp37-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed1b2130f5456a09a134cc505a17fc2830a1a48ed53efd37dcc904a23d7b82fa",
-              "url": "https://files.pythonhosted.org/packages/36/02/0dd2889e62fbb8a7dcd2effa11e35138863dd309ad9955e12029aab41b0e/cryptography-42.0.1-cp37-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529",
+              "url": "https://files.pythonhosted.org/packages/0c/a8/b89bbf4eba7fedba5ed0963a9ad27c3b106622bb70f7c2bfae921cad6573/cryptography-42.0.2-cp37-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ab6b302d51fbb1dd339abc6f139a480de14d49d50f65fdc7dff782aa8631d035",
-              "url": "https://files.pythonhosted.org/packages/38/74/015cd4fa9c0b4d1cd8398e0331b056b122b7cb0248d46c509a7ad4eaef96/cryptography-42.0.1-cp37-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888",
+              "url": "https://files.pythonhosted.org/packages/0f/6f/40f1b5c6bafc809dd21a9e577458ecc1d8062a7e10148d140f402b535eaa/cryptography-42.0.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "2fe16624637d6e3e765530bc55caa786ff2cbca67371d306e5d0a72e7c3d0407",
-              "url": "https://files.pythonhosted.org/packages/3f/e3/ad97e93e5ad1e88cf4c7b85b736f90700dc9533c07163ca0920f5dc0f23a/cryptography-42.0.1-cp37-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589",
+              "url": "https://files.pythonhosted.org/packages/13/e0/529b44aac99133684311c4807d5eb7706c4acbffabd26ff1fa088ea59dad/cryptography-42.0.2-cp39-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fd33f53809bb363cf126bebe7a99d97735988d9b0131a2be59fbf83e1259a5b7",
-              "url": "https://files.pythonhosted.org/packages/3f/ed/a233522ab5201b988a482cbb19ae3b63bef8ad2ad3e11fc5216b7053b2e4/cryptography-42.0.1.tar.gz"
+              "hash": "28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a",
+              "url": "https://files.pythonhosted.org/packages/1a/36/4f5f60d9a94d1b4be9df2a15dc3394f4435e0119e15af8de6bd7fe4118ed/cryptography-42.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb2861a9364fa27d24832c718150fdbf9ce6781d7dc246a516435f57cfa31fe7",
-              "url": "https://files.pythonhosted.org/packages/45/11/10fc8fb180663e2482d882f3dfdb61f703779857edae46d93c4601f32693/cryptography-42.0.1-cp39-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929",
+              "url": "https://files.pythonhosted.org/packages/2f/dc/74877e59e9d5f7014c833a93d4299925d3f4b0259131c930711061c3d51f/cryptography-42.0.2-cp37-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "727387886c9c8de927c360a396c5edcb9340d9e960cda145fca75bdafdabd24c",
-              "url": "https://files.pythonhosted.org/packages/65/f7/23adf59c99635fd562cc0fec0dcf192ee5094555f599fe9e804f7688d06a/cryptography-42.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3",
+              "url": "https://files.pythonhosted.org/packages/3c/72/fb557573cebcae88c6efe3a73981181384e08408c1125a8e97a7fb3edde4/cryptography-42.0.2-cp39-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "160fa08dfa6dca9cb8ad9bd84e080c0db6414ba5ad9a7470bc60fb154f60111e",
-              "url": "https://files.pythonhosted.org/packages/69/26/c8e12473cb0915c26f6c8e7ef08084227a5d7bedba005458aa40c457e542/cryptography-42.0.1-cp37-abi3-macosx_10_12_x86_64.whl"
+              "hash": "130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea",
+              "url": "https://files.pythonhosted.org/packages/45/82/3da127b1b75ea24f09ad85bcef5a6a7526be795eec4077663cd3ff52d19d/cryptography-42.0.2-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6edc3a568667daf7d349d7e820783426ee4f1c0feab86c29bd1d6fe2755e009",
-              "url": "https://files.pythonhosted.org/packages/7c/e5/26a7bb4b3c599c3803cadb871e420d0bd013dd7c0c66fae02fd4441bdced/cryptography-42.0.1-cp37-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446",
+              "url": "https://files.pythonhosted.org/packages/5b/44/4c984f47a302236e1c76b721bfc8d407de9ab6620a9037c2de026d30c38f/cryptography-42.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2dff7a32880a51321f5de7869ac9dde6b1fca00fc1fef89d60e93f215468e824",
-              "url": "https://files.pythonhosted.org/packages/81/e6/c1fccf36cb1067c8805cf73ad071ef0e605ff9ee988e959d4c5d6a0f22e9/cryptography-42.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90",
+              "url": "https://files.pythonhosted.org/packages/61/dd/aecb8fe565b5c90a04bd5e564d0a42eadf33596b87ab87f75d986f06480f/cryptography-42.0.2-cp39-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b7cacc142260ada944de070ce810c3e2a438963ee3deb45aa26fd2cee94c9a4",
-              "url": "https://files.pythonhosted.org/packages/82/65/8fd4f70ec781f59eba46172daa6454cfe69bdbb3ce45c611b61fba147489/cryptography-42.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+              "hash": "fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33",
+              "url": "https://files.pythonhosted.org/packages/74/bb/f5e04bb44e7bfb88bb71ecb4d60a8dffaa19262c1ebe832250ee82e06de8/cryptography-42.0.2-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "32ea63ceeae870f1a62e87f9727359174089f7b4b01e4999750827bf10e15d60",
-              "url": "https://files.pythonhosted.org/packages/83/86/7a2e09cbc9c2325264eab15cd8da2ccd3905d85e17b89c054768c9b986af/cryptography-42.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
+              "hash": "320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008",
+              "url": "https://files.pythonhosted.org/packages/7a/19/4ff78f1bd152ee90c7e7dd174dedc8516ab9f872029a7bf58bd0eaaa199e/cryptography-42.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9544492e8024f29919eac2117edd8c950165e74eb551a22c53f6fdf6ba5f4cb8",
-              "url": "https://files.pythonhosted.org/packages/94/42/b47fbecc8dfb843b8d84410e71ae19923689034af7b3b5f654b83fbb50be/cryptography-42.0.1-cp37-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d",
+              "url": "https://files.pythonhosted.org/packages/9a/d8/cb66df54747a05218b9e0cfa1e7606d96b892750a173196139ac29fe3f2e/cryptography-42.0.2-cp37-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b512f33c6ab195852595187af5440d01bb5f8dd57cb7a91e1e009a17f1b7ebca",
-              "url": "https://files.pythonhosted.org/packages/be/51/9ed445aead4562a56278bdcb20069d50252c0de4ce07d7aa0d06cc38c7e4/cryptography-42.0.1-cp39-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12",
+              "url": "https://files.pythonhosted.org/packages/a6/0a/7e8a98209a8f3c7f8200207ad7a32d123cd6d520a9bd6edc5c957f56b335/cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "265bdc693570b895eb641410b8fc9e8ddbce723a669236162b9d9cfb70bd8d77",
-              "url": "https://files.pythonhosted.org/packages/be/73/57323763ddf5b6a153366ac57b342c58c30f99bd1148101eda87f8f083ee/cryptography-42.0.1-cp37-abi3-macosx_10_12_universal2.whl"
+              "hash": "b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9",
+              "url": "https://files.pythonhosted.org/packages/af/4e/178466a513ff8c1aba7f56fafb169fe27af4c28df4b770cd2c30fa6fde5e/cryptography-42.0.2-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "351db02c1938c8e6b1fee8a78d6b15c5ccceca7a36b5ce48390479143da3b411",
-              "url": "https://files.pythonhosted.org/packages/bf/db/7040a3224e8d506b3e341429d1e0bae2d9db02f6cffea7786e9427f92289/cryptography-42.0.1-cp39-abi3-macosx_10_12_universal2.whl"
+              "hash": "ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4",
+              "url": "https://files.pythonhosted.org/packages/b1/85/11c92b74d7560cb2725653b49f54129c7284748bc56119a6dbabcaf51d05/cryptography-42.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "25ec6e9e81de5d39f111a4114193dbd39167cc4bbd31c30471cebedc2a92c323",
-              "url": "https://files.pythonhosted.org/packages/d8/41/1e2cfc14cdae6ad0b5c6677e2cb03af2a6e01c05a72d5b3fddf693b26f3d/cryptography-42.0.1-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1",
+              "url": "https://files.pythonhosted.org/packages/b8/ca/acd576a5e2cf16448c9c31ae72c0d389a12acd58bd190bf91bb6082ffc91/cryptography-42.0.2-cp37-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9d61fcdf37647765086030d81872488e4cb3fafe1d2dda1d487875c3709c0a49",
-              "url": "https://files.pythonhosted.org/packages/da/2b/89d2b301e3f38324d9569be98962fc1bcb1fa2c7dd8874cdeba294ab5cc7/cryptography-42.0.1-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2",
+              "url": "https://files.pythonhosted.org/packages/d2/f6/a506b5a7b73253c450fab89c882b635cd0038adcc8e83e9729219d68f597/cryptography-42.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d50718dd574a49d3ef3f7ef7ece66ef281b527951eb2267ce570425459f6a404",
-              "url": "https://files.pythonhosted.org/packages/f6/79/227c6f7e98657cf9387d5797d56e983165f294ed838679b2b8ca12118e18/cryptography-42.0.1-cp37-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a",
+              "url": "https://files.pythonhosted.org/packages/ef/9f/49de69b6b55b812b492824bb1e5f4e37bb6953886c4c3fe0062be240f7e7/cryptography-42.0.2-cp39-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "95d900d19a370ae36087cc728e6e7be9c964ffd8cbcb517fd1efb9c9284a6abc",
-              "url": "https://files.pythonhosted.org/packages/f8/46/2776ca9b602f79633fdf69824b5e18c94f2e0c5f09a94fc69e5b0887c14d/cryptography-42.0.1-cp39-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be",
+              "url": "https://files.pythonhosted.org/packages/f3/cd/e76223293a9c1c668e6de1c5400276a710f8fb5c69da1b07a6e66bbb45ae/cryptography-42.0.2-cp37-abi3-macosx_10_12_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242",
+              "url": "https://files.pythonhosted.org/packages/f4/06/4229967761a1daf385bdb09bcb11d3d40970a54b52e896b41f43065eecf6/cryptography-42.0.2-cp39-abi3-macosx_10_12_universal2.whl"
             }
           ],
           "project_name": "cryptography",
@@ -906,7 +928,7 @@
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\""
           ],
           "requires_python": ">=3.7",
-          "version": "42.0.1"
+          "version": "42.0.2"
         },
         {
           "artifacts": [
@@ -2140,94 +2162,145 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "96e44b21fe407b8ed48afbb3721f3c8c8ce17e345fbe232bd4651ace7317782d",
-              "url": "https://files.pythonhosted.org/packages/83/74/6ebad2afc1470d6ce4362f93562cd8d2e3f05ac75d77553ae35b6ff4f8f4/orjson-3.9.12-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac",
+              "url": "https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a0cd56e8ee56b203abae7d482ac0d233dbfb436bb2e2d5cbcb539fe1200a312",
-              "url": "https://files.pythonhosted.org/packages/04/0e/7651f51438ea74c4f86b97289be0b4ee7415002a1a1ebd88a1b49e1ef1c3/orjson-3.9.12-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98",
+              "url": "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz"
+            }
+          ],
+          "project_name": "nose",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "1.3.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3f7c48d7aa5030fe872211cbffc6852e64e4e356ddbac5958a35796bf15dc225",
+              "url": "https://files.pythonhosted.org/packages/64/08/9968ef72b3ee8f3243e1f300219afdfb753a3432b203afe9bef56e34ce95/nose_parallel-0.4.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "975e72e81a249174840d5a8df977d067b0183ef1560a32998be340f7e195c730",
-              "url": "https://files.pythonhosted.org/packages/35/77/3586efb29ee6b336583f56c3f39f7e1be7d8afe9a8085fb8f43334d1dd51/orjson-3.9.12-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "e4e6d6891a4bb417f09abf1f400554f557f0a9df3fdaed6517d4236e87ed0f51",
+              "url": "https://files.pythonhosted.org/packages/70/60/039898d68516d2086db9b8ec8e318f84f44a15a8584b2abdfc2d97980a68/nose-parallel-0.4.0.tar.gz"
+            }
+          ],
+          "project_name": "nose-parallel",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "0.4.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8f70d103b7ffd9122a589de0df9d037a7d967519bf6de122621d2186609b9e3a",
+              "url": "https://files.pythonhosted.org/packages/ee/fc/ad961aa29606e20b3c85f739ab7d2e5abe0c285310c468a5850dcaf9c720/nose-timer-1.0.1.tar.gz"
+            }
+          ],
+          "project_name": "nose-timer",
+          "requires_dists": [
+            "nose"
+          ],
+          "requires_python": null,
+          "version": "1.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8a730bf07feacb0863974e67b206b7c503a62199de1cece2eb0d4c233ec29c11",
+              "url": "https://files.pythonhosted.org/packages/2d/ae/ea699c694fec052dbd4e780f455929c76a4ebc95d1e78e8721738494ce93/orjson-3.9.13-cp39-cp39-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "da908d23a3b3243632b523344403b128722a5f45e278a8343c2bb67538dff0e4",
-              "url": "https://files.pythonhosted.org/packages/3d/27/6a821fc97a2b68705cba3158e5ddb300938500a8c2b19dc084f6d43587d4/orjson-3.9.12.tar.gz"
+              "hash": "62e9a99879c4d5a04926ac2518a992134bfa00d546ea5a4cae4b9be454d35a22",
+              "url": "https://files.pythonhosted.org/packages/01/3f/d2f6eafe2c433a71d6f5ae4898e5e7331011ecf937d3ff9e794850509211/orjson-3.9.13-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dde1bc7c035f2d03aa49dc8642d9c6c9b1a81f2470e02055e76ed8853cfae0c3",
-              "url": "https://files.pythonhosted.org/packages/4a/6c/960d5c647cd4638a454c676a9a23b5d7418954d4e9d8e6cdac3d9d7c80cb/orjson-3.9.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0d691c44604941945b00e0a13b19a7d9c1a19511abadf0080f373e98fdeb6b31",
+              "url": "https://files.pythonhosted.org/packages/11/99/633ecbdbf143d973ec8d11bc08fbf6f1eb8d86fcbd76a472de3eb99fbb24/orjson-3.9.13-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b159baecfda51c840a619948c25817d37733a4d9877fea96590ef8606468b362",
-              "url": "https://files.pythonhosted.org/packages/7a/d9/c394afab3f54665d3427cbe55142ce6356f41d30f5fc7ec97f4f295802b3/orjson-3.9.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "ddc089315d030c54f0f03fb38286e2667c05009a78d659f108a8efcfbdf2e585",
+              "url": "https://files.pythonhosted.org/packages/20/a8/430898dac6968adff44b1d1e3b3f53601d98776ef9e308dd2dc11ea15d6f/orjson-3.9.13-cp38-cp38-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09d60450cda3fa6c8ed17770c3a88473a16460cd0ff2ba74ef0df663b6fd3bb8",
-              "url": "https://files.pythonhosted.org/packages/87/eb/b6d578fcccee7b8113638ed9d8c2e1c94569d6d119bf0f4ecff4a3420b2c/orjson-3.9.12-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "7e8e4a571d958910272af8d53a9cbe6599f9f5fd496a1bc51211183bb2072cbd",
+              "url": "https://files.pythonhosted.org/packages/30/0b/b0749bec64217385c3d4a0fe72924ed7ca935d469d5d9892902a8c859bad/orjson-3.9.13-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "54071b7398cd3f90e4bb61df46705ee96cb5e33e53fc0b2f47dbd9b000e238e1",
-              "url": "https://files.pythonhosted.org/packages/93/5f/c3f8e8f22f7e724d44d7c1be9eafffb7d559a596b815d9605a1e7b88a54f/orjson-3.9.12-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "16946d095212a3dec552572c5d9bca7afa40f3116ad49695a397be07d529f1fa",
+              "url": "https://files.pythonhosted.org/packages/37/68/31db892410b0f4d5ad8dd988679a96ab375a5f9bd10ea54ffd1a23914289/orjson-3.9.13-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a84a0c3d4841a42e2571b1c1ead20a83e2792644c5827a606c50fc8af7ca4bee",
-              "url": "https://files.pythonhosted.org/packages/b2/fa/bbed27b635949be48e60e08e88a53090edcefb0ab45b9d379ef05f8e3628/orjson-3.9.12-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "828c502bb261588f7de897e06cb23c4b122997cb039d2014cb78e7dabe92ef0c",
+              "url": "https://files.pythonhosted.org/packages/39/ff/6333bb87edc16eb02a00481689148a88a207c2aa8217a3bba3ae72201c50/orjson-3.9.13-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "06e42e899dde61eb1851a9fad7f1a21b8e4be063438399b63c07839b57668f6c",
-              "url": "https://files.pythonhosted.org/packages/c4/40/8840e2a23cd816e5404a62e3f0e87ed7efb8fc4ca18e92bf6767c62776f6/orjson-3.9.12-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "31fb66b41fb2c4c817d9610f0bc7d31345728d7b5295ac78b63603407432a2b2",
+              "url": "https://files.pythonhosted.org/packages/3d/88/8824659c2044a3f18646aacd5937bd46cdd23a80ef7b2b41a406d759b6b2/orjson-3.9.13-cp39-cp39-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4098c7674901402c86ba6045a551a2ee345f9f7ed54eeffc7d86d155c8427e5",
-              "url": "https://files.pythonhosted.org/packages/e1/0e/9836c08824c082107b6e3aaeaeba8dff09cfac8b58d7d0a4c6dc77baaf7c/orjson-3.9.12-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
+              "hash": "d92a3e835a5100f1d5b566fff79217eab92223ca31900dba733902a182a35ab0",
+              "url": "https://files.pythonhosted.org/packages/44/e3/bc2dc2a9c81b7a2817fedfc3e0cf3e97df657958e6bba5eb704919ef801a/orjson-3.9.13-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc82a4db9934a78ade211cf2e07161e4f068a461c1796465d10069cb50b32a80",
-              "url": "https://files.pythonhosted.org/packages/e7/a9/915fe5556840e31cf42a67983543454c712d074b6f5e6b25ff921cd7d191/orjson-3.9.12-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "9b1b5adc5adf596c59dca57156b71ad301d73956f5bab4039b0e34dbf50b9fa0",
+              "url": "https://files.pythonhosted.org/packages/5a/2c/fe832ead2a8c8a223da5d5005ef7de0276380e1087a4c10fd10c36a4f07d/orjson-3.9.13-cp38-cp38-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67426651faa671b40443ea6f03065f9c8e22272b62fa23238b3efdacd301df31",
-              "url": "https://files.pythonhosted.org/packages/e9/26/07556d074673915e57236893f3f36a5d0a0dbf5b3caf999d081cbf76f949/orjson-3.9.12-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "fc6bc65b0cf524ee042e0bc2912b9206ef242edfba7426cf95763e4af01f527a",
+              "url": "https://files.pythonhosted.org/packages/67/1a/2d21f7ab742d49e4a5417481b9dd357550699c24f44a030ca8cc0954e74e/orjson-3.9.13.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "5586a533998267458fad3a457d6f3cdbddbcce696c916599fa8e2a10a89b24d3",
-              "url": "https://files.pythonhosted.org/packages/ee/67/d1821e9c28877546504fcc3b6a073b1cef1a36cf9532f9af585c9c8c0884/orjson-3.9.12-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "9156b96afa38db71344522f5517077eaedf62fcd2c9148392ff93d801128809c",
+              "url": "https://files.pythonhosted.org/packages/71/51/69aa8bc35357640ff7ad8fe998df9cbfecb2ce54997f246eb7b55d719009/orjson-3.9.13-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5c157e999e5694475a5515942aebeed6e43f7a1ed52267c1c93dcfde7d78d421",
-              "url": "https://files.pythonhosted.org/packages/f2/6e/b3e40721f54f112fa294aa7bb79b81f34fb46eef0f6c4f712a4a12d0c505/orjson-3.9.12-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "a8c83718346de08d68b3cb1105c5d91e5fc39885d8610fdda16613d4e3941459",
+              "url": "https://files.pythonhosted.org/packages/84/80/952ad6648bab7c96c22fd68c71e0c11dbcfe78cd7783455f7000a6b532b2/orjson-3.9.13-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e773f251258dd82795fd5daeac081d00b97bacf1548e44e71245543374874bcf",
-              "url": "https://files.pythonhosted.org/packages/f6/d1/f61a7573ace3cf48a1fbb2fbe8ea5f1eb67b37f28f70b2d80d79a0330e06/orjson-3.9.12-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
+              "hash": "23f21faf072ed3b60b5954686f98157e073f6a8068eaa58dbde83e87212eda84",
+              "url": "https://files.pythonhosted.org/packages/a7/c1/32c5bd7f9f77fa89c81522b73742f502d70d53214164a31512bff73b6372/orjson-3.9.13-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b0e9d73cdbdad76a53a48f563447e0e1ce34bcecef4614eb4b146383e6e7d8c9",
-              "url": "https://files.pythonhosted.org/packages/fd/75/20d7a7af259edcabba6659241e1761948ec6de7c06a7c48e564995bed31a/orjson-3.9.12-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "3deadd8dc0e9ff844b5b656fa30a48dbee1c3b332d8278302dd9637f6b09f627",
+              "url": "https://files.pythonhosted.org/packages/ba/9a/c4a4105698fc8428831b64af7c06ebd3e9da41d6966a334fba9d1a73dd20/orjson-3.9.13-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "63ef57a53bfc2091a7cd50a640d9ae866bd7d92a5225a1bab6baa60ef62583f2",
+              "url": "https://files.pythonhosted.org/packages/ba/be/bfd996ce3cc35e0deb731bcde0e5ea0cf6b4afeec8293b07fc2594fb913b/orjson-3.9.13-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cfad553a36548262e7da0f3a7464270e13900b898800fb571a5d4b298c3f8356",
+              "url": "https://files.pythonhosted.org/packages/d1/c6/c4b711c63685e858612ef6dea37fe7c423a9e384ae79d273d28a6e856f0a/orjson-3.9.13-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "orjson",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "3.9.12"
+          "version": "3.9.13"
         },
         {
           "artifacts": [
@@ -2467,47 +2540,47 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76",
-              "url": "https://files.pythonhosted.org/packages/15/aa/3f4c7bcee2057a76562a5b33ecbd199be08cdb4443a02e26bd2c3cf6fc39/pip-23.3.2-py3-none-any.whl"
+              "hash": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7fd9972f96db22c8077a1ee2691b172c8089b17a5652a44494a9ecb0d78f9149",
-              "url": "https://files.pythonhosted.org/packages/b7/06/6b1ad0ae8f97d7a0d6f6ad640db10780578999e647a9593512ceb6f06469/pip-23.3.2.tar.gz"
+              "hash": "ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2",
+              "url": "https://files.pythonhosted.org/packages/94/59/6638090c25e9bc4ce0c42817b5a234e183872a1129735a9330c472cc2056/pip-24.0.tar.gz"
             }
           ],
           "project_name": "pip",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "23.3.2"
+          "version": "24.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380",
-              "url": "https://files.pythonhosted.org/packages/be/53/42fe5eab4a09d251a76d0043e018172db324a23fcdac70f77a551c11f618/platformdirs-4.1.0-py3-none-any.whl"
+              "hash": "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
+              "url": "https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420",
-              "url": "https://files.pythonhosted.org/packages/62/d1/7feaaacb1a3faeba96c06e6c5091f90695cc0f94b7e8e1a3a3fe2b33ff9a/platformdirs-4.1.0.tar.gz"
+              "hash": "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768",
+              "url": "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
             "covdefaults>=2.3; extra == \"test\"",
-            "furo>=2023.7.26; extra == \"docs\"",
+            "furo>=2023.9.10; extra == \"docs\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4.1; extra == \"test\"",
-            "pytest-mock>=3.11.1; extra == \"test\"",
-            "pytest>=7.4; extra == \"test\"",
-            "sphinx-autodoc-typehints>=1.24; extra == \"docs\"",
-            "sphinx>=7.1.1; extra == \"docs\""
+            "pytest-mock>=3.12; extra == \"test\"",
+            "pytest>=7.4.3; extra == \"test\"",
+            "sphinx-autodoc-typehints>=1.25.2; extra == \"docs\"",
+            "sphinx>=7.2.6; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "4.1.0"
+          "version": "4.2.0"
         },
         {
           "artifacts": [
@@ -3240,19 +3313,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f90ef520d95e7c46951105338d918664ebfd6f1d995bd7d153127ce90efafa6a",
-              "url": "https://files.pythonhosted.org/packages/3b/dd/9b84302ba85ac6d3d3042d3e8698374838bde1c386b4adb1223d7a0efd4e/pytz-2023.4-py2.py3-none-any.whl"
+              "hash": "328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319",
+              "url": "https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31d4583c4ed539cd037956140d695e42c033a19e984bfce9964a3f7d59bc2b40",
-              "url": "https://files.pythonhosted.org/packages/ae/fd/c5bafe60236bc2a464452f916b6a1806257109c8954d6a7d19e5d4fb012f/pytz-2023.4.tar.gz"
+              "hash": "2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812",
+              "url": "https://files.pythonhosted.org/packages/90/26/9f1f00a5d021fff16dee3de13d43e5e978f3d58928e129c3a62cf7eb9738/pytz-2024.1.tar.gz"
             }
           ],
           "project_name": "pytz",
           "requires_dists": [],
           "requires_python": null,
-          "version": "2023.4"
+          "version": "2024.1"
         },
         {
           "artifacts": [
@@ -3393,6 +3466,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "6da77917788be277b70259edc0bb92fc6f28fe268b765b4ea88206cc3543a3e1",
+              "url": "https://files.pythonhosted.org/packages/3a/a8/4b73ae7466c2e9b63b3c4d66040d1c0eda1f764812353753702546d8c87f/rednose-1.3.0.tar.gz"
+            }
+          ],
+          "project_name": "rednose",
+          "requires_dists": [
+            "colorama",
+            "setuptools",
+            "termstyle>=0.1.7"
+          ],
+          "requires_python": null,
+          "version": "1.3.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea",
               "url": "https://files.pythonhosted.org/packages/b0/30/6cc0c95f0b59ad4b3b9163bff7cdcf793cc96fac64cf398ff26271f5cf5e/repoze.lru-0.7-py3-none-any.whl"
             },
@@ -3524,13 +3614,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada",
-              "url": "https://files.pythonhosted.org/packages/57/db/4b74a29f5fd175aea3ff0d95f8230d9bb8a54e38d963c6f96065b9e2eef3/ruamel.yaml-0.18.5-py3-none-any.whl"
+              "hash": "57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636",
+              "url": "https://files.pythonhosted.org/packages/73/67/8ece580cc363331d9a53055130f86b096bf16e38156e33b1d3014fffda6b/ruamel.yaml-0.18.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e",
-              "url": "https://files.pythonhosted.org/packages/82/43/fa976e03a4a9ae406904489119cd7dd4509752ca692b2e0a19491ca1782c/ruamel.yaml-0.18.5.tar.gz"
+              "hash": "8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b",
+              "url": "https://files.pythonhosted.org/packages/29/81/4dfc17eb6ebb1aac314a3eb863c1325b907863a1b8b1382cdffcb6ac0ed9/ruamel.yaml-0.18.6.tar.gz"
             }
           ],
           "project_name": "ruamel-yaml",
@@ -3541,7 +3631,7 @@
             "ryd; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.18.5"
+          "version": "0.18.6"
         },
         {
           "artifacts": [
@@ -3933,7 +4023,7 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "71d3c18ea65c7fb0891a860b9e1fed0f65c255013b7555444d4e44c5c3312fde",
+              "hash": "e49a85b9d1ad7cd9e75d53810ddf1e3ec50c83b1e4d8629d80f0566a233e5637",
               "url": "git+https://github.com/StackStorm/st2-rbac-backend.git@master"
             }
           ],
@@ -4020,6 +4110,21 @@
           ],
           "requires_python": null,
           "version": "6.3.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ef74b83698ea014112040cf32b1a093c1ab3d91c4dd18ecc03ec178fd99c9f9f",
+              "url": "https://files.pythonhosted.org/packages/65/53/4dfdfe12b499f375cc78caca9cf146c01e752bab7713de4510d35e3da306/termstyle-0.1.11.tar.gz"
+            }
+          ],
+          "project_name": "termstyle",
+          "requires_dists": [
+            "setuptools"
+          ],
+          "requires_python": null,
+          "version": "0.1.11"
         },
         {
           "artifacts": [
@@ -4317,24 +4422,25 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
-              "url": "https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl"
+              "hash": "ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224",
+              "url": "https://files.pythonhosted.org/packages/88/75/311454fd3317aefe18415f04568edc20218453b709c63c58b9292c71be17/urllib3-2.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54",
-              "url": "https://files.pythonhosted.org/packages/36/dd/a6b232f449e1bc71802a5b7950dc3675d32c6dbc2a1bd6d71f065551adb6/urllib3-2.1.0.tar.gz"
+              "hash": "051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
+              "url": "https://files.pythonhosted.org/packages/e2/cc/abf6746cc90bc52df4ba730f301b89b3b844d6dc133cb89a01cfe2511eb9/urllib3-2.2.0.tar.gz"
             }
           ],
           "project_name": "urllib3",
           "requires_dists": [
             "brotli>=1.0.9; platform_python_implementation == \"CPython\" and extra == \"brotli\"",
             "brotlicffi>=0.8.0; platform_python_implementation != \"CPython\" and extra == \"brotli\"",
+            "h2<5,>=4; extra == \"h2\"",
             "pysocks!=1.5.7,<2.0,>=1.5.6; extra == \"socks\"",
             "zstandard>=0.18.0; extra == \"zstd\""
           ],
           "requires_python": ">=3.8",
-          "version": "2.1.0"
+          "version": "2.2.0"
         },
         {
           "artifacts": [
@@ -4413,31 +4519,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ab202b5164b4bbd2c9bf2d4f264efef6f0f30fc0f570be27f1332be4514eefe0",
-              "url": "https://files.pythonhosted.org/packages/12/44/2d0c03d9cc9edaed681842a441a9ab3e960b62adb172865692745fc9eff1/voluptuous-0.14.1-py3-none-any.whl"
+              "hash": "efc1dadc9ae32a30cc622602c1400a17b7bf8ee2770d64f70418144860739c3b",
+              "url": "https://files.pythonhosted.org/packages/3e/21/0424844b889dccd8f1899f92f239d6eca5f4995f5c86baff094694140828/voluptuous-0.14.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b6e5f7553ce02461cce17fedb0e3603195496eb260ece9aca86cc4cc6625218",
-              "url": "https://files.pythonhosted.org/packages/d8/33/98b8032d580525c04e0691f4df9a74b0cfb327661823e32fe6d00bed55a4/voluptuous-0.14.1.tar.gz"
+              "hash": "533e36175967a310f1b73170d091232bf881403e4ebe52a9b4ade8404d151f5d",
+              "url": "https://files.pythonhosted.org/packages/a1/ce/0733e4d6f870a0e5f4dbb00766b36b71ee0d25f8de33d27fb662f29154b1/voluptuous-0.14.2.tar.gz"
             }
           ],
           "project_name": "voluptuous",
           "requires_dists": [],
-          "requires_python": ">=3.7",
-          "version": "0.14.1"
+          "requires_python": ">=3.8",
+          "version": "0.14.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a",
-              "url": "https://files.pythonhosted.org/packages/58/6a/b4b5c582e04e837e4422cab6ec9de7fc10ca7ad7f4e370bb89d280d39552/waitress-2.1.2-py3-none-any.whl"
+              "hash": "2a06f242f4ba0cc563444ca3d1998959447477363a2d7e9b8b4d75d35cfd1669",
+              "url": "https://files.pythonhosted.org/packages/5b/a9/485c953a1ac4cb98c28e41fd2c7184072df36bbf99734a51d44d04176878/waitress-3.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba",
-              "url": "https://files.pythonhosted.org/packages/72/83/c3de9799e2305898b02ea67bcd125ad06f271e2a82cc86fe66b7bf4e6f63/waitress-2.1.2.tar.gz"
+              "hash": "005da479b04134cdd9dd602d1ee7c49d79de0537610d653674cc6cbde222b8a1",
+              "url": "https://files.pythonhosted.org/packages/70/34/cb77e5249c433eb177a11ab7425056b32d3b57855377fa1e38b397412859/waitress-3.0.0.tar.gz"
             }
           ],
           "project_name": "waitress",
@@ -4446,11 +4552,11 @@
             "coverage>=5.0; extra == \"testing\"",
             "docutils; extra == \"docs\"",
             "pylons-sphinx-themes>=1.0.9; extra == \"docs\"",
-            "pytest-cover; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
             "pytest; extra == \"testing\""
           ],
-          "requires_python": ">=3.7.0",
-          "version": "2.1.2"
+          "requires_python": ">=3.8.0",
+          "version": "3.0.0"
         },
         {
           "artifacts": [
@@ -4886,6 +4992,9 @@
     "mock",
     "mongoengine",
     "networkx",
+    "nose",
+    "nose-parallel",
+    "nose-timer",
     "orjson",
     "orquesta",
     "oslo.config<1.13,>=1.12.1",
@@ -4908,6 +5017,7 @@
     "pytz",
     "pywinrm",
     "redis",
+    "rednose",
     "requests[security]",
     "retrying",
     "routes",

--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -32,7 +32,7 @@
 //     "logshipper@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched ; platform_system == \"Linux\"",
 //     "mail-parser==3.15.0",
 //     "mock",
-//     "mongoengine",
+//     "mongoengine<0.24.0,>=0.21.0",
 //     "networkx",
 //     "nose",
 //     "nose-parallel",
@@ -48,7 +48,7 @@
 //     "prompt-toolkit<2",
 //     "psutil",
 //     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
-//     "pymongo",
+//     "pymongo<3.13.0,>=3.11.0",
 //     "pyrabbit",
 //     "pysocks",
 //     "pytest",
@@ -790,118 +790,118 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a",
-              "url": "https://files.pythonhosted.org/packages/e1/2b/73e7a235e5f52cb003ceff06d57d6c70257b9d406fb83b35833537b70eb1/cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "9541c69c62d7446539f2c1c06d7046aef822940d248fa4b8962ff0302862cc1f",
+              "url": "https://files.pythonhosted.org/packages/8e/47/315b3969afbbec7aa3ab0027aa0e6d771a3d4790f6c35430eae42c968da9/cryptography-42.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1",
-              "url": "https://files.pythonhosted.org/packages/02/87/555b8e1b44386da3eacf5cf5a67c75e46224ca4c6213e4af152ac5941963/cryptography-42.0.2-cp37-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "0d3ec384058b642f7fb7e7bff9664030011ed1af8f852540c76a1317a9dd0d20",
+              "url": "https://files.pythonhosted.org/packages/04/6c/9534de577ef1ef442942a98d42c4778dfdb57c18ebbc2fc6c7e33c51aa78/cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2",
-              "url": "https://files.pythonhosted.org/packages/0b/9a/4957ac93763929e0b5ea2222114ee86fcfcdacf915447978b3a1e5ac7323/cryptography-42.0.2-cp37-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "04859aa7f12c2b5f7e22d25198ddd537391f1695df7057c8700f71f26f47a129",
+              "url": "https://files.pythonhosted.org/packages/1c/a2/4d7a1bf10039e4b21c856c070b34372fd68ba4d1f983dd1780d4e5e09f68/cryptography-42.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529",
-              "url": "https://files.pythonhosted.org/packages/0c/a8/b89bbf4eba7fedba5ed0963a9ad27c3b106622bb70f7c2bfae921cad6573/cryptography-42.0.2-cp37-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "20100c22b298c9eaebe4f0b9032ea97186ac2555f426c3e70670f2517989543b",
+              "url": "https://files.pythonhosted.org/packages/24/a4/12a424d5009590891ddfbeb89edea0615ce711f37ca9713a96239b74fc37/cryptography-42.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888",
-              "url": "https://files.pythonhosted.org/packages/0f/6f/40f1b5c6bafc809dd21a9e577458ecc1d8062a7e10148d140f402b535eaa/cryptography-42.0.2.tar.gz"
+              "hash": "6c25e1e9c2ce682d01fc5e2dde6598f7313027343bd14f4049b82ad0402e52cd",
+              "url": "https://files.pythonhosted.org/packages/43/be/dcac16b787b898c0ab403bbfd1691a4724ec52de614c2420a42df1e1d531/cryptography-42.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589",
-              "url": "https://files.pythonhosted.org/packages/13/e0/529b44aac99133684311c4807d5eb7706c4acbffabd26ff1fa088ea59dad/cryptography-42.0.2-cp39-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "90147dad8c22d64b2ff7331f8d4cddfdc3ee93e4879796f837bdbb2a0b141e0c",
+              "url": "https://files.pythonhosted.org/packages/47/98/3453216d25df6a8063990e1df06327c9fc0353abd9a3f0c316da236b19c3/cryptography-42.0.3-cp37-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a",
-              "url": "https://files.pythonhosted.org/packages/1a/36/4f5f60d9a94d1b4be9df2a15dc3394f4435e0119e15af8de6bd7fe4118ed/cryptography-42.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "93fbee08c48e63d5d1b39ab56fd3fdd02e6c2431c3da0f4edaf54954744c718f",
+              "url": "https://files.pythonhosted.org/packages/4c/aa/fd1379655a9798d6c94bfee579dc0da52f374ae2474576ddc387bed3e4f2/cryptography-42.0.3-cp37-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929",
-              "url": "https://files.pythonhosted.org/packages/2f/dc/74877e59e9d5f7014c833a93d4299925d3f4b0259131c930711061c3d51f/cryptography-42.0.2-cp37-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "df34312149b495d9d03492ce97471234fd9037aa5ba217c2a6ea890e9166f151",
+              "url": "https://files.pythonhosted.org/packages/4e/8a/a36f452b8cf725073521c8e7af664d85b337d699f29cb5845d92977af1ca/cryptography-42.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3",
-              "url": "https://files.pythonhosted.org/packages/3c/72/fb557573cebcae88c6efe3a73981181384e08408c1125a8e97a7fb3edde4/cryptography-42.0.2-cp39-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "935cca25d35dda9e7bd46a24831dfd255307c55a07ff38fd1a92119cffc34857",
+              "url": "https://files.pythonhosted.org/packages/59/65/60994410c3f244a7a695cb0bdddb8f1fd65dd9dc753ca50551fd5cbfe9f6/cryptography-42.0.3-cp37-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea",
-              "url": "https://files.pythonhosted.org/packages/45/82/3da127b1b75ea24f09ad85bcef5a6a7526be795eec4077663cd3ff52d19d/cryptography-42.0.2-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "d1998e545081da0ab276bcb4b33cce85f775adb86a516e8f55b3dac87f469548",
+              "url": "https://files.pythonhosted.org/packages/5c/a6/a38cd9ddd15ab79f5e3bf51221171015a655ec229f020d1eeca5df918ede/cryptography-42.0.3-cp37-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446",
-              "url": "https://files.pythonhosted.org/packages/5b/44/4c984f47a302236e1c76b721bfc8d407de9ab6620a9037c2de026d30c38f/cryptography-42.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "39d5c93e95bcbc4c06313fc6a500cee414ee39b616b55320c1904760ad686938",
+              "url": "https://files.pythonhosted.org/packages/60/50/7282bf57ba9fadaa6bfbeb8a0a16dfb20b69bbd72604b5107fff9e55e307/cryptography-42.0.3-cp37-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90",
-              "url": "https://files.pythonhosted.org/packages/61/dd/aecb8fe565b5c90a04bd5e564d0a42eadf33596b87ab87f75d986f06480f/cryptography-42.0.2-cp39-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "db0480ffbfb1193ac4e1e88239f31314fe4c6cdcf9c0b8712b55414afbf80db4",
+              "url": "https://files.pythonhosted.org/packages/63/0c/1d240e25cab1a9136490acaee2166290c99af09cf6b098b9fb3046a23ad6/cryptography-42.0.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33",
-              "url": "https://files.pythonhosted.org/packages/74/bb/f5e04bb44e7bfb88bb71ecb4d60a8dffaa19262c1ebe832250ee82e06de8/cryptography-42.0.2-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "25b09b73db78facdfd7dd0fa77a3f19e94896197c86e9f6dc16bce7b37a96504",
+              "url": "https://files.pythonhosted.org/packages/67/97/55e572ce90af588044cafa23f0924c9384ca977eb8cbd8757b39325e5079/cryptography-42.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008",
-              "url": "https://files.pythonhosted.org/packages/7a/19/4ff78f1bd152ee90c7e7dd174dedc8516ab9f872029a7bf58bd0eaaa199e/cryptography-42.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
+              "hash": "d5cf11bc7f0b71fb71af26af396c83dfd3f6eed56d4b6ef95d57867bf1e4ba65",
+              "url": "https://files.pythonhosted.org/packages/6b/45/a0f7a0ff613e25dc8270bc0f6f5f7f149119bec4237df7b7757cfea1c6d8/cryptography-42.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d",
-              "url": "https://files.pythonhosted.org/packages/9a/d8/cb66df54747a05218b9e0cfa1e7606d96b892750a173196139ac29fe3f2e/cryptography-42.0.2-cp37-abi3-macosx_10_12_x86_64.whl"
+              "hash": "3d96ea47ce6d0055d5b97e761d37b4e84195485cb5a38401be341fabf23bc32a",
+              "url": "https://files.pythonhosted.org/packages/6c/28/231fa3669e6555ce83dd574154706f19f6b81540a7f60c4bdf7cbeef5039/cryptography-42.0.3-cp37-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12",
-              "url": "https://files.pythonhosted.org/packages/a6/0a/7e8a98209a8f3c7f8200207ad7a32d123cd6d520a9bd6edc5c957f56b335/cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
+              "hash": "c3d1f5a1d403a8e640fa0887e9f7087331abb3f33b0f2207d2cc7f213e4a864c",
+              "url": "https://files.pythonhosted.org/packages/8d/05/e732c8e4e22557fcf6d59071168093b627f5a157b3858cdcbd1947ecc198/cryptography-42.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9",
-              "url": "https://files.pythonhosted.org/packages/af/4e/178466a513ff8c1aba7f56fafb169fe27af4c28df4b770cd2c30fa6fde5e/cryptography-42.0.2-cp37-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "0fab2a5c479b360e5e0ea9f654bcebb535e3aa1e493a715b13244f4e07ea8eec",
+              "url": "https://files.pythonhosted.org/packages/a0/32/5d06b82a425cffa725d4fc89e3f79eef949f08a564808540d5811fb9697b/cryptography-42.0.3-cp39-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4",
-              "url": "https://files.pythonhosted.org/packages/b1/85/11c92b74d7560cb2725653b49f54129c7284748bc56119a6dbabcaf51d05/cryptography-42.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "069d2ce9be5526a44093a0991c450fe9906cdf069e0e7cd67d9dee49a62b9ebe",
+              "url": "https://files.pythonhosted.org/packages/b3/cc/988dee9e00be594cb1e20fd0eb83facda0c229fdef4cd7746742ecd44371/cryptography-42.0.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1",
-              "url": "https://files.pythonhosted.org/packages/b8/ca/acd576a5e2cf16448c9c31ae72c0d389a12acd58bd190bf91bb6082ffc91/cryptography-42.0.2-cp37-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "de5086cd475d67113ccb6f9fae6d8fe3ac54a4f9238fd08bfdb07b03d791ff0a",
+              "url": "https://files.pythonhosted.org/packages/bf/79/67ca436f7b8fc14fd4fb875b0e7757183e0d71763b9892d5da3fe1048478/cryptography-42.0.3-cp37-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2",
-              "url": "https://files.pythonhosted.org/packages/d2/f6/a506b5a7b73253c450fab89c882b635cd0038adcc8e83e9729219d68f597/cryptography-42.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "35772a6cffd1f59b85cb670f12faba05513446f80352fe811689b4e439b5d89e",
+              "url": "https://files.pythonhosted.org/packages/d4/6b/8f31bcab2051af50188276b7a4a327cbc9e9eee6cb747643fcf3947dc69a/cryptography-42.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a",
-              "url": "https://files.pythonhosted.org/packages/ef/9f/49de69b6b55b812b492824bb1e5f4e37bb6953886c4c3fe0062be240f7e7/cryptography-42.0.2-cp39-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "2eb6368d5327d6455f20327fb6159b97538820355ec00f8cc9464d617caecead",
+              "url": "https://files.pythonhosted.org/packages/de/4c/e7246ff4b8083e740dbc529aca63de7696a54bcd0b440a0fa3627aa6a4e9/cryptography-42.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be",
-              "url": "https://files.pythonhosted.org/packages/f3/cd/e76223293a9c1c668e6de1c5400276a710f8fb5c69da1b07a6e66bbb45ae/cryptography-42.0.2-cp37-abi3-macosx_10_12_universal2.whl"
+              "hash": "4dcab7c25e48fc09a73c3e463d09ac902a932a0f8d0c568238b3696d06bf377b",
+              "url": "https://files.pythonhosted.org/packages/ef/78/b270c233009e8927f4bbf1a8646ead1ca24e2ac9c314f5a7e5b8b5355967/cryptography-42.0.3-cp37-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242",
-              "url": "https://files.pythonhosted.org/packages/f4/06/4229967761a1daf385bdb09bcb11d3d40970a54b52e896b41f43065eecf6/cryptography-42.0.2-cp39-abi3-macosx_10_12_universal2.whl"
+              "hash": "de4ae486041878dc46e571a4c70ba337ed5233a1344c14a0790c4c4be4bbb8b4",
+              "url": "https://files.pythonhosted.org/packages/f3/4c/616fec87c7240bc998662da1e16906ec158b7d383ddeaa9217b1ad426346/cryptography-42.0.3-cp39-abi3-musllinux_1_1_aarch64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -928,7 +928,7 @@
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\""
           ],
           "requires_python": ">=3.7",
-          "version": "42.0.2"
+          "version": "42.0.3"
         },
         {
           "artifacts": [
@@ -1190,13 +1190,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c36b6634d069b3f719610175020a9aed919421c87552185b085e04fbbdb10b7c",
-              "url": "https://files.pythonhosted.org/packages/45/c6/a637a7a11d4619957cb95ca195168759a4502991b1b91c13d3203ffc3748/GitPython-3.1.41-py3-none-any.whl"
+              "hash": "1bf9cd7c9e7255f77778ea54359e54ac22a72a5b51288c457c881057b7bb9ecd",
+              "url": "https://files.pythonhosted.org/packages/67/c7/995360c87dd74e27539ccbfecddfb58e08f140d849fcd7f35d2ed1a5f80f/GitPython-3.1.42-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed66e624884f76df22c8e16066d567aaa5a37d5b5fa19db2c6df6f7156db9048",
-              "url": "https://files.pythonhosted.org/packages/e5/c2/6e3a26945a7ff7cf2854b8825026cf3f22ac8e18285bc11b6b1ceeb8dc3f/GitPython-3.1.41.tar.gz"
+              "hash": "2d99869e0fef71a73cbd242528105af1d6c1b108c60dfabd994bf292f76c3ceb",
+              "url": "https://files.pythonhosted.org/packages/8f/12/71a40ffce4aae431c69c45a191e5f03aca2304639264faf5666c2767acc4/GitPython-3.1.42.tar.gz"
             }
           ],
           "project_name": "gitpython",
@@ -1213,11 +1213,10 @@
             "pytest-mock; extra == \"test\"",
             "pytest-sugar; extra == \"test\"",
             "pytest>=7.3.1; extra == \"test\"",
-            "sumtypes; extra == \"test\"",
             "typing-extensions>=3.7.4.3; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.1.41"
+          "version": "3.1.42"
         },
         {
           "artifacts": [
@@ -1932,21 +1931,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c3523b8f886052f3deb200b3218bcc13e4b781661e3bea38587cc936c80ea358",
-              "url": "https://files.pythonhosted.org/packages/0a/16/4fac4a2f18b4a9b4c9010cf6e961868de93b78d136e415b69739abc169ca/mongoengine-0.27.0-py3-none-any.whl"
+              "hash": "3d1c8b9f5d43144bd726a3f01e58d2831c6fb112960a4a60b3a26fa85e026ab3",
+              "url": "https://files.pythonhosted.org/packages/61/a2/dbdaa22cd49441060c6403252c384457cf2dfe8698deb6b8df6ce93191e4/mongoengine-0.23.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f38df7834dc4b192d89f2668dcf3091748d12f74d55648ce77b919167a4a49b",
-              "url": "https://files.pythonhosted.org/packages/f9/b3/8f368e8c925887adbd4c729ce12977c00ab53dfe0e53e84255a22c157983/mongoengine-0.27.0.tar.gz"
+              "hash": "de275e70cd58891dc46eef43369c522ce450dccb6d6f1979cbc9b93e6bdaf6cb",
+              "url": "https://files.pythonhosted.org/packages/ff/c7/856f7bb8f5f2c545d121800a50d7eb85a0af9db454d335b00f7a479863d2/mongoengine-0.23.1.tar.gz"
             }
           ],
           "project_name": "mongoengine",
           "requires_dists": [
-            "pymongo<5.0,>=3.4"
+            "pymongo<4.0,>=3.4"
           ],
-          "requires_python": ">=3.7",
-          "version": "0.27.0"
+          "requires_python": ">=3.6",
+          "version": "0.23.1"
         },
         {
           "artifacts": [
@@ -2055,21 +2054,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9822305b42ea1020d54fee322d43cee5622b044c07a1f0130b459bb467efcf88",
-              "url": "https://files.pythonhosted.org/packages/b6/a6/aa2c645188e00f7db040d1b0b1dd353b5b51c67984ada4f6d60aa388982f/netaddr-0.10.1-py2.py3-none-any.whl"
+              "hash": "d542c37909f1624665ec7f59ea2e388a20eb678188f1b0c4cb50fdd600f89264",
+              "url": "https://files.pythonhosted.org/packages/7f/e1/1b7ebbccd9262cd08f8fde49a2632724268e952a1613bcad0de6062b0cc4/netaddr-1.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4da4222ca8c3f43c8e18a8263e5426c750a3a837fdfeccf74c68d0408eaa3bf",
-              "url": "https://files.pythonhosted.org/packages/af/96/f4878091248450bbdebfbd01bf1d95821bd47eb38e756815a0431baa6b07/netaddr-0.10.1.tar.gz"
+              "hash": "eabeba62193525757ed3ab4aacc4ab8089f84e57059fd41fde58df95c128a26d",
+              "url": "https://files.pythonhosted.org/packages/d4/79/a9b05aa527c0032c0eb6c20d70c0a1335d1dadf000b789d9bbfb8993168c/netaddr-1.1.0.tar.gz"
             }
           ],
           "project_name": "netaddr",
           "requires_dists": [
-            "importlib-resources; python_version < \"3.7\""
+            "ipython; extra == \"shell\""
           ],
-          "requires_python": null,
-          "version": "0.10.1"
+          "requires_python": ">=3.7",
+          "version": "1.1.0"
         },
         {
           "artifacts": [
@@ -2213,94 +2212,94 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8a730bf07feacb0863974e67b206b7c503a62199de1cece2eb0d4c233ec29c11",
-              "url": "https://files.pythonhosted.org/packages/2d/ae/ea699c694fec052dbd4e780f455929c76a4ebc95d1e78e8721738494ce93/orjson-3.9.13-cp39-cp39-musllinux_1_2_x86_64.whl"
+              "hash": "6f52ac2eb49e99e7373f62e2a68428c6946cda52ce89aa8fe9f890c7278e2d3a",
+              "url": "https://files.pythonhosted.org/packages/3f/cd/a3bd40d2db4da9e56ecfcf7a0a70db93f5f0d7629b84e4f7ebf9f10ae02b/orjson-3.9.14-cp39-cp39-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "62e9a99879c4d5a04926ac2518a992134bfa00d546ea5a4cae4b9be454d35a22",
-              "url": "https://files.pythonhosted.org/packages/01/3f/d2f6eafe2c433a71d6f5ae4898e5e7331011ecf937d3ff9e794850509211/orjson-3.9.13-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
+              "hash": "3014ccbda9be0b1b5f8ea895121df7e6524496b3908f4397ff02e923bcd8f6dd",
+              "url": "https://files.pythonhosted.org/packages/1a/03/e93ecf2634676ec345a0bdbeb3acab8ceb80b32eb27ed06200acdd1a38fc/orjson-3.9.14-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d691c44604941945b00e0a13b19a7d9c1a19511abadf0080f373e98fdeb6b31",
-              "url": "https://files.pythonhosted.org/packages/11/99/633ecbdbf143d973ec8d11bc08fbf6f1eb8d86fcbd76a472de3eb99fbb24/orjson-3.9.13-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "df3266d54246cb56b8bb17fa908660d2a0f2e3f63fbc32451ffc1b1505051d07",
+              "url": "https://files.pythonhosted.org/packages/1a/2f/d1959e2d9d9943ccaf73b41201cad5c4dfaaf952bbd64fd705f8a907f0cf/orjson-3.9.14-cp38-cp38-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ddc089315d030c54f0f03fb38286e2667c05009a78d659f108a8efcfbdf2e585",
-              "url": "https://files.pythonhosted.org/packages/20/a8/430898dac6968adff44b1d1e3b3f53601d98776ef9e308dd2dc11ea15d6f/orjson-3.9.13-cp38-cp38-musllinux_1_2_x86_64.whl"
+              "hash": "23d1528db3c7554f9d6eeb09df23cb80dd5177ec56eeb55cc5318826928de506",
+              "url": "https://files.pythonhosted.org/packages/27/38/04022b06144bc4896be146133be24ffa38c710f336bcff3509126caec501/orjson-3.9.14-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7e8e4a571d958910272af8d53a9cbe6599f9f5fd496a1bc51211183bb2072cbd",
-              "url": "https://files.pythonhosted.org/packages/30/0b/b0749bec64217385c3d4a0fe72924ed7ca935d469d5d9892902a8c859bad/orjson-3.9.13-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
+              "hash": "814f288c011efdf8f115c5ebcc1ab94b11da64b207722917e0ceb42f52ef30a3",
+              "url": "https://files.pythonhosted.org/packages/29/16/53b5035b544752b2e4f5222f53eed2b1951c5dc3f50ab2ce3862b08b344b/orjson-3.9.14-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16946d095212a3dec552572c5d9bca7afa40f3116ad49695a397be07d529f1fa",
-              "url": "https://files.pythonhosted.org/packages/37/68/31db892410b0f4d5ad8dd988679a96ab375a5f9bd10ea54ffd1a23914289/orjson-3.9.13-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "5bf597530544db27a8d76aced49cfc817ee9503e0a4ebf0109cd70331e7bbe0c",
+              "url": "https://files.pythonhosted.org/packages/3f/b7/473b8ba97204c49def78ecf7b802f864f78414ebd1797d8cc9f355dea197/orjson-3.9.14-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "828c502bb261588f7de897e06cb23c4b122997cb039d2014cb78e7dabe92ef0c",
-              "url": "https://files.pythonhosted.org/packages/39/ff/6333bb87edc16eb02a00481689148a88a207c2aa8217a3bba3ae72201c50/orjson-3.9.13-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "ba3518b999f88882ade6686f1b71e207b52e23546e180499be5bbb63a2f9c6e6",
+              "url": "https://files.pythonhosted.org/packages/46/c9/05a8f30e339b985e15e5c9264e161ecdef0a275fe59f0be0c69ecf38b8ac/orjson-3.9.14-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31fb66b41fb2c4c817d9610f0bc7d31345728d7b5295ac78b63603407432a2b2",
-              "url": "https://files.pythonhosted.org/packages/3d/88/8824659c2044a3f18646aacd5937bd46cdd23a80ef7b2b41a406d759b6b2/orjson-3.9.13-cp39-cp39-musllinux_1_2_aarch64.whl"
+              "hash": "f75823cc1674a840a151e999a7dfa0d86c911150dd6f951d0736ee9d383bf415",
+              "url": "https://files.pythonhosted.org/packages/4a/7f/6db5bf9206d5a9e156f7071213e177221cf927f59af6f4297404da77851c/orjson-3.9.14-cp39-cp39-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d92a3e835a5100f1d5b566fff79217eab92223ca31900dba733902a182a35ab0",
-              "url": "https://files.pythonhosted.org/packages/44/e3/bc2dc2a9c81b7a2817fedfc3e0cf3e97df657958e6bba5eb704919ef801a/orjson-3.9.13-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a88cafb100af68af3b9b29b5ccd09fdf7a48c63327916c8c923a94c336d38dd3",
+              "url": "https://files.pythonhosted.org/packages/6d/53/56fc416cbf8aa6e6ae6a90adf464ac2425d90d9dd4c40cee878f1c0c4db5/orjson-3.9.14-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b1b5adc5adf596c59dca57156b71ad301d73956f5bab4039b0e34dbf50b9fa0",
-              "url": "https://files.pythonhosted.org/packages/5a/2c/fe832ead2a8c8a223da5d5005ef7de0276380e1087a4c10fd10c36a4f07d/orjson-3.9.13-cp38-cp38-musllinux_1_2_aarch64.whl"
+              "hash": "ac650d49366fa41fe702e054cb560171a8634e2865537e91f09a8d05ea5b1d37",
+              "url": "https://files.pythonhosted.org/packages/94/f1/fe022db74151381e234b945417eb0029457011289735bc51603740835377/orjson-3.9.14-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc6bc65b0cf524ee042e0bc2912b9206ef242edfba7426cf95763e4af01f527a",
-              "url": "https://files.pythonhosted.org/packages/67/1a/2d21f7ab742d49e4a5417481b9dd357550699c24f44a030ca8cc0954e74e/orjson-3.9.13.tar.gz"
+              "hash": "fca33fdd0b38839b01912c57546d4f412ba7bfa0faf9bf7453432219aec2df07",
+              "url": "https://files.pythonhosted.org/packages/b1/91/c69c35f36b5eea58305b944b1ebddbc7e21390da57c62980db34e089886a/orjson-3.9.14-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9156b96afa38db71344522f5517077eaedf62fcd2c9148392ff93d801128809c",
-              "url": "https://files.pythonhosted.org/packages/71/51/69aa8bc35357640ff7ad8fe998df9cbfecb2ce54997f246eb7b55d719009/orjson-3.9.13-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "06fb40f8e49088ecaa02f1162581d39e2cf3fd9dbbfe411eb2284147c99bad79",
+              "url": "https://files.pythonhosted.org/packages/bb/92/4280f93e3e1826b57a34a12de1b4a9d68bd850a34f528954c1cea0f49b14/orjson-3.9.14.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "a8c83718346de08d68b3cb1105c5d91e5fc39885d8610fdda16613d4e3941459",
-              "url": "https://files.pythonhosted.org/packages/84/80/952ad6648bab7c96c22fd68c71e0c11dbcfe78cd7783455f7000a6b532b2/orjson-3.9.13-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "7183cc68ee2113b19b0b8714221e5e3b07b3ba10ca2bb108d78fd49cefaae101",
+              "url": "https://files.pythonhosted.org/packages/c5/7f/fd73ea3c9d619df74efbfedeff87fa6f15198deb196ad8d8915cb029d214/orjson-3.9.14-cp38-cp38-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "23f21faf072ed3b60b5954686f98157e073f6a8068eaa58dbde83e87212eda84",
-              "url": "https://files.pythonhosted.org/packages/a7/c1/32c5bd7f9f77fa89c81522b73742f502d70d53214164a31512bff73b6372/orjson-3.9.13-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "236230433a9a4968ab895140514c308fdf9f607cb8bee178a04372b771123860",
+              "url": "https://files.pythonhosted.org/packages/d0/5b/a76631401cd4c9d7815aa5d5154c9bfaa90babb39e1a3bc9a31ff9aaeced/orjson-3.9.14-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3deadd8dc0e9ff844b5b656fa30a48dbee1c3b332d8278302dd9637f6b09f627",
-              "url": "https://files.pythonhosted.org/packages/ba/9a/c4a4105698fc8428831b64af7c06ebd3e9da41d6966a334fba9d1a73dd20/orjson-3.9.13-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "75fc593cf836f631153d0e21beaeb8d26e144445c73645889335c2247fcd71a0",
+              "url": "https://files.pythonhosted.org/packages/d5/3f/7f81a31a201242996102f6643098d41b981b06ca0b9324c451abb6058587/orjson-3.9.14-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "63ef57a53bfc2091a7cd50a640d9ae866bd7d92a5225a1bab6baa60ef62583f2",
-              "url": "https://files.pythonhosted.org/packages/ba/be/bfd996ce3cc35e0deb731bcde0e5ea0cf6b4afeec8293b07fc2594fb913b/orjson-3.9.13-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "978f416bbff9da8d2091e3cf011c92da68b13f2c453dcc2e8109099b2a19d234",
+              "url": "https://files.pythonhosted.org/packages/d6/42/4161277eedcbfb7eb4719de0e9f0ca225edd590a0bc5906b53c56fbd4de9/orjson-3.9.14-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cfad553a36548262e7da0f3a7464270e13900b898800fb571a5d4b298c3f8356",
-              "url": "https://files.pythonhosted.org/packages/d1/c6/c4b711c63685e858612ef6dea37fe7c423a9e384ae79d273d28a6e856f0a/orjson-3.9.13-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "ac0c7eae7ad3a223bde690565442f8a3d620056bd01196f191af8be58a5248e1",
+              "url": "https://files.pythonhosted.org/packages/e0/ba/6a8496ade6dbd6940ef50f1a80ab2b24d606b3136b9435de1f409e8e033e/orjson-3.9.14-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             }
           ],
           "project_name": "orjson",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "3.9.13"
+          "version": "3.9.14"
         },
         {
           "artifacts": [
@@ -2814,180 +2813,174 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3094c7d2f820eecabadae76bfec02669567bbdd1730eabce10a5764778564f7b",
-              "url": "https://files.pythonhosted.org/packages/be/a7/b95541846762b858164f5c0a15be7fcc2d00f4225d08bc39f7fcc80cbd22/pymongo-4.6.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+              "hash": "0be605bfb8461384a4cb81e80f51eb5ca1b89851f2d0e69a75458c788a7263a4",
+              "url": "https://files.pythonhosted.org/packages/a3/6c/10b9cc7baa860ae72467344ffb6a2b6ce06181894dfdc6bc7abd34237f00/pymongo-3.12.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "76013fef1c9cd1cd00d55efde516c154aa169f2bf059b197c263a255ba8a9ddf",
-              "url": "https://files.pythonhosted.org/packages/00/19/c756203185ec6a8c8ae3d2fb0cc9560dec8ef74c1d935934d448e9f58e11/pymongo-4.6.1-cp38-cp38-manylinux2014_x86_64.whl"
+              "hash": "e1fc4d3985868860b6585376e511bb32403c5ffb58b0ed913496c27fd791deea",
+              "url": "https://files.pythonhosted.org/packages/18/04/47c3546228ee303ad28306b1f53b1cbfaac537d4e514c715cb6877827edb/pymongo-3.12.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3d18a9b9b858ee140c15c5bfcb3e66e47e2a70a03272c2e72adda2482f76a6ad",
-              "url": "https://files.pythonhosted.org/packages/06/cf/3a324db19429956def624fe4a60119dcac1e1cfa8048250f5ecefcc6171e/pymongo-4.6.1-cp38-cp38-manylinux2014_i686.whl"
+              "hash": "89d7baa847383b9814de640c6f1a8553d125ec65e2761ad146ea2e75a7ad197c",
+              "url": "https://files.pythonhosted.org/packages/1a/03/8105130d1b1d3d3dd2c5915b712a096fadaeb3d472e59a84f1127e982d6e/pymongo-3.12.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0355cff58a4ed6d5e5f6b9c3693f52de0784aa0c17119394e2a8e376ce489d4",
-              "url": "https://files.pythonhosted.org/packages/06/de/b79272fbe5cef29f86ae2862bdd817cae5dc80034fbd4662b70889d3b9ec/pymongo-4.6.1-cp39-cp39-manylinux2014_i686.whl"
+              "hash": "517b09b1dd842390a965a896d1327c55dfe78199c9f5840595d40facbcd81854",
+              "url": "https://files.pythonhosted.org/packages/1b/63/c3023c7fd6bee4f79ce3d24b6a63b59baed2d4abec25c017183ef7805dca/pymongo-3.12.3-cp39-cp39-manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c79d597fb3a7c93d7c26924db7497eba06d58f88f58e586aa69b2ad89fee0f8",
-              "url": "https://files.pythonhosted.org/packages/09/3e/e47ebf391b282bc575e534c1e2b9e7801a2eb20dd64c7b7ff0b16478d3cf/pymongo-4.6.1-cp39-cp39-manylinux2014_s390x.whl"
+              "hash": "7a6e4dccae8ef5dd76052647d78f02d5d0ffaff1856277d951666c54aeba3ad2",
+              "url": "https://files.pythonhosted.org/packages/24/83/0f16452e3f8a8b4fa016b065899eb48683cc792b510a231a1981c251b480/pymongo-3.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5e641f931c5cd95b376fd3c59db52770e17bec2bf86ef16cc83b3906c054845",
-              "url": "https://files.pythonhosted.org/packages/0b/53/5217f2d95986040354be3546631316ce940cb276fc68db9103bef9fc1daf/pymongo-4.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "80710d7591d579442c67a3bc7ae9dcba9ff95ea8414ac98001198d894fc4ff46",
+              "url": "https://files.pythonhosted.org/packages/28/f9/01f3ae759b4176ffbf7d71767433c2154f7f140e2465ad886dfaecd652f0/pymongo-3.12.3-cp38-cp38-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f9756f1d25454ba6a3c2f1ef8b7ddec23e5cdeae3dc3c3377243ae37a383db00",
-              "url": "https://files.pythonhosted.org/packages/0c/0f/c7d9b39a5c19215782efd54ed43195117a86025d6c3af22304d7e2d034fe/pymongo-4.6.1-cp38-cp38-manylinux1_x86_64.whl"
+              "hash": "28bfd5244d32faf3e49b5a8d1fab0631e922c26e8add089312e4be19fb05af50",
+              "url": "https://files.pythonhosted.org/packages/2e/fe/a44602e61ee23ef6ae64150bb2bf86cac9241c4d668791c8e6255b598aa1/pymongo-3.12.3-cp38-cp38-manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3c74f4725485f0a7a3862cfd374cc1b740cebe4c133e0c1425984bcdcce0f4bb",
-              "url": "https://files.pythonhosted.org/packages/0e/a6/d6fb15531ce8be59b76ea51b33a4fdbd2189dca1d6d418e6f323ef617b65/pymongo-4.6.1-cp39-cp39-manylinux2014_ppc64le.whl"
+              "hash": "a1ba93be779a9b8e5e44f5c133dc1db4313661cead8a2fd27661e6cb8d942ee9",
+              "url": "https://files.pythonhosted.org/packages/3b/33/0852648d70775d288608346887f77f96b5121faa45ebd67d6ad8c717a20c/pymongo-3.12.3-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd1fa413f8b9ba30140de198e4f408ffbba6396864c7554e0867aa7363eb58b2",
-              "url": "https://files.pythonhosted.org/packages/13/b6/9273418774f5a9cda7f25a93d14d083c0af8f03f814780257264b5220a9d/pymongo-4.6.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "1b4c535f524c9d8c86c3afd71d199025daa070859a2bdaf94a298120b0de16db",
+              "url": "https://files.pythonhosted.org/packages/41/3c/2f7979ca86ee88ede3b6733dab55181e35754c19c8a349dbe9fdee960dfd/pymongo-3.12.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27b81ecf18031998ad7db53b960d1347f8f29e8b7cb5ea7b4394726468e4295e",
-              "url": "https://files.pythonhosted.org/packages/1d/5c/93d489be8db5380a145ddf04744f28ca14546a0f7fd8224465e5fb3ce2de/pymongo-4.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e4e5d163e6644c2bc84dd9f67bfa89288c23af26983d08fefcc2cbc22f6e57e6",
+              "url": "https://files.pythonhosted.org/packages/52/80/934ed944cda7414405ffd7dc47d2b2767be5032a1eb61c2282e709358771/pymongo-3.12.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "31dab1f3e1d0cdd57e8df01b645f52d43cc1b653ed3afd535d2891f4fc4f9712",
-              "url": "https://files.pythonhosted.org/packages/1d/f0/b5fcf9aee64ac3650a3df3bd1d7e8870838a82944fa4868768ab9db5416a/pymongo-4.6.1.tar.gz"
+              "hash": "cebb3d8bcac4a6b48be65ebbc5c9881ed4a738e27bb96c86d9d7580a1fb09e05",
+              "url": "https://files.pythonhosted.org/packages/53/cc/0a58955ec937d61e4cba830df2ec1c909cf8c7e1cf850f7043360e3769db/pymongo-3.12.3-cp38-cp38-manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a1810c2cbde714decf40f811d1edc0dae45506eb37298fd9d4247b8801509fe",
-              "url": "https://files.pythonhosted.org/packages/20/6f/a92effb4b69f1287f2910a0f854dcb12d690f61b5e53f4889f5a7202762c/pymongo-4.6.1-cp39-cp39-manylinux1_x86_64.whl"
+              "hash": "bfc2d763d05ec7211313a06e8571236017d3e61d5fef97fcf34ec4b36c0b6556",
+              "url": "https://files.pythonhosted.org/packages/65/1f/b0df4f763ba6aa56aa12d63b08b2f87391adf85e84e55772f9721bdbb8f1/pymongo-3.12.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "061598cbc6abe2f382ab64c9caa83faa2f4c51256f732cdd890bcc6e63bfb67e",
-              "url": "https://files.pythonhosted.org/packages/2c/e1/dad12b6b78b553ec7d44dd61b86c83a64f0d8bdc13c4eb728dd8cd5ff94c/pymongo-4.6.1-cp38-cp38-macosx_11_0_universal2.whl"
+              "hash": "2577b8161eeae4dd376d13100b2137d883c10bb457dd08935f60c9f9d4b5c5f6",
+              "url": "https://files.pythonhosted.org/packages/66/fd/450ca78ed199ddbe76d3f398d124d86d8925582fef500f9baf13aabb1c52/pymongo-3.12.3-cp39-cp39-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56816e43c92c2fa8c11dc2a686f0ca248bea7902f4a067fa6cbc77853b0f041e",
-              "url": "https://files.pythonhosted.org/packages/3c/b0/082730a898389b56acdcff3c615907863ed58d1cba391aaa430087cfc953/pymongo-4.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "8d92c6bb9174d47c2257528f64645a00bbc6324a9ff45a626192797aff01dc14",
+              "url": "https://files.pythonhosted.org/packages/72/35/9c79295df4efb913eb921bd706806404a3fbaadec69cba05bde47f474f3f/pymongo-3.12.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2aced6fb2f5261b47d267cb40060b73b6527e64afe54f6497844c9affed5fd0",
-              "url": "https://files.pythonhosted.org/packages/4e/21/b551e55e392f2dc8e85a8b8d727966747deb5ca1240e0eb946736b3a49cd/pymongo-4.6.1-cp39-cp39-manylinux2014_aarch64.whl"
+              "hash": "b7df0d99e189b7027d417d4bfd9b8c53c9c7ed5a0a1495d26a6f547d820eca88",
+              "url": "https://files.pythonhosted.org/packages/72/b3/142dd8a64b12d7b101f9f4b6b32609b13ac6358b57f04f44192b40843c09/pymongo-3.12.3-cp39-cp39-manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ed23b0e2dac6f84f44c8494fbceefe6eb5c35db5c1099f56ab78fc0d94ab3af",
-              "url": "https://files.pythonhosted.org/packages/4f/17/eae7b0a289ca0e9bfde9394f3f709c6892c13d1f743ca981c0a3c49d50c7/pymongo-4.6.1-cp38-cp38-manylinux2014_aarch64.whl"
+              "hash": "14dee106a10b77224bba5efeeb6aee025aabe88eb87a2b850c46d3ee55bdab4a",
+              "url": "https://files.pythonhosted.org/packages/97/0d/0c6c458751c418b35b7199f1dfaaa78df2900494373ae02ed8d91eb1f071/pymongo-3.12.3-cp39-cp39-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4c2be9760b112b1caf649b4977b81b69893d75aa86caf4f0f398447be871f3c",
-              "url": "https://files.pythonhosted.org/packages/5a/d5/c5b3a4ca6c6da693551a85af38daba311dfc7e792a5c0320670066c089f1/pymongo-4.6.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl"
+              "hash": "0a89cadc0062a5e53664dde043f6c097172b8c1c5f0094490095282ff9995a5f",
+              "url": "https://files.pythonhosted.org/packages/97/79/9382c00183979e6cedfb82d7c8d9667a121c19bb2ed66334da930b6f4ef2/pymongo-3.12.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ec75f35f62571a43e31e7bd11749d974c1b5cd5ea4a8388725d579263c0fdf6",
-              "url": "https://files.pythonhosted.org/packages/5f/47/2d6e1ef9535a44ed7c0a9e297791f56d77fcfdc4a0128fa91392e8d5d422/pymongo-4.6.1-cp39-cp39-manylinux2014_x86_64.whl"
+              "hash": "07398d8a03545b98282f459f2603a6bb271f4448d484ed7f411121a519a7ea48",
+              "url": "https://files.pythonhosted.org/packages/9c/12/193a4455db2f149b65943a1eff80f5bc2eb680659b6505ae2fb41256458d/pymongo-3.12.3-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ec31adc2e988fd7db3ab509954791bbc5a452a03c85e45b804b4bfc31fa221d",
-              "url": "https://files.pythonhosted.org/packages/68/f3/f0909bd0498c1e34d9fbdc432feb55cb25d58aeb1a2022be9827afabdc61/pymongo-4.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0e7a5d0b9077e8c3e57727f797ee8adf12e1d5e7534642230d98980d160d1320",
+              "url": "https://files.pythonhosted.org/packages/9e/6d/059656d398305f5dd16bce0465f89602c0ed75489b3db87ded90dfa055d7/pymongo-3.12.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9167e735379ec43d8eafa3fd675bfbb12e2c0464f98960586e9447d2cf2c7a83",
-              "url": "https://files.pythonhosted.org/packages/6d/27/71bf4a56683944e1bf3321cb70bda7ad0727452d79edf9c86668796d8993/pymongo-4.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "4294f2c1cd069b793e31c2e6d7ac44b121cf7cedccd03ebcc30f3fc3417b314a",
+              "url": "https://files.pythonhosted.org/packages/9e/9d/75b82308fa1f7759f79758102f911ff4171708a4f24000ad47ffd224519d/pymongo-3.12.3-cp38-cp38-manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d219b4508f71d762368caec1fc180960569766049bbc4d38174f05e8ef2fe5b",
-              "url": "https://files.pythonhosted.org/packages/6d/7c/dadb62a8e7b92eacc19a36c3809c9349951c438d91ce11acff13da4c2d92/pymongo-4.6.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "a283425e6a474facd73072d8968812d1d9058490a5781e022ccf8895500b83ce",
+              "url": "https://files.pythonhosted.org/packages/9e/c0/98d2c2214d882f0639bc4e9f9ba15f82b6ae57a902948534de3a81182173/pymongo-3.12.3-cp39-cp39-manylinux1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1f2b856518bfcfa316c8dae3d7b412aecacf2e8ba30b149f5eb3b63128d703b9",
-              "url": "https://files.pythonhosted.org/packages/73/d6/a8e1199db917103d708df45dbe297c10235dc3d5c33ed61aefe7a3599bab/pymongo-4.6.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "602284e652bb56ca8760f8e88a5280636c5b63d7946fca1c2fe0f83c37dffc64",
+              "url": "https://files.pythonhosted.org/packages/b3/16/fb0a9bd6d1b5a9158924b7b998f4aa8afbc063825716a23472daed05626d/pymongo-3.12.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d483793a384c550c2d12cb794ede294d303b42beff75f3b3081f57196660edaf",
-              "url": "https://files.pythonhosted.org/packages/7d/63/e33d2af602efe9e7b66a14710817db7744527c92a07fe5d68436b25f5e63/pymongo-4.6.1-cp38-cp38-manylinux1_i686.whl"
+              "hash": "8455176fd1b86de97d859fed4ae0ef867bf998581f584c7a1a591246dfec330f",
+              "url": "https://files.pythonhosted.org/packages/b8/05/76e0e5809d7798011ce541ed2f2447c1f9c77522bb227333cd9f604a8c85/pymongo-3.12.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c258dbacfff1224f13576147df16ce3c02024a0d792fd0323ac01bed5d3c545d",
-              "url": "https://files.pythonhosted.org/packages/84/23/0643b3efa87f3715cd179fd8fbb626bebeb282785e2dd728bbe4eae376ab/pymongo-4.6.1-cp38-cp38-manylinux2014_ppc64le.whl"
+              "hash": "a8a3540e21213cb8ce232e68a7d0ee49cdd35194856c50b8bd87eeb572fadd42",
+              "url": "https://files.pythonhosted.org/packages/ba/fa/95bc121e929671e3a492c317170f84d0d71b3030d7bb1e6ba3a22bf0a029/pymongo-3.12.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9aafd036f6f2e5ad109aec92f8dbfcbe76cff16bad683eb6dd18013739c0b3ae",
-              "url": "https://files.pythonhosted.org/packages/89/ea/4fcb0f7156aaab44f8c91690bd63050a9b6826b23bf265ce8354ee310378/pymongo-4.6.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "2567885ff0c8c7c0887ba6cefe4ae4af96364a66a7069f924ce0cd12eb971d04",
+              "url": "https://files.pythonhosted.org/packages/c3/14/e7e7127961b231794bb89039a1cea3b8825e4a1d0b195c4e2b874629d236/pymongo-3.12.3-cp39-cp39-manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "69247f7a2835fc0984bbf0892e6022e9a36aec70e187fcfe6cae6a373eb8c4de",
-              "url": "https://files.pythonhosted.org/packages/90/dc/50134dee1df0e3904d8a0bff40b6b455bb47e582b6e087f1df43ddf1e399/pymongo-4.6.1-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "bf254a1a95e95fdf4eaa25faa1ea450a6533ed7a997f9f8e49ab971b61ea514d",
+              "url": "https://files.pythonhosted.org/packages/c3/9a/101b17a28da73b170a21b24e11d05365c4a98e8fc8ab8ba0e51f1440607c/pymongo-3.12.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1461199b07903fc1424709efafe379205bf5f738144b1a50a08b0396357b5abf",
-              "url": "https://files.pythonhosted.org/packages/93/f2/c938cf8897e090bc0257ebff44bb554a043e0d598621de48c981cc644b19/pymongo-4.6.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "f38b35ecd2628bf0267761ed659e48af7e620a7fcccfccf5774e7308fb18325c",
+              "url": "https://files.pythonhosted.org/packages/d8/50/e6b9f16ec031cdf6a11d31347ada3be4a581337ebd9d3ad644e2cb9e12d8/pymongo-3.12.3-cp38-cp38-manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3f0e6a6c807fa887a0c51cc24fe7ea51bb9e496fe88f00d7930063372c3664c3",
-              "url": "https://files.pythonhosted.org/packages/9f/3e/50e2e44f2292cdb5eeb8e599a8a79aacc30a7bd84343c85e6983eaa1f68e/pymongo-4.6.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "71c5c200fd37a5322706080b09c3ec8907cf01c377a7187f354fc9e9e13abc73",
+              "url": "https://files.pythonhosted.org/packages/e9/87/11ccaf5cd991f7a7406ed947f6c8f1f85a356f074a439bce48d303206baf/pymongo-3.12.3-cp39-cp39-manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bb0e9049e81def6829d09558ad12d16d0454c26cabe6efc3658e544460688d9",
-              "url": "https://files.pythonhosted.org/packages/e4/8c/30096d46d706a1b2fcb32a8835bd38e14ae069ecbead67b6dee50918f643/pymongo-4.6.1-cp39-cp39-manylinux1_i686.whl"
+              "hash": "f340a2a908644ea6cccd399be0fb308c66e05d2800107345f9f0f0d59e1731c4",
+              "url": "https://files.pythonhosted.org/packages/ea/84/c558b19e8e8d3442e8394f313d74ffad4919dca963f1923567629f7dba09/pymongo-3.12.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f7acc03a4f1154ba2643edeb13658d08598fe6e490c3dd96a241b94f09801626",
-              "url": "https://files.pythonhosted.org/packages/e9/2f/f378ad5d6842d6f9eaca384e450d319f6208636eea855f68f298a7cd4c77/pymongo-4.6.1-cp38-cp38-manylinux2014_s390x.whl"
+              "hash": "176fdca18391e1206c32fb1d8265628a84d28333c20ad19468d91e3e98312cd1",
+              "url": "https://files.pythonhosted.org/packages/f0/4e/b2f5dc8584bc11ff871aab182ba15ab2c3d4d9f39cbd8c7749f0fd1275ea/pymongo-3.12.3-cp38-cp38-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef801027629c5b511cf2ba13b9be29bfee36ae834b2d95d9877818479cdc99ea",
-              "url": "https://files.pythonhosted.org/packages/f5/06/33ce5c8483ad04059ccf80335a25cf21d85241086761a7ac75f9d4824a0e/pymongo-4.6.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "845b178bd127bb074835d2eac635b980c58ec5e700ebadc8355062df708d5a71",
+              "url": "https://files.pythonhosted.org/packages/f7/0e/8185c5b8968cc3db6176d5a2f79f245da1bf963a629fda88640441cea90f/pymongo-3.12.3-cp38-cp38-manylinux1_x86_64.whl"
             }
           ],
           "project_name": "pymongo",
           "requires_dists": [
-            "certifi; (os_name == \"nt\" or sys_platform == \"darwin\") and extra == \"encryption\"",
-            "certifi; (os_name == \"nt\" or sys_platform == \"darwin\") and extra == \"ocsp\"",
-            "cryptography>=2.5; extra == \"ocsp\"",
-            "dnspython<3.0.0,>=1.16.0",
-            "pykerberos; os_name != \"nt\" and extra == \"gssapi\"",
+            "dnspython<3.0.0,>=1.16.0; extra == \"srv\"",
+            "pykerberos; extra == \"gssapi\"",
             "pymongo-auth-aws<2.0.0; extra == \"aws\"",
-            "pymongo[aws]; extra == \"encryption\"",
-            "pymongocrypt<2.0.0,>=1.6.0; extra == \"encryption\"",
+            "pymongocrypt<2.0.0,>=1.1.0; extra == \"encryption\"",
             "pyopenssl>=17.2.0; extra == \"ocsp\"",
-            "pytest>=7; extra == \"test\"",
             "python-snappy; extra == \"snappy\"",
             "requests<3.0.0; extra == \"ocsp\"",
             "service-identity>=18.1.0; extra == \"ocsp\"",
-            "winkerberos>=0.5.0; os_name == \"nt\" and extra == \"gssapi\"",
             "zstandard; extra == \"zstd\""
           ],
-          "requires_python": ">=3.7",
-          "version": "4.6.1"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
+          "version": "3.12.3"
         },
         {
           "artifacts": [
@@ -3728,13 +3721,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05",
-              "url": "https://files.pythonhosted.org/packages/55/3a/5121b58b578a598b269537e09a316ad2a94fdd561a2c6eb75cd68578cc6b/setuptools-69.0.3-py3-none-any.whl"
+              "hash": "c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6",
+              "url": "https://files.pythonhosted.org/packages/bb/0a/203797141ec9727344c7649f6d5f6cf71b89a6c28f8f55d4f18de7a1d352/setuptools-69.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78",
-              "url": "https://files.pythonhosted.org/packages/fc/c9/b146ca195403e0182a374e0ea4dbc69136bad3cd55bc293df496d625d0f7/setuptools-69.0.3.tar.gz"
+              "hash": "850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401",
+              "url": "https://files.pythonhosted.org/packages/c9/3d/74c56f1c9efd7353807f8f5fa22adccdba99dc72f34311c30a69627a0fad/setuptools-69.1.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -3756,14 +3749,14 @@
             "packaging>=23.1; extra == \"testing-integration\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
-            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=2.2; extra == \"testing\"",
+            "pytest-home>=0.5; extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; sys_platform != \"cygwin\" and extra == \"testing\"",
-            "pytest-ruff; sys_platform != \"cygwin\" and extra == \"testing\"",
+            "pytest-ruff>=0.2.1; sys_platform != \"cygwin\" and extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
@@ -3786,7 +3779,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.8",
-          "version": "69.0.3"
+          "version": "69.1.0"
         },
         {
           "artifacts": [
@@ -4215,19 +4208,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3",
-              "url": "https://files.pythonhosted.org/packages/a3/fb/52b62131e21b24ee297e4e95ed41eba29647dad0e0051a92bb66b43c70ff/tzdata-2023.4-py2.py3-none-any.whl"
+              "hash": "9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252",
+              "url": "https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9",
-              "url": "https://files.pythonhosted.org/packages/4d/60/acd18ca928cc20eace3497b616b6adb8ce1abc810dd4b1a22bc6bdefac92/tzdata-2023.4.tar.gz"
+              "hash": "2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
+              "url": "https://files.pythonhosted.org/packages/74/5b/e025d02cb3b66b7b76093404392d4b44343c69101cc85f4d180dd5784717/tzdata-2024.1.tar.gz"
             }
           ],
           "project_name": "tzdata",
           "requires_dists": [],
           "requires_python": ">=2",
-          "version": "2023.4"
+          "version": "2024.1"
         },
         {
           "artifacts": [
@@ -4990,7 +4983,7 @@
     "logshipper",
     "mail-parser==3.15.0",
     "mock",
-    "mongoengine",
+    "mongoengine<0.24.0,>=0.21.0",
     "networkx",
     "nose",
     "nose-parallel",
@@ -5006,7 +4999,7 @@
     "prompt-toolkit<2",
     "psutil",
     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
-    "pymongo",
+    "pymongo<3.13.0,>=3.11.0",
     "pyrabbit",
     "pysocks",
     "pytest",

--- a/pants.toml
+++ b/pants.toml
@@ -146,6 +146,13 @@ twine = ["CPython>=3.8,<3.10"]
 # put indirect/transitive version constraints here:
 st2 = "lockfiles/st2-constraints.txt"
 
+[export]
+py_editable_in_resolve = [
+  # Include PEP-660 editable installs of st2 code in exported virtualenv
+  # (this is like doing `pip install -e`) to facilitate development.
+  "st2",
+]
+
 [python-infer]
 # https://www.pantsbuild.org/docs/reference-python-infer#string_imports
 # https://www.pantsbuild.org/docs/reference-python-infer#string_imports_min_dots

--- a/pants.toml
+++ b/pants.toml
@@ -147,11 +147,11 @@ twine = ["CPython>=3.8,<3.10"]
 st2 = "lockfiles/st2-constraints.txt"
 
 [export]
-py_editable_in_resolve = [
-  # Include PEP-660 editable installs of st2 code in exported virtualenv
-  # (this is like doing `pip install -e`) to facilitate development.
-  "st2",
-]
+# When exporting the virtualenv, include editable installs of our sources
+# so that the entry_points metadata is available for stevedore's use.
+py_editable_in_resolve = ["st2"]
+# We need mutable venvs to use the editable installs of our sources.
+py_resolve_format = "mutable_virtualenv"
 
 [python-infer]
 # https://www.pantsbuild.org/docs/reference-python-infer#string_imports

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -99,8 +99,8 @@ zake
 
 ###########
 
-# not needed with switch to pytest
-#nose
-#nose-timer
-#nose-parallel
-#rednose
+# remove once we switch to pytest
+nose
+nose-timer
+nose-parallel
+rednose

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -26,7 +26,8 @@ jsonschema>=3,<4
 kombu
 lockfile
 mock
-mongoengine
+# mongoengine 0.24.0 has breaking changes to support pymongo 4.0
+mongoengine>=0.21.0,<0.24.0
 # Note: networkx v2.6 dropped support for Python3.6
 # networkx version is constrained in orquesta.
 networkx
@@ -45,7 +46,8 @@ prettytable
 # For st2client: prompt-toolkit v2+ does not have prompt_toolkit.token.Token
 prompt-toolkit<2
 psutil
-pymongo
+# pymongo 3.13 has backports of APIs from pymongo 4 to help w/ migration
+pymongo>=3.11.0,<3.13.0
 # pyrabbit used in an integration test
 pyrabbit
 pytest


### PR DESCRIPTION
With this change, you can run `pants export --resolve=st2` to get a venv under `dist/export/python/virtualenvs/st2/<python version>`. The venv includes:
- editable installs of all of our st2* (st2api, st2auth, ...) and runners
- everything in `lockfiles/st2.lock`:
    - `nose` so that you can run the tests.
    - versions of `pymongo` and `mongoengine` that is compatible with our code
        - **All unit tests pass with this**

Pex (used by pants) will create the venv with the first interpreter on the path that matches the interpreter_constraints in pants.toml. If you want to generate a venv with a particular python binary use this:
```
pants export --resolve=st2 --python-bootstrap-search-path=[] --python-bootstrap-search-path=/usr/bin/python3.9
```
_Replace `/usr/bin/python3.9` with the interpreter you want pants to use._

This PR does not attempt to get the Makefile to use the venv. This PR just extracts the bits I'm confident about from #6130.

Summary of changes in the Lockfile:
```
==                    Upgraded dependencies                     ==

  certifi                        2023.11.17   -->   2024.2.2
  cryptography                   42.0.1       -->   42.0.3
  gitpython                      3.1.41       -->   3.1.42
  netaddr                        0.10.1       -->   1.1.0
  orjson                         3.9.12       -->   3.9.14
  pip                            23.3.2       -->   24.0
  platformdirs                   4.1.0        -->   4.2.0
  pytz                           2023.4       -->   2024.1
  setuptools                     69.0.3       -->   69.1.0
  ruamel-yaml                    0.18.5       -->   0.18.6
  tzdata                         2023.4       -->   2024.1
  urllib3                        2.1.0        -->   2.2.0
  voluptuous                     0.14.1       -->   0.14.2
  waitress                       2.1.2        -->   3.0.0

==                      Added dependencies                      ==

  colorama                       0.4.6
  nose                           1.3.7
  nose-parallel                  0.4.0
  nose-timer                     1.0.1
  rednose                        1.3.0
  termstyle                      0.1.11

==                !! Downgraded dependencies !!                 ==

  mongoengine                    0.27.0       -->   0.23.1
  pymongo                        4.6.1        -->   3.12.3
```