### PR TITLE
Update st2client deps: editor and prompt-toolkit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
   Contributed by (@philipphomberger Schwarz IT KG)
 * Refactor `tools/launchdev.sh` to use `tmux` instead of `screen`. #6186 (by @nzlosh and @cognifloyd)
 * Updated package build container environment to use py3.8 and mongo4.4  #6129
+* Update st2client deps: editor and prompt-toolkit. #6189 (by @nzlosh)
 
 Added
 ~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -53,7 +53,7 @@ python-keyczar==0.716
 pytz==2024.1
 pywinrm==0.4.3
 pyyaml==6.0.1
-redis==5.0.3
+redis==5.0.4
 requests==2.31.0
 retrying==1.3.4
 routes==2.5.1
@@ -70,9 +70,9 @@ stevedore==5.2.0
 tenacity==8.2.3
 tooz==6.1.0
 # Note: virtualenv embeds wheels for pip, wheel, and setuptools. So pinning virtualenv pins those as well.
-# virtualenv==20.25.1 (<21) has pip==24.0 wheel==0.42.0 setuptools==68.0.0 and 69.1.0
+# virtualenv==20.26.0 (<21) has pip==24.0 wheel==0.43.0 setuptools==69.5.1
 # lockfiles/st2.lock has pip==24.0 wheel==0.43.0 setuptools==69.2.0
-virtualenv==20.25.3
+virtualenv==20.26.0
 webob==1.8.7
 zake==0.2.2
 # test requirements below

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -48,7 +48,7 @@ zstandard==0.22.0
 # 202403: switch from python-editor to editor for py3.10 support
 editor==1.6.6
 # editor dependency, required here for inclusion in st2client setup.py
-Pygments==2.5.2
+pygments==2.5.2
 python-keyczar==0.716
 pytz==2024.1
 pywinrm==0.4.3

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -37,8 +37,8 @@ oslo.utils==7.1.0
 # paramiko 2.11.0 is needed by cryptography > 37.0.0
 paramiko==3.4.0
 passlib==1.7.4
-# For st2client: prompt-toolkit v2+ does not have prompt_toolkit.token.Token
-prompt-toolkit==1.0.18
+# 202403: bump to 3.0.43 for py3.10 support
+prompt-toolkit==3.0.43
 pyinotify==0.9.6 ; platform_system=="Linux"
 pymongo==3.12.3
 pyparsing==3.1.2

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -48,7 +48,7 @@ zstandard==0.22.0
 # 202403: switch from python-editor to editor for py3.10 support
 editor==1.6.6
 # editor dependency, required here for inclusion in st2client setup.py
-pygments==2.5.2
+pygments==2.17.2
 python-keyczar==0.716
 pytz==2024.1
 pywinrm==0.4.3

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -45,7 +45,8 @@ pyparsing==3.1.2
 zstandard==0.22.0
 # pyOpenSSL 23.1.0 supports cryptography up to 40.0.x
 #pyOpenSSL==23.1.0
-python-editor==1.0.4
+# 202403: switch from python-editor to editor for py3.10 support
+editor==1.6.6
 python-keyczar==0.716
 pytz==2024.1
 pywinrm==0.4.3

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -47,6 +47,8 @@ zstandard==0.22.0
 #pyOpenSSL==23.1.0
 # 202403: switch from python-editor to editor for py3.10 support
 editor==1.6.6
+# editor dependency, required here for inclusion in st2client setup.py
+Pygments==2.5.2
 python-keyczar==0.716
 pytz==2024.1
 pywinrm==0.4.3

--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -16,6 +16,7 @@
 //     "beautifulsoup4",
 //     "ciso8601",
 //     "cryptography",
+//     "editor",
 //     "eventlet",
 //     "flask",
 //     "flex",
@@ -45,15 +46,15 @@
 //     "pip",
 //     "prance",
 //     "prettytable",
-//     "prompt-toolkit<2",
+//     "prompt-toolkit",
 //     "psutil",
+//     "pygments",
 //     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
 //     "pymongo<3.13.0,>=3.11.0",
 //     "pyrabbit",
 //     "pysocks",
 //     "pytest",
 //     "python-dateutil",
-//     "python-editor",
 //     "python-json-logger",
 //     "python-statsd",
 //     "pytz",
@@ -1072,6 +1073,27 @@
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
           "version": "1.16.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf",
