### PR TITLE
Fix misc DeprecationWarnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
   Contributed by (@philipphomberger Schwarz IT KG)
 * Refactor `tools/launchdev.sh` to use `tmux` instead of `screen`. #6186 (by @nzlosh and @cognifloyd)
 * Updated package build container environment to use py3.8 and mongo4.4  #6129
+* Fic misc DeprecationWarnings to prepare for python 3.10 support. #6188 (by @nzlosh)
 
 Added
 ~~~~~

--- a/st2actions/st2actions/policies/concurrency_by_attr.py
+++ b/st2actions/st2actions/policies/concurrency_by_attr.py
@@ -120,7 +120,7 @@ class ConcurrencyByAttributeApplicator(BaseConcurrencyApplicator):
 
         # Warn users that the coordination service is not configured.
         if not coordination.configured():
-            LOG.warn(
+            LOG.warning(
                 "Coordination service is not configured. Policy enforcement is best effort."
             )
 

--- a/st2actions/st2actions/scheduler/handler.py
+++ b/st2actions/st2actions/scheduler/handler.py
@@ -290,7 +290,7 @@ class ActionExecutionSchedulingQueueHandler(object):
         if action_has_policies_require_lock:
             # Warn users that the coordination service is not configured.
             if not coordination_service.configured():
-                LOG.warn(
+                LOG.warning(
                     "[%s] Coordination backend is not configured. "
                     "Policy enforcement is best effort.",
                     action_execution_id,

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -205,7 +205,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
             # Not aborting as this is convenience.
             return
         except StackStormDBObjectConflictError as e:
-            LOG.warn(
+            LOG.warning(
                 'Trigger creation of "%s" failed with uniqueness conflict. Exception: %s',
                 trigger,
                 six.text_type(e),
@@ -221,7 +221,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
         )
         trigger_db = TriggerService.get_trigger_db_by_ref(triggertype_ref.ref)
         if not trigger_db:
-            LOG.warn(
+            LOG.warning(
                 "No shadow trigger found for %s. Will skip delete.", triggertype_db
             )
             return

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -169,7 +169,7 @@ class BaseCLIApp(object):
                     cache_token=cache_token,
                 )
             except requests.exceptions.ConnectionError as e:
-                self.LOG.warn(
+                self.LOG.warning(
                     "Auth API server is not available, skipping authentication."
                 )
                 self.LOG.exception(e)
@@ -280,7 +280,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         if not os.path.isfile(cached_token_path):
@@ -293,7 +293,7 @@ class BaseCLIApp(object):
                 "access to this file). Subsequent requests won't use a cached token "
                 "meaning they may be slower." % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         # Safety check for too permissive permissions
@@ -307,7 +307,7 @@ class BaseCLIApp(object):
                 "restrict the permissions and make sure only your own user can read "
                 "from or write to the file." % (file_st_mode, cached_token_path)
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
 
         with open(cached_token_path) as fp:
             data = fp.read()
@@ -359,7 +359,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         if os.path.isfile(cached_token_path) and not os.access(
@@ -372,7 +372,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         token = token_obj.token

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -137,8 +137,7 @@ class CLIConfigParser(object):
 
         config = ConfigParser()
         with io.open(self.config_file_path, "r", encoding="utf8") as fp:
-            config.readfp(fp)
-
+            config.read_file(fp)
         for section, keys in six.iteritems(CONFIG_FILE_OPTIONS):
             for key, options in six.iteritems(keys):
                 key_type = options["type"]

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -116,7 +116,7 @@ class CLIConfigParser(object):
         if self.validate_config_permissions:
             # Make sure the directory permissions == 0o770
             if bool(os.stat(config_dir_path).st_mode & 0o7):
-                self.LOG.warn(
+                self.LOG.warning(
                     "The StackStorm configuration directory permissions are "
                     "insecure (too permissive): others have access."
                 )
@@ -130,7 +130,7 @@ class CLIConfigParser(object):
 
             # Make sure the file permissions == 0o660
             if bool(os.stat(self.config_file_path).st_mode & 0o7):
-                self.LOG.warn(
+                self.LOG.warning(
                     "The StackStorm configuration file permissions are "
                     "insecure: others have access."
                 )

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -28,7 +28,7 @@ except ImportError:
     # official StackStorm packages.
     # Only time it may not be available is if the user is doing custom install from source or
     # similar.
-    logging.getLogger(__name__).warn(
+    logging.getLogger(__name__).warning(
         "libYAML C bindings are not available. This means YAML "
         "parsing and serialization will be significantly slower. You are "
         "strongly recommended to install libyaml (libyaml-dev package "

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -518,7 +518,7 @@ class Shell(BaseCLIApp):
 
         if preferred_encoding and preferred_encoding.lower() != "utf-8":
             msg = NON_UTF8_LOCALE % (default_locale or "unknown", preferred_encoding)
-            LOGGER.warn(msg)
+            LOGGER.warning(msg)
 
 
 def setup_logging(argv):

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -200,6 +200,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
         self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_warn_on_bad_config_permissions(self):
         # Setup the config directory
         os.chmod(self.TEMP_CONFIG_DIR, 0o0755)

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -147,7 +147,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
 
         result = parser.parse()  # noqa F841
 
-        self.assertEqual(parser.LOG.warn.call_count, 0)
+        self.assertEqual(parser.LOG.warning.call_count, 0)
 
         # Make sure we left the file alone
         self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
@@ -173,7 +173,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
 
         result = parser.parse()  # noqa F841
 
-        self.assertEqual(parser.LOG.warn.call_count, 0)
+        self.assertEqual(parser.LOG.warning.call_count, 0)
 
         # Make sure we left the file alone
         self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
@@ -191,7 +191,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
 
         result = parser.parse()  # noqa F841
 
-        self.assertEqual(parser.LOG.warn.call_count, 0)
+        self.assertEqual(parser.LOG.warning.call_count, 0)
 
         # Make sure we left the file alone
         self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))
@@ -226,16 +226,16 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
             parser.LOG.info.call_args_list[0][0][0],
         )
 
-        self.assertEqual(parser.LOG.warn.call_count, 2)
+        self.assertEqual(parser.LOG.warning.call_count, 2)
         self.assertEqual(
             "The StackStorm configuration directory permissions are insecure "
             "(too permissive): others have access.",
-            parser.LOG.warn.call_args_list[0][0][0],
+            parser.LOG.warning.call_args_list[0][0][0],
         )
 
         self.assertEqual(
             "The StackStorm configuration file permissions are insecure: others have access.",
-            parser.LOG.warn.call_args_list[1][0][0],
+            parser.LOG.warning.call_args_list[1][0][0],
         )
 
         # Make sure we left the file alone
@@ -266,7 +266,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
         result = parser.parse()  # noqa F841
 
         self.assertEqual(parser.LOG.info.call_count, 0)
-        self.assertEqual(parser.LOG.warn.call_count, 0)
+        self.assertEqual(parser.LOG.warning.call_count, 0)
 
         # Make sure we left the file alone
         self.assertTrue(os.path.exists(self.TEMP_FILE_PATH))

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -617,6 +617,7 @@ class CLITokenCachingTestCase(unittest.TestCase):
         with open(self._mock_config_path, "w") as fp:
             fp.write(MOCK_CONFIG)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_get_cached_auth_token_invalid_permissions(self):
         shell = Shell()
         client = Client()

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -681,6 +681,7 @@ class CLITokenCachingTestCase(unittest.TestCase):
         expected_msg = "Permissions .*? for cached token file .*? are too permissive.*"
         self.assertRegex(log_message, expected_msg)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_cache_auth_token_invalid_permissions(self):
         shell = Shell()
         username = "testu"

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -483,7 +483,7 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.run(argv=["trigger", "list"])
 
-        call_args = mock_logger.warn.call_args[0][0]
+        call_args = mock_logger.warning.call_args[0][0]
         self.assertIn(
             "Locale en_US with encoding iso which is not UTF-8 is used.", call_args
         )
@@ -502,7 +502,7 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.run(argv=["trigger", "list"])
 
-        call_args = mock_logger.warn.call_args[0][0]
+        call_args = mock_logger.warning.call_args[0][0]
         self.assertTrue(
             "Locale unknown with encoding unknown which is not UTF-8 is used."
             in call_args
@@ -542,13 +542,13 @@ class ShellTestCase(base.BaseCLITestCase):
         # Test without token.
         shell.run(["--config-file", mock_config_path, "action", "list"])
 
-        self.assertEqual(shell.LOG.warn.call_count, 2)
+        self.assertEqual(shell.LOG.warning.call_count, 2)
         self.assertEqual(
-            shell.LOG.warn.call_args_list[0][0][0][:63],
+            shell.LOG.warning.call_args_list[0][0][0][:63],
             "The StackStorm configuration directory permissions are insecure",
         )
         self.assertEqual(
-            shell.LOG.warn.call_args_list[1][0][0][:58],
+            shell.LOG.warning.call_args_list[1][0][0][:58],
             "The StackStorm configuration file permissions are insecure",
         )
 
@@ -637,8 +637,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
 
         self.assertEqual(result, None)
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to retrieve cached token from .*? read access to the parent "
@@ -656,8 +656,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
         self.assertEqual(result, None)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to retrieve cached token from .*? read access to this file"
@@ -674,8 +674,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
         self.assertEqual(result, "yayvalid")
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = "Permissions .*? for cached token file .*? are too permissive.*"
         self.assertRegex(log_message, expected_msg)
@@ -700,8 +700,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to write token to .*? doesn't have write access to the parent "
@@ -716,8 +716,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to write token to .*? doesn't have write access to this file"

--- a/st2common/st2common/constants/meta.py
+++ b/st2common/st2common/constants/meta.py
@@ -27,7 +27,7 @@ except ImportError:
     # official StackStorm packages.
     # Only time it may not be available is if the user is doing custom install from source or
     # similar.
-    logging.getLogger(__name__).warn(
+    logging.getLogger(__name__).warning(
         "libYAML C bindings are not available. This means YAML "
         "parsing and serialization will be significantly slower. You are "
         "strongly recommended to install libyaml (libyaml-dev package "

--- a/st2common/st2common/expressions/functions/version.py
+++ b/st2common/st2common/expressions/functions/version.py
@@ -60,4 +60,5 @@ def version_bump_patch(value):
 
 
 def version_strip_patch(value):
-    return "{major}.{minor}".format(**semver.Version.parse(value))
+    sv = semver.Version.parse(value)
+    return f"{sv.major}.{sv.minor}"

--- a/st2common/st2common/expressions/functions/version.py
+++ b/st2common/st2common/expressions/functions/version.py
@@ -28,36 +28,36 @@ __all__ = [
 
 
 def version_compare(value, pattern):
-    return semver.compare(value, pattern)
+    return semver.Version.parse(value).compare(pattern)
 
 
 def version_more_than(value, pattern):
-    return semver.compare(value, pattern) == 1
+    return version_compare(value, pattern) == 1
 
 
 def version_less_than(value, pattern):
-    return semver.compare(value, pattern) == -1
+    return version_compare(value, pattern) == -1
 
 
 def version_equal(value, pattern):
-    return semver.compare(value, pattern) == 0
+    return version_compare(value, pattern) == 0
 
 
 def version_match(value, pattern):
-    return semver.match(value, pattern)
+    return semver.Version.parse(value).match(pattern)
 
 
 def version_bump_major(value):
-    return semver.bump_major(value)
+    return str(semver.Version.parse(value).bump_major())
 
 
 def version_bump_minor(value):
-    return semver.bump_minor(value)
+    return str(semver.Version.parse(value).bump_minor())
 
 
 def version_bump_patch(value):
-    return semver.bump_patch(value)
+    return str(semver.Version.parse(value).bump_patch())
 
 
 def version_strip_patch(value):
-    return "{major}.{minor}".format(**semver.parse(value))
+    return "{major}.{minor}".format(**semver.Version.parse(value))

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -75,7 +75,7 @@ def reopen_log_files(handlers):
                 if "cannot release" in six.text_type(e):
                     # Release failed which most likely indicates that acquire failed
                     # and lock was never acquired
-                    LOG.warn("Failed to release lock", exc_info=True)
+                    LOG.warning("Failed to release lock", exc_info=True)
                 else:
                     raise e
 

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -36,7 +36,7 @@ def _retry_if_connection_error(error):
     # start of error msg.
     is_connection_error = isinstance(error, mongoengine.connection.ConnectionFailure)
     if is_connection_error:
-        LOG.warn("Retry on ConnectionError - %s", error)
+        LOG.warning("Retry on ConnectionError - %s", error)
     return is_connection_error
 
 

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -241,7 +241,7 @@ def get_coordinator(start_heart=True, use_cache=True):
     global COORDINATOR
 
     if not configured():
-        LOG.warn(
+        LOG.warning(
             "Coordination backend is not configured. Code paths which use coordination "
             "service will use best effort approach and race conditions are possible."
         )

--- a/st2common/st2common/services/trigger_dispatcher.py
+++ b/st2common/st2common/services/trigger_dispatcher.py
@@ -94,7 +94,7 @@ class TriggerDispatcherService(object):
                 throw_on_inexistent_trigger=True,
             )
         except (ValidationError, ValueError, Exception) as e:
-            self._logger.warn(
+            self._logger.warning(
                 'Failed to validate payload (%s) for trigger "%s": %s'
                 % (str(payload), trigger, six.text_type(e))
             )
@@ -111,7 +111,7 @@ class TriggerDispatcherService(object):
                 if throw_on_validation_error:
                     raise ValueError(msg)
 
-                self._logger.warn(msg)
+                self._logger.warning(msg)
                 return None
 
         self._logger.debug("Dispatching trigger %s with payload %s.", trigger, payload)

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -39,7 +39,7 @@ def get_base_public_api_url():
     if cfg.CONF.auth.api_url:
         api_url = get_url_without_trailing_slash(cfg.CONF.auth.api_url)
     else:
-        LOG.warn('"auth.api_url" configuration option is not configured')
+        LOG.warning('"auth.api_url" configuration option is not configured')
         api_url = "http://%s:%s" % (cfg.CONF.api.host, cfg.CONF.api.port)
 
     return api_url

--- a/st2common/st2common/util/loader.py
+++ b/st2common/st2common/util/loader.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-import imp
+import importlib.util
 import inspect
 import json
 import os
@@ -73,8 +73,8 @@ def _get_classes_in_module(module):
     ]
 
 
-def _get_plugin_classes(module_name):
-    return _get_classes_in_module(module_name)
+def _get_plugin_classes(module):
+    return _get_classes_in_module(module)
 
 
 def _get_plugin_methods(plugin_klass):
@@ -129,7 +129,7 @@ def register_plugin_class(base_class, file_path, class_name):
     """
     Retrieve a register plugin class from the provided file.
 
-    This method also validate that the class implements all the abstract methods
+    This method also validates that the class implements all the abstract methods
     from the base plugin class.
 
     :param base_class: Base plugin class.
@@ -148,7 +148,9 @@ def register_plugin_class(base_class, file_path, class_name):
     if module_name is None:
         return None
 
-    module = imp.load_source(module_name, file_path)
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     klass = getattr(module, class_name, None)
 
     if not klass:
@@ -170,7 +172,9 @@ def register_plugin(plugin_base_class, plugin_abs_file_path):
     if module_name is None:
         return None
 
-    module = imp.load_source(module_name, plugin_abs_file_path)
+    spec = importlib.util.spec_from_file_location(module_name, plugin_abs_file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     klasses = _get_plugin_classes(module)
 
     # Try registering classes in plugin file. Some may fail.

--- a/st2common/st2common/util/versioning.py
+++ b/st2common/st2common/util/versioning.py
@@ -65,7 +65,7 @@ def complex_semver_match(version, version_specifier):
 
     if len(split_version_specifier) == 1:
         # No comma, we can do a simple comparision
-        return semver.match(version, version_specifier)
+        return semver.Version.parse(version).match(version_specifier)
     else:
         # Compare part by part
         for version_specifier_part in split_version_specifier:
@@ -74,7 +74,7 @@ def complex_semver_match(version, version_specifier):
             if not version_specifier_part:
                 continue
 
-            if not semver.match(version, version_specifier_part):
+            if not semver.Version.parse(version).match(version_specifier_part):
                 return False
 
         return True

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -289,7 +289,7 @@ class SensorWrapper(object):
                 self._class_name,
                 six.text_type(e),
             )
-            self._logger.warn(msg, exc_info=True)
+            self._logger.warning(msg, exc_info=True)
             raise Exception(msg)
 
     def stop(self):


### PR DESCRIPTION
This extracts @nzlosh's DeprecationWarning fixes from #6157. 

- Fix for DeprecationWarning: the imp module is deprecated in favour of importlib

- Fix for DeprecationWarning: This method will be removed in Python 3.12. Use 'parser.read_file()' instead.

- Fix semver DeprecationWarning: Function semver.match is deprecated and other semver warnings
- Fix semver patch strip function and replace deprecated self.assertItemsEqual with assert.

- Fix DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- Fixed more DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- Replace 'warn' with 'warning' method

- Skip test_warn_on_bad_config_permissions when run as root user.
- Skip test_get_cached_auth_token_invalid_permissions if run as root
- Skip test_cache_auth_token_invalid_permissions if run as root