### PR TITLE
Improve testing logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -818,17 +818,19 @@ unit-tests: requirements .unit-tests
 	@echo
 	@echo "----- Dropping st2-test db -----"
 	@mongo st2-test --eval "db.dropDatabase();"
-	@for component in $(COMPONENTS_TEST); do\
+	@failed=0; \
+	for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
 		    nosetests $(NOSE_OPTS) -s -v \
-		    $$component/tests/unit || exit 1; \
+		    $$component/tests/unit || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
-	done
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: .run-unit-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -840,6 +842,7 @@ endif
 	@echo
 	@echo "----- Dropping st2-test db -----"
 	@mongo st2-test --eval "db.dropDatabase();"
+	failed=0; \
 	for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
@@ -848,11 +851,12 @@ endif
 		    COVERAGE_FILE=.coverage.unit.$$(echo $$component | tr '/' '.') \
 		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \
-		    $$component/tests/unit || exit 1; \
+		    $$component/tests/unit || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
-	done
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: .combine-unit-tests-coverage
 .combine-unit-tests-coverage: .run-unit-tests-coverage
@@ -897,17 +901,19 @@ itests: requirements .itests
 	@echo
 	@echo "----- Dropping st2-test db -----"
 	@mongo st2-test --eval "db.dropDatabase();"
-	@for component in $(COMPONENTS_TEST); do\
+	@failed=0; \
+	for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running integration tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
 		    nosetests $(NOSE_OPTS) -s -v \
-		    $$component/tests/integration || exit 1; \
+		    $$component/tests/integration || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \
 		echo "Done running integration tests in" $$component; \
 		echo "==========================================================="; \
-	done
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: .run-integration-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -919,7 +925,8 @@ endif
 	@echo
 	@echo "----- Dropping st2-test db -----"
 	@mongo st2-test --eval "db.dropDatabase();"
-	@for component in $(COMPONENTS_TEST); do\
+	@failed=0; \
+	for component in $(COMPONENTS_TEST); do\
 		echo "==========================================================="; \
 		echo "Running integration tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
@@ -927,24 +934,27 @@ endif
 		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
 		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \
-		    $$component/tests/integration || exit 1; \
+		    $$component/tests/integration || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \
 		echo "Done integration running tests in" $$component; \
 		echo "==========================================================="; \
-	done
+	done \
+	if [ $failed -gt 0 ]; then exit 1; done
 	@echo
 	@echo "============== runners integration tests with coverage =============="
 	@echo
 	@echo "The tests assume st2 is running on 127.0.0.1."
-	@for component in $(COMPONENTS_RUNNERS); do\
+	@failed=0; \
+	for component in $(COMPONENTS_RUNNERS); do\
 		echo "==========================================================="; \
 		echo "Running integration tests in" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
 		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
 			nosetests $(NOSE_OPTS) -s -v \
-			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || exit 1; \
-	done
+			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 	# NOTE: If you also want to run orquesta tests which seem to have a bunch of race conditions, use
 	# ci-integration-full target
 #	@echo
@@ -1071,12 +1081,14 @@ runners-tests: requirements .runners-tests
 	@echo
 	@echo "----- Dropping st2-test db -----"
 	@mongo st2-test --eval "db.dropDatabase();"
-	@for component in $(COMPONENTS_RUNNERS); do\
+	@failed=0; \
+	for component in $(COMPONENTS_RUNNERS); do\
 		echo "==========================================================="; \
 		echo "Running tests in" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/unit || exit 1; \
-	done
+		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/unit || ((failed+=1)); \
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: runners-itests
 runners-itests: requirements .runners-itests
@@ -1087,12 +1099,14 @@ runners-itests: requirements .runners-itests
 	@echo "==================== runners-itests ===================="
 	@echo
 	@echo "----- Dropping st2-test db -----"
-	@for component in $(COMPONENTS_RUNNERS); do\
+	@failed=0; \
+	for component in $(COMPONENTS_RUNNERS); do\
 		echo "==========================================================="; \
 		echo "Running integration tests in" $$component; \
 		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/integration || exit 1; \