+              "url": "https://files.pythonhosted.org/packages/1b/c2/4bc8cd09b14e28ce3f406a8b05761bed0d785d1ca8c2a5c6684d884c66a2/editor-1.6.6-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8",
+              "url": "https://files.pythonhosted.org/packages/2a/92/734a4ab345914259cb6146fd36512608ea42be16195375c379046f33283d/editor-1.6.6.tar.gz"
+            }
+          ],
+          "project_name": "editor",
+          "requires_dists": [
+            "runs",
+            "xmod"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.6.6"
         },
         {
           "artifacts": [
@@ -2623,13 +2645,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
-              "url": "https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl"
+              "hash": "17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1",
+              "url": "https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768",
-              "url": "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz"
+              "hash": "031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf",
+              "url": "https://files.pythonhosted.org/packages/b2/e4/2856bf61e54d7e3a03dd00d0c1b5fa86e6081e8f262eb91befbe64d20937/platformdirs-4.2.1.tar.gz"
             }
           ],
           "project_name": "platformdirs",
@@ -2637,6 +2659,7 @@
             "appdirs==1.4.4; extra == \"test\"",
             "covdefaults>=2.3; extra == \"test\"",
             "furo>=2023.9.10; extra == \"docs\"",
+            "mypy>=1.8; extra == \"type\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4.1; extra == \"test\"",
             "pytest-mock>=3.12; extra == \"test\"",
@@ -2645,19 +2668,19 @@
             "sphinx>=7.2.6; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "4.2.0"
+          "version": "4.2.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-              "url": "https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl"
+              "hash": "44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669",
+              "url": "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be",
-              "url": "https://files.pythonhosted.org/packages/54/c6/43f9d44d92aed815e781ca25ba8c174257e27253a94630d21be8725a2b59/pluggy-1.4.0.tar.gz"
+              "hash": "2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+              "url": "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz"
             }
           ],
           "project_name": "pluggy",
@@ -2668,7 +2691,7 @@
             "tox; extra == \"dev\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.4.0"
+          "version": "1.5.0"
         },
         {
           "artifacts": [
@@ -2750,22 +2773,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "37925b37a4af1f6448c76b7606e0285f79f434ad246dda007a27411cca730c6d",
-              "url": "https://files.pythonhosted.org/packages/64/27/5fd61a451d086ad4aa806dc72fe1383d2bc0e74323668672287f616d5d51/prompt_toolkit-1.0.18-py3-none-any.whl"
+              "hash": "a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6",
+              "url": "https://files.pythonhosted.org/packages/ee/fd/ca7bf3869e7caa7a037e23078539467b433a4e01eebd93f77180ab927766/prompt_toolkit-3.0.43-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd4fca02c8069497ad931a2d09914c6b0d1b50151ce876bc15bde4c747090126",
-              "url": "https://files.pythonhosted.org/packages/c5/64/c170e5b1913b540bf0c8ab7676b21fdd1d25b65ddeb10025c6ca43cccd4c/prompt_toolkit-1.0.18.tar.gz"
+              "hash": "3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d",
+              "url": "https://files.pythonhosted.org/packages/cc/c6/25b6a3d5cd295304de1e32c9edbcf319a52e965b339629d37d42bb7126ca/prompt_toolkit-3.0.43.tar.gz"
             }
           ],
           "project_name": "prompt-toolkit",
           "requires_dists": [
-            "six>=1.9.0",
             "wcwidth"
           ],
-          "requires_python": null,
-          "version": "1.0.18"
+          "requires_python": ">=3.7.0",
+          "version": "3.0.43"
         },
         {
           "artifacts": [
@@ -2861,6 +2883,27 @@
           "requires_dists": [],
           "requires_python": ">=3.8",
           "version": "2.22"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c",
+              "url": "https://files.pythonhosted.org/packages/97/9c/372fef8377a6e340b1704768d20daaded98bf13282b5327beb2e2fe2c7ef/pygments-2.17.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367",
+              "url": "https://files.pythonhosted.org/packages/55/59/8bccf4157baf25e4aa5a0bb7fa3ba8600907de105ebc22b0c78cfbf6f565/pygments-2.17.2.tar.gz"
+            }
+          ],
+          "project_name": "pygments",
+          "requires_dists": [
+            "colorama>=0.4.6; extra == \"windows-terminal\"",
+            "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.17.2"
         },
         {
           "artifacts": [
@@ -3295,24 +3338,6 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
-              "url": "https://files.pythonhosted.org/packages/c6/d3/201fc3abe391bbae6606e6f1d598c15d367033332bd54352b12f35513717/python_editor-1.0.4-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
-              "url": "https://files.pythonhosted.org/packages/0a/85/78f4a216d28343a67b7397c99825cff336330893f00601443f7c7b2f2234/python-editor-1.0.4.tar.gz"
-            }
-          ],
-          "project_name": "python-editor",
-          "requires_dists": [],
-          "requires_python": null,
-          "version": "1.0.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
               "hash": "f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd",
               "url": "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl"
             },
