### PR TITLE
Fix deprecated use of `logging.warn`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 * Drop Python 3.6 testing in CircleCI. #6080
   Contributed by (@philipphomberger Schwarz IT KG)
 * Refactor `tools/launchdev.sh` to use `tmux` instead of `screen`. #6186 (by @nzlosh and @cognifloyd)
+* Fic misc DeprecationWarnings to prepare for python 3.10 support. #6188 #6190 (by @nzlosh)
 
 Added
 ~~~~~

--- a/st2actions/st2actions/policies/concurrency_by_attr.py
+++ b/st2actions/st2actions/policies/concurrency_by_attr.py
@@ -120,7 +120,7 @@ class ConcurrencyByAttributeApplicator(BaseConcurrencyApplicator):
 
         # Warn users that the coordination service is not configured.
         if not coordination.configured():
-            LOG.warn(
+            LOG.warning(
                 "Coordination service is not configured. Policy enforcement is best effort."
             )
 

--- a/st2actions/st2actions/scheduler/handler.py
+++ b/st2actions/st2actions/scheduler/handler.py
@@ -290,7 +290,7 @@ class ActionExecutionSchedulingQueueHandler(object):
         if action_has_policies_require_lock:
             # Warn users that the coordination service is not configured.
             if not coordination_service.configured():
-                LOG.warn(
+                LOG.warning(
                     "[%s] Coordination backend is not configured. "
                     "Policy enforcement is best effort.",
                     action_execution_id,

--- a/st2api/st2api/controllers/v1/triggers.py
+++ b/st2api/st2api/controllers/v1/triggers.py
@@ -205,7 +205,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
             # Not aborting as this is convenience.
             return
         except StackStormDBObjectConflictError as e:
-            LOG.warn(
+            LOG.warning(
                 'Trigger creation of "%s" failed with uniqueness conflict. Exception: %s',
                 trigger,
                 six.text_type(e),
@@ -221,7 +221,7 @@ class TriggerTypeController(resource.ContentPackResourceController):
         )
         trigger_db = TriggerService.get_trigger_db_by_ref(triggertype_ref.ref)
         if not trigger_db:
-            LOG.warn(
+            LOG.warning(
                 "No shadow trigger found for %s. Will skip delete.", triggertype_db
             )
             return

--- a/st2client/st2client/base.py
+++ b/st2client/st2client/base.py
@@ -169,7 +169,7 @@ class BaseCLIApp(object):
                     cache_token=cache_token,
                 )
             except requests.exceptions.ConnectionError as e:
-                self.LOG.warn(
+                self.LOG.warning(
                     "Auth API server is not available, skipping authentication."
                 )
                 self.LOG.exception(e)
@@ -280,7 +280,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         if not os.path.isfile(cached_token_path):
@@ -293,7 +293,7 @@ class BaseCLIApp(object):
                 "access to this file). Subsequent requests won't use a cached token "
                 "meaning they may be slower." % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         # Safety check for too permissive permissions
@@ -307,7 +307,7 @@ class BaseCLIApp(object):
                 "restrict the permissions and make sure only your own user can read "
                 "from or write to the file." % (file_st_mode, cached_token_path)
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
 
         with open(cached_token_path) as fp:
             data = fp.read()
@@ -359,7 +359,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         if os.path.isfile(cached_token_path) and not os.access(
@@ -372,7 +372,7 @@ class BaseCLIApp(object):
                 "cached token meaning they may be slower."
                 % (cached_token_path, os.getlogin())
             )
-            self.LOG.warn(message)
+            self.LOG.warning(message)
             return None
 
         token = token_obj.token

--- a/st2client/st2client/config_parser.py
+++ b/st2client/st2client/config_parser.py
@@ -116,7 +116,7 @@ class CLIConfigParser(object):
         if self.validate_config_permissions:
             # Make sure the directory permissions == 0o770
             if bool(os.stat(config_dir_path).st_mode & 0o7):
-                self.LOG.warn(
+                self.LOG.warning(
                     "The StackStorm configuration directory permissions are "
                     "insecure (too permissive): others have access."
                 )
@@ -130,7 +130,7 @@ class CLIConfigParser(object):
 
             # Make sure the file permissions == 0o660
             if bool(os.stat(self.config_file_path).st_mode & 0o7):
-                self.LOG.warn(
+                self.LOG.warning(
                     "The StackStorm configuration file permissions are "
                     "insecure: others have access."
                 )

--- a/st2client/st2client/formatters/execution.py
+++ b/st2client/st2client/formatters/execution.py
@@ -28,7 +28,7 @@ except ImportError:
     # official StackStorm packages.
     # Only time it may not be available is if the user is doing custom install from source or
     # similar.
-    logging.getLogger(__name__).warn(
+    logging.getLogger(__name__).warning(
         "libYAML C bindings are not available. This means YAML "
         "parsing and serialization will be significantly slower. You are "
         "strongly recommended to install libyaml (libyaml-dev package "

--- a/st2client/st2client/shell.py
+++ b/st2client/st2client/shell.py
@@ -518,7 +518,7 @@ class Shell(BaseCLIApp):
 
         if preferred_encoding and preferred_encoding.lower() != "utf-8":
             msg = NON_UTF8_LOCALE % (default_locale or "unknown", preferred_encoding)
-            LOGGER.warn(msg)
+            LOGGER.warning(msg)
 
 
 def setup_logging(argv):

--- a/st2client/tests/unit/test_config_parser.py
+++ b/st2client/tests/unit/test_config_parser.py
@@ -200,6 +200,7 @@ class CLIConfigPermissionsTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(self.TEMP_CONFIG_DIR))
         self.assertEqual(os.stat(self.TEMP_CONFIG_DIR).st_mode & 0o7777, 0o2770)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_warn_on_bad_config_permissions(self):
         # Setup the config directory
         os.chmod(self.TEMP_CONFIG_DIR, 0o0755)

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -617,6 +617,7 @@ class CLITokenCachingTestCase(unittest.TestCase):
         with open(self._mock_config_path, "w") as fp:
             fp.write(MOCK_CONFIG)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_get_cached_auth_token_invalid_permissions(self):
         shell = Shell()
         client = Client()

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -681,6 +681,7 @@ class CLITokenCachingTestCase(unittest.TestCase):
         expected_msg = "Permissions .*? for cached token file .*? are too permissive.*"
         self.assertRegex(log_message, expected_msg)
 
+    @unittest.skipIf(os.getuid() == 0, reason="Test must be run as non-root user.")
     def test_cache_auth_token_invalid_permissions(self):
         shell = Shell()
         username = "testu"

--- a/st2client/tests/unit/test_shell.py
+++ b/st2client/tests/unit/test_shell.py
@@ -483,7 +483,7 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.run(argv=["trigger", "list"])
 
-        call_args = mock_logger.warn.call_args[0][0]
+        call_args = mock_logger.warning.call_args[0][0]
         self.assertIn(
             "Locale en_US with encoding iso which is not UTF-8 is used.", call_args
         )
@@ -502,7 +502,7 @@ class ShellTestCase(base.BaseCLITestCase):
         shell = Shell()
         shell.run(argv=["trigger", "list"])
 
-        call_args = mock_logger.warn.call_args[0][0]
+        call_args = mock_logger.warning.call_args[0][0]
         self.assertTrue(
             "Locale unknown with encoding unknown which is not UTF-8 is used."
             in call_args
@@ -542,13 +542,13 @@ class ShellTestCase(base.BaseCLITestCase):
         # Test without token.
         shell.run(["--config-file", mock_config_path, "action", "list"])
 
-        self.assertEqual(shell.LOG.warn.call_count, 2)
+        self.assertEqual(shell.LOG.warning.call_count, 2)
         self.assertEqual(
-            shell.LOG.warn.call_args_list[0][0][0][:63],
+            shell.LOG.warning.call_args_list[0][0][0][:63],
             "The StackStorm configuration directory permissions are insecure",
         )
         self.assertEqual(
-            shell.LOG.warn.call_args_list[1][0][0][:58],
+            shell.LOG.warning.call_args_list[1][0][0][:58],
             "The StackStorm configuration file permissions are insecure",
         )
 
@@ -637,8 +637,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
 
         self.assertEqual(result, None)
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to retrieve cached token from .*? read access to the parent "
@@ -656,8 +656,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
         self.assertEqual(result, None)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to retrieve cached token from .*? read access to this file"
@@ -674,8 +674,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         )
         self.assertEqual(result, "yayvalid")
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = "Permissions .*? for cached token file .*? are too permissive.*"
         self.assertRegex(log_message, expected_msg)
@@ -700,8 +700,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to write token to .*? doesn't have write access to the parent "
@@ -716,8 +716,8 @@ class CLITokenCachingTestCase(unittest.TestCase):
         shell.LOG = mock.Mock()
         shell._cache_auth_token(token_obj=token_db)
 
-        self.assertEqual(shell.LOG.warn.call_count, 1)
-        log_message = shell.LOG.warn.call_args[0][0]
+        self.assertEqual(shell.LOG.warning.call_count, 1)
+        log_message = shell.LOG.warning.call_args[0][0]
 
         expected_msg = (
             "Unable to write token to .*? doesn't have write access to this file"

--- a/st2common/st2common/constants/meta.py
+++ b/st2common/st2common/constants/meta.py
@@ -27,7 +27,7 @@ except ImportError:
     # official StackStorm packages.
     # Only time it may not be available is if the user is doing custom install from source or
     # similar.
-    logging.getLogger(__name__).warn(
+    logging.getLogger(__name__).warning(
         "libYAML C bindings are not available. This means YAML "
         "parsing and serialization will be significantly slower. You are "
         "strongly recommended to install libyaml (libyaml-dev package "

--- a/st2common/st2common/logging/misc.py
+++ b/st2common/st2common/logging/misc.py
@@ -75,7 +75,7 @@ def reopen_log_files(handlers):
                 if "cannot release" in six.text_type(e):
                     # Release failed which most likely indicates that acquire failed
                     # and lock was never acquired
-                    LOG.warn("Failed to release lock", exc_info=True)
+                    LOG.warning("Failed to release lock", exc_info=True)
                 else:
                     raise e
 

--- a/st2common/st2common/persistence/db_init.py
+++ b/st2common/st2common/persistence/db_init.py
@@ -36,7 +36,7 @@ def _retry_if_connection_error(error):
     # start of error msg.
     is_connection_error = isinstance(error, mongoengine.connection.ConnectionFailure)
     if is_connection_error:
-        LOG.warn("Retry on ConnectionError - %s", error)
+        LOG.warning("Retry on ConnectionError - %s", error)
     return is_connection_error
 
 

--- a/st2common/st2common/services/coordination.py
+++ b/st2common/st2common/services/coordination.py
@@ -241,7 +241,7 @@ def get_coordinator(start_heart=True, use_cache=True):
     global COORDINATOR
 
     if not configured():
-        LOG.warn(
+        LOG.warning(
             "Coordination backend is not configured. Code paths which use coordination "
             "service will use best effort approach and race conditions are possible."
         )

--- a/st2common/st2common/services/trigger_dispatcher.py
+++ b/st2common/st2common/services/trigger_dispatcher.py
@@ -94,7 +94,7 @@ class TriggerDispatcherService(object):
                 throw_on_inexistent_trigger=True,
             )
         except (ValidationError, ValueError, Exception) as e:
-            self._logger.warn(
+            self._logger.warning(
                 'Failed to validate payload (%s) for trigger "%s": %s'
                 % (str(payload), trigger, six.text_type(e))
             )
@@ -111,7 +111,7 @@ class TriggerDispatcherService(object):
                 if throw_on_validation_error:
                     raise ValueError(msg)
 
-                self._logger.warn(msg)
+                self._logger.warning(msg)
                 return None
 
         self._logger.debug("Dispatching trigger %s with payload %s.", trigger, payload)

--- a/st2common/st2common/util/api.py
+++ b/st2common/st2common/util/api.py
@@ -39,7 +39,7 @@ def get_base_public_api_url():
     if cfg.CONF.auth.api_url:
         api_url = get_url_without_trailing_slash(cfg.CONF.auth.api_url)
     else:
-        LOG.warn('"auth.api_url" configuration option is not configured')
+        LOG.warning('"auth.api_url" configuration option is not configured')
         api_url = "http://%s:%s" % (cfg.CONF.api.host, cfg.CONF.api.port)
 
     return api_url

--- a/st2reactor/st2reactor/container/sensor_wrapper.py
+++ b/st2reactor/st2reactor/container/sensor_wrapper.py
@@ -289,7 +289,7 @@ class SensorWrapper(object):
                 self._class_name,
                 six.text_type(e),
             )
-            self._logger.warn(msg, exc_info=True)
+            self._logger.warning(msg, exc_info=True)
             raise Exception(msg)
 
     def stop(self):


### PR DESCRIPTION
- Fix DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- Fixed more DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- Replace 'warn' with 'warning' method
- Skip test_warn_on_bad_config_permissions when run as root user.
- Skip test_get_cached_auth_token_invalid_permissions if run as root
- Skip test_cache_auth_token_invalid_permissions if run as root