-	done
+		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/integration || ((failed+=1)); \
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: .runners-itests-coverage-html
 .runners-itests-coverage-html:
@@ -1100,13 +1114,15 @@ runners-itests: requirements .runners-itests
 	@echo "============== runners-itests-coverage-html =============="
 	@echo
 	@echo "The tests assume st2 is running on 127.0.0.1."
-	@for component in $(COMPONENTS_RUNNERS); do\
+	@failed=0; \
+	for component in $(COMPONENTS_RUNNERS); do\
 		echo "==========================================================="; \
 		echo "Running integration tests in" $$component; \
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v --with-coverage \
-			--cover-inclusive --cover-html $$component/tests/integration || exit 1; \
-	done
+			--cover-inclusive --cover-html $$component/tests/integration || ((failed+=1)); \
+	done; \
+	if [ $failed -gt 0 ]; then exit 1; done
 
 .PHONY: cli
 cli:

--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,7 @@ unit-tests: requirements .unit-tests
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: .run-unit-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -856,7 +856,7 @@ endif
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: .combine-unit-tests-coverage
 .combine-unit-tests-coverage: .run-unit-tests-coverage
@@ -913,7 +913,7 @@ itests: requirements .itests
 		echo "Done running integration tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: .run-integration-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -939,7 +939,7 @@ endif
 		echo "Done integration running tests in" $$component; \
 		echo "==========================================================="; \
 	done \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 	@echo
 	@echo "============== runners integration tests with coverage =============="
 	@echo
@@ -954,7 +954,7 @@ endif
 			nosetests $(NOSE_OPTS) -s -v \
 			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 	# NOTE: If you also want to run orquesta tests which seem to have a bunch of race conditions, use
 	# ci-integration-full target
 #	@echo
@@ -1088,7 +1088,7 @@ runners-tests: requirements .runners-tests
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/unit || ((failed+=1)); \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: runners-itests
 runners-itests: requirements .runners-itests
@@ -1106,7 +1106,7 @@ runners-itests: requirements .runners-itests
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: .runners-itests-coverage-html
 .runners-itests-coverage-html:
@@ -1122,7 +1122,7 @@ runners-itests: requirements .runners-itests
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v --with-coverage \
 			--cover-inclusive --cover-html $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $$failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; fi
 
 .PHONY: cli
 cli:

--- a/Makefile
+++ b/Makefile
@@ -940,22 +940,6 @@ endif
 		echo "==========================================================="; \
 	done; \
 	if [ $$failed -gt 0 ]; then exit 1; fi
-# COMPONTENTS_RUNNERS is included in COMPONENTS_TEST, so this just duplicates running the runner integration tests!
-#	@echo
-#	@echo "============== runners integration tests with coverage =============="
-#	@echo
-#	@echo "The tests assume st2 is running on 127.0.0.1."
-#	@failed=0; \
-#	for component in $(COMPONENTS_RUNNERS); do\
-#		echo "==========================================================="; \
-#		echo "Running integration tests in" $$component; \
-#		echo "==========================================================="; \
-#		. $(VIRTUALENV_DIR)/bin/activate; \
-#		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
-#			nosetests $(NOSE_OPTS) -s -v \
-#			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
-#	done; \
-#	if [ $$failed -gt 0 ]; then exit 1; fi
 	# NOTE: If you also want to run orquesta tests which seem to have a bunch of race conditions, use
 	# ci-integration-full target
 #	@echo

--- a/Makefile
+++ b/Makefile
@@ -940,21 +940,22 @@ endif
 		echo "==========================================================="; \
 	done; \
 	if [ $$failed -gt 0 ]; then exit 1; fi