@@ -3498,13 +3523,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5da9b8fe9e1254293756c16c008e8620b3d15fcc6dde6babde9541850e72a32d",
-              "url": "https://files.pythonhosted.org/packages/bb/f1/a384c5582d9a28e4a02eb1a2c279668053dd09aafeb08d2bd4dd323fc466/redis-5.0.3-py3-none-any.whl"
+              "hash": "7adc2835c7a9b5033b7ad8f8918d09b7344188228809c98df07af226d39dec91",
+              "url": "https://files.pythonhosted.org/packages/65/f2/540ad07910732733138beb192991c67c69e7f6ebf549ce1a3a77846cbae7/redis-5.0.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4973bae7444c0fbed64a06b87446f79361cb7e4ec1538c022d696ed7a5015580",
-              "url": "https://files.pythonhosted.org/packages/eb/fc/8e822fd1e0a023c5ff80ca8c469b1d854c905ebb526ba38a90e7487c9897/redis-5.0.3.tar.gz"
+              "hash": "ec31f2ed9675cc54c21ba854cfe0462e6faf1d83c8ce5944709db8a4700b9c61",
+              "url": "https://files.pythonhosted.org/packages/cd/9c/1d57b0f61402aabdd9c3b2882e3fddd86a269c1df2cfd2e77daa607ef047/redis-5.0.4.tar.gz"
             }
           ],
           "project_name": "redis",
@@ -3518,7 +3543,7 @@
             "typing-extensions; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "5.0.3"
+          "version": "5.0.4"
         },
         {
           "artifacts": [
@@ -3763,6 +3788,26 @@
           "requires_dists": [],
           "requires_python": ">=3.6",
           "version": "0.2.8"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0980dcbc25aba1505f307ac4f0e9e92cbd0be2a15a1e983ee86c24c87b839dfd",
+              "url": "https://files.pythonhosted.org/packages/86/d6/17caf2e4af1dec288477a0cbbe4a96fbc9b8a28457dce3f1f452630ce216/runs-1.2.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9dc1815e2895cfb3a48317b173b9f1eac9ba5549b36a847b5cc60c3bf82ecef1",
+              "url": "https://files.pythonhosted.org/packages/26/6d/b9aace390f62db5d7d2c77eafce3d42774f27f1829d24fa9b6f598b3ef71/runs-1.2.2.tar.gz"
+            }
+          ],
+          "project_name": "runs",
+          "requires_dists": [
+            "xmod"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.2.2"
         },
         {
           "artifacts": [
@@ -4509,13 +4554,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8aac4332f2ea6ef519c648d0bc48a5b1d324994753519919bddbb1aff25a104e",
-              "url": "https://files.pythonhosted.org/packages/cd/8a/709e9994dc2f9705d1127c63b64151582655e02c953e163b317803864fc0/virtualenv-20.25.3-py3-none-any.whl"
+              "hash": "0846377ea76e818daaa3e00a4365c018bc3ac9760cbb3544de542885aad61fb3",
+              "url": "https://files.pythonhosted.org/packages/fa/80/4230da6f5898d50c427591d81c4ca154c19ff3ea789266affcd9a770ed3d/virtualenv-20.26.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bb554bbdfeaacc3349fa614ea5bff6ac300fc7c335e9facf3a3bcfc703f45be",
-              "url": "https://files.pythonhosted.org/packages/42/28/846fb3eb75955d191f13bca658fb0082ddcef8e2d4b6fd0c76146556f0be/virtualenv-20.25.3.tar.gz"
+              "hash": "ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210",
+              "url": "https://files.pythonhosted.org/packages/d8/02/0737e7aca2f7df4a7e4bfcd4de73aaad3ae6465da0940b77d222b753b474/virtualenv-20.26.0.tar.gz"
             }
           ],
           "project_name": "virtualenv",
@@ -4545,7 +4590,7 @@
             "towncrier>=23.6; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "20.25.3"
+          "version": "20.26.0"
         },
         {
           "artifacts": [
@@ -4827,6 +4872,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "a24e9458a4853489042522bdca9e50ee2eac5ab75c809a91150a8a7f40670d48",
+              "url": "https://files.pythonhosted.org/packages/33/6b/0dc75b64a764ea1cb8e4c32d1fb273c147304d4e5483cd58be482dc62e45/xmod-1.8.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "38c76486b9d672c546d57d8035df0beb7f4a9b088bc3fb2de5431ae821444377",
+              "url": "https://files.pythonhosted.org/packages/72/b2/e3edc608823348e628a919e1d7129e641997afadd946febdd704aecc5881/xmod-1.8.1.tar.gz"
+            }
+          ],
+          "project_name": "xmod",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "1.8.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "20f7c16485b31721e2c0ef75e990d613b72a2912d001dcc8e9a85d4934499122",
               "url": "https://files.pythonhosted.org/packages/d1/4c/55a6629d077ae297472312c0a4bcfbea42f99bb11be3c64eb38c77857701/yaql-3.0.0-py3-none-any.whl"
             },