-	@echo
-	@echo "============== runners integration tests with coverage =============="
-	@echo
-	@echo "The tests assume st2 is running on 127.0.0.1."
-	@failed=0; \
-	for component in $(COMPONENTS_RUNNERS); do\
-		echo "==========================================================="; \
-		echo "Running integration tests in" $$component; \
-		echo "==========================================================="; \
-		. $(VIRTUALENV_DIR)/bin/activate; \
-		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
-			nosetests $(NOSE_OPTS) -s -v \
-			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
-	done; \
-	if [ $$failed -gt 0 ]; then exit 1; fi
+# COMPONTENTS_RUNNERS is included in COMPONENTS_TEST, so this just duplicates running the runner integration tests!
+#	@echo
+#	@echo "============== runners integration tests with coverage =============="
+#	@echo
+#	@echo "The tests assume st2 is running on 127.0.0.1."
+#	@failed=0; \
+#	for component in $(COMPONENTS_RUNNERS); do\
+#		echo "==========================================================="; \
+#		echo "Running integration tests in" $$component; \
+#		echo "==========================================================="; \
+#		. $(VIRTUALENV_DIR)/bin/activate; \
+#		    COVERAGE_FILE=.coverage.integration.$$(echo $$component | tr '/' '.') \
+#			nosetests $(NOSE_OPTS) -s -v \
+#			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
+#	done; \
+#	if [ $$failed -gt 0 ]; then exit 1; fi
 	# NOTE: If you also want to run orquesta tests which seem to have a bunch of race conditions, use
 	# ci-integration-full target
 #	@echo

--- a/Makefile
+++ b/Makefile
@@ -938,7 +938,7 @@ endif
 		echo "-----------------------------------------------------------"; \
 		echo "Done integration running tests in" $$component; \
 		echo "==========================================================="; \
-	done \
+	done; \
 	if [ $$failed -gt 0 ]; then exit 1; fi
 	@echo
 	@echo "============== runners integration tests with coverage =============="

--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,7 @@ unit-tests: requirements .unit-tests
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: .run-unit-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -856,7 +856,7 @@ endif
 		echo "Done running tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: .combine-unit-tests-coverage
 .combine-unit-tests-coverage: .run-unit-tests-coverage
@@ -913,7 +913,7 @@ itests: requirements .itests
 		echo "Done running integration tests in" $$component; \
 		echo "==========================================================="; \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: .run-integration-tests-coverage
 ifdef INCLUDE_TESTS_IN_COVERAGE
@@ -939,7 +939,7 @@ endif
 		echo "Done integration running tests in" $$component; \
 		echo "==========================================================="; \
 	done \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 	@echo
 	@echo "============== runners integration tests with coverage =============="
 	@echo
@@ -954,7 +954,7 @@ endif
 			nosetests $(NOSE_OPTS) -s -v \
 			$(NOSE_COVERAGE_FLAGS) $(NOSE_COVERAGE_PACKAGES) $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 	# NOTE: If you also want to run orquesta tests which seem to have a bunch of race conditions, use
 	# ci-integration-full target
 #	@echo
@@ -1088,7 +1088,7 @@ runners-tests: requirements .runners-tests
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/unit || ((failed+=1)); \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: runners-itests
 runners-itests: requirements .runners-itests
@@ -1106,7 +1106,7 @@ runners-itests: requirements .runners-itests
 		echo "==========================================================="; \
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: .runners-itests-coverage-html
 .runners-itests-coverage-html:
@@ -1122,7 +1122,7 @@ runners-itests: requirements .runners-itests
 		. $(VIRTUALENV_DIR)/bin/activate; nosetests $(NOSE_OPTS) -s -v --with-coverage \
 			--cover-inclusive --cover-html $$component/tests/integration || ((failed+=1)); \
 	done; \
-	if [ $failed -gt 0 ]; then exit 1; done
+	if [ $$failed -gt 0 ]; then exit 1; done
 
 .PHONY: cli
 cli:


### PR DESCRIPTION
- Do more of the tests before quitting
- drop duplicate test runs from Makefile

We already run nosetest so it doesn't stop on failure. But we run nosetest in a loop, and the loop exits on the first failure. So, CI is not providing a complete set of failures right now.

Fix this by delaying exit with failure till all components have been tested.

Also, stop running runner integration tests twice. Looping over `COMPONENTS_RUNNERS` is not helpful because runners are already included in `COMPONENTS_TEST` which is done first. Drop these duplicate trst runs to save CI time.