@@ -5004,6 +5067,7 @@
     "beautifulsoup4",
     "ciso8601",
     "cryptography",
+    "editor",
     "eventlet",
     "flask",
     "flex",
@@ -5033,15 +5097,15 @@
     "pip",
     "prance",
     "prettytable",
-    "prompt-toolkit<2",
+    "prompt-toolkit",
     "psutil",
+    "pygments",
     "pyinotify<=0.10,>=0.9.5; platform_system == \"Linux\"",
     "pymongo<3.13.0,>=3.11.0",
     "pyrabbit",
     "pysocks",
     "pytest",
     "python-dateutil",
-    "python-editor",
     "python-json-logger",
     "python-statsd",
     "pytz",

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -50,6 +50,7 @@ pyrabbit
 pytest
 python-dateutil
 editor
+Pygments
 # pythonjsonlogger referenced in st2actions/conf/logging.conf
 python-json-logger
 python-statsd

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -41,8 +41,7 @@ pip
 # prance needs flex, but do not use the extra as that gets an old version.
 prance
 prettytable
-# For st2client: prompt-toolkit v2+ does not have prompt_toolkit.token.Token
-prompt-toolkit<2
+prompt-toolkit
 psutil
 # pymongo 3.13 has backports of APIs from pymongo 4 to help w/ migration
 pymongo>=3.11.0,<3.13.0
@@ -50,7 +49,7 @@ pymongo>=3.11.0,<3.13.0
 pyrabbit
 pytest
 python-dateutil
-python-editor
+editor
 # pythonjsonlogger referenced in st2actions/conf/logging.conf
 python-json-logger
 python-statsd

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -50,7 +50,7 @@ pyrabbit
 pytest
 python-dateutil
 editor
-Pygments
+pygments
 # pythonjsonlogger referenced in st2actions/conf/logging.conf
 python-json-logger
 python-statsd

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -10,6 +10,7 @@ apscheduler
 argcomplete
 ciso8601
 cryptography
+editor
 eventlet
 # flex parses the openapi 2 spec in our router
 flex
@@ -43,14 +44,13 @@ prance
 prettytable
 prompt-toolkit
 psutil
+pygments
 # pymongo 3.13 has backports of APIs from pymongo 4 to help w/ migration
 pymongo>=3.11.0,<3.13.0
 # pyrabbit used in an integration test
 pyrabbit
 pytest
 python-dateutil
-editor
-pygments
 # pythonjsonlogger referenced in st2actions/conf/logging.conf
 python-json-logger
 python-statsd

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ ciso8601
 cryptography==42.0.5
 decorator==5.1.1
 dnspython==1.16.0
+editor==1.6.6
 eventlet==0.36.1
 flex==6.14.1
 gitdb==4.0.11
@@ -52,7 +53,6 @@ pyparsing==3.1.2
 pyrabbit
 pysocks
 python-dateutil==2.9.0
-python-editor==1.0.4
 python-json-logger
 python-statsd==2.1.0
 pytz==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ oslo.utils==7.1.0
 paramiko==3.4.0
 passlib==1.7.4
 prettytable==3.10.0
-prompt-toolkit==1.0.18
+prompt-toolkit==3.0.43
 psutil==5.9.8
 pyOpenSSL
 pyinotify==0.9.6 ; platform_system=="Linux"

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ prettytable==3.10.0
 prompt-toolkit==3.0.43
 psutil==5.9.8
 pyOpenSSL
+pygments==2.5.2
 pyinotify==0.9.6 ; platform_system=="Linux"
 pymongo==3.12.3
 pyparsing==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ python-statsd==2.1.0
 pytz==2024.1
 pywinrm==0.4.3
 pyyaml==6.0.1
-redis==5.0.3
+redis==5.0.4
 rednose
 requests==2.31.0
 retrying==1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ prettytable==3.10.0
 prompt-toolkit==3.0.43
 psutil==5.9.8
 pyOpenSSL
-pygments==2.5.2
+pygments==2.17.2
 pyinotify==0.9.6 ; platform_system=="Linux"
 pymongo==3.12.3
 pyparsing==3.1.2

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -12,7 +12,7 @@ jsonpath-rw
 requests
 six
 sseclient-py
-python-editor
+editor
 prompt-toolkit
 # mention cffi used by cryptography so we can control version
 cffi

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -13,6 +13,7 @@ requests
 six
 sseclient-py
 editor
+pygments
 prompt-toolkit
 # mention cffi used by cryptography so we can control version
 cffi

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -17,7 +17,7 @@ orjson==3.10.1
 prettytable==3.10.0
 prompt-toolkit==3.0.43
 pyOpenSSL
-pygments==2.5.2
+pygments==2.17.2
 pysocks
 python-dateutil==2.9.0
 pytz==2024.1

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -14,7 +14,7 @@ jsonpath-rw==1.4.0
 jsonschema==3.2.0
 orjson==3.10.1
 prettytable==3.10.0
-prompt-toolkit==1.0.18
+prompt-toolkit==3.0.43
 pyOpenSSL
 pysocks
 python-dateutil==2.9.0

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -17,6 +17,7 @@ orjson==3.10.1
 prettytable==3.10.0
 prompt-toolkit==3.0.43
 pyOpenSSL
+pygments==2.5.2
 pysocks
 python-dateutil==2.9.0
 pytz==2024.1

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -9,6 +9,7 @@ argcomplete==3.3.0
 cffi==1.16.0
 chardet==3.0.4
 cryptography==42.0.5
+editor==1.6.6
 importlib-metadata==7.1.0
 jsonpath-rw==1.4.0
 jsonschema==3.2.0
@@ -18,7 +19,6 @@ prompt-toolkit==3.0.43
 pyOpenSSL
 pysocks
 python-dateutil==2.9.0
-python-editor==1.0.4
 pytz==2024.1
 pyyaml==6.0.1
 requests==2.31.0

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -540,12 +540,9 @@ class PackConfigCommand(resource.ResourceCommand):
             message, {"default": "y", "description": description}
         )
         if preview_dialog.read() == "y":
-            try:
-                contents = yaml.safe_dump(config, indent=4, default_flow_style=False)
-                modified = editor.editor(text=contents)
-                config = yaml.safe_load(modified)
-            except editor.EditorError as e:
-                print(six.text_type(e))
+            contents = yaml.safe_dump(config, indent=4, default_flow_style=False)
+            modified = editor.editor(text=contents)
+            config = yaml.safe_load(modified)
 
         message = "---\nDo you want me to save it?"
         save_dialog = interactive.Question(message, {"default": "y"})

--- a/st2client/st2client/commands/pack.py
+++ b/st2client/st2client/commands/pack.py
@@ -542,7 +542,7 @@ class PackConfigCommand(resource.ResourceCommand):
         if preview_dialog.read() == "y":
             try:
                 contents = yaml.safe_dump(config, indent=4, default_flow_style=False)
-                modified = editor.edit(contents=contents)
+                modified = editor.editor(text=contents)
                 config = yaml.safe_load(modified)
             except editor.EditorError as e:
                 print(six.text_type(e))

--- a/st2client/st2client/utils/interactive.py
+++ b/st2client/st2client/utils/interactive.py
@@ -21,7 +21,7 @@ import six
 import jsonschema
 from jsonschema import Draft3Validator
 from prompt_toolkit import prompt
-from prompt_toolkit import token
+from pygments import token
 from prompt_toolkit import validation
 
 from st2client.exceptions.operations import OperationFailureException

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -35,7 +35,7 @@ pymongo==3.12.3
 python-dateutil==2.9.0
 python-statsd==2.1.0
 pyyaml==6.0.1
-redis==5.0.3
+redis==5.0.4
 requests==2.31.0
 retrying==1.3.4
 routes==2.5.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,6 +25,8 @@ nose-timer==1.0.1
 nose-parallel==0.4.0
 # Required by st2client tests
 pyyaml==6.0.1
+# Constrain pygments required by editor to align with st2 core version
+pygments==2.17.2
 RandomWords
 gunicorn==21.2.0
 psutil==5.8.0


### PR DESCRIPTION
This extracts @nzlosh's st2client requirements updates from #6157.

- Bump prompt-toolkit to 3.0.43 for py3.10 support
- Switch python-editor to editor for py3.10 support.
- Use pygment token in place of prompt_toolkit
- update pants requirements to align with fixed requirements
- Remove editor.EditorError since editor defaults to output redirection when binary not found.
- Update pygment to be included in st2client
- dependency tweak
- Update pygment pinning to avoid version conflicts in st2client.
- alphabetize requirements-pants.txt
- add changelog entry
- regenerate lockfiles/st2.lock
