### PR TITLE
Update pylint to 3.1.0

### DIFF
--- a/contrib/examples/actions/ubuntu_pkg_info/ubuntu_pkg_info.py
+++ b/contrib/examples/actions/ubuntu_pkg_info/ubuntu_pkg_info.py
@@ -19,7 +19,7 @@ import sys
 import subprocess
 
 import six
-import lib.datatransformer as transformer
+import lib.datatransformer as transformer  # pylint:disable=import-error,no-name-in-module
 
 
 def main(args):

--- a/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
+++ b/contrib/packs/actions/pack_mgmt/get_pack_dependencies.py
@@ -125,9 +125,9 @@ def get_pack_version(pack=None):
         pack_metadata = get_pack_metadata(pack_dir=pack_path)
         result = pack_metadata.get("version", None)
     except Exception:
-        result = None
-    finally:
-        return result
+        return None
+
+    return result
 
 
 def get_dependency_list(pack=None):
@@ -138,6 +138,6 @@ def get_dependency_list(pack=None):
         result = pack_metadata.get("dependencies", None)
     except Exception:
         print("Could not open pack.yaml at location %s" % pack_path)
-        result = None
-    finally:
-        return result
+        return None
+
+    return result

--- a/lint-configs/python/.pylintrc
+++ b/lint-configs/python/.pylintrc
@@ -1,12 +1,9 @@
 [MESSAGES CONTROL]
 # C0111 Missing docstring
 # I0011 Warning locally suppressed using disable-msg
-# W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
 # W0212 Access to a protected member %s of a client class
-# W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
 # W0613 Unused argument %r Used when a function or method argument is not used.
 # W0702 No exception's type specified Used when an except clause doesn't specify exceptions type to catch.
-# R0201 Method could be a function
 # W0614 Unused import XYZ from wildcard import
 # R0914 Too many local variables
 # R0912 Too many branches
@@ -16,14 +13,13 @@
 # E0211: Method has no argument
 # E1128: Assigning to function call which only returns None Used when an assignment is done on a function call but the inferred function returns nothing but None.
 # E1129: Context manager ‘%s’ doesn’t implement __enter__ and __exit__. Used when an instance in a with statement doesn’t implement the context manager protocol(__enter__/__exit__).
-disable=C0103,C0111,I0011,W0142,W0212,W0232,W0613,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801,not-context-manager,assignment-from-none
+disable=C0103,C0111,I0011,W0212,W0613,W0702,W0614,R0914,R0912,R0915,R0913,R0904,R0801,not-context-manager,assignment-from-none
 
 [BASIC]
 property-classes=abc.abstractproperty
 
 [TYPECHECK]
-# Note: This modules are manipulated during the runtime so we can't detect all the properties during
-# static analysis
+# Note: These modules are manipulated during the runtime so we can't detect all the properties during static analysis
 # orjson has type stubs, but pylint doesn't support __init__.pyi yet: https://github.com/PyCQA/pylint/issues/2873
 ignored-modules=distutils,eventlet.green.subprocess,six,six.moves,orjson
 

--- a/lint-configs/python/.pylintrc
+++ b/lint-configs/python/.pylintrc
@@ -1,8 +1,6 @@
 [MESSAGES CONTROL]
 # C0111 Missing docstring
 # I0011 Warning locally suppressed using disable-msg
-# I0012 Warning locally suppressed using disable-msg
-# W0704 Except doesn't do anything Used when an except clause does nothing but "pass" and there is no "else" clause
 # W0142 Used * or * magic* Used when a function or method is called using *args or **kwargs to dispatch arguments.
 # W0212 Access to a protected member %s of a client class
 # W0232 Class has no __init__ method Used when a class has no __init__ method, neither its parent classes.
@@ -18,7 +16,7 @@
 # E0211: Method has no argument
 # E1128: Assigning to function call which only returns None Used when an assignment is done on a function call but the inferred function returns nothing but None.
 # E1129: Context manager ‘%s’ doesn’t implement __enter__ and __exit__. Used when an instance in a with statement doesn’t implement the context manager protocol(__enter__/__exit__).
-disable=C0103,C0111,I0011,I0012,W0704,W0142,W0212,W0232,W0613,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801,not-context-manager,assignment-from-none
+disable=C0103,C0111,I0011,W0142,W0212,W0232,W0613,W0702,R0201,W0614,R0914,R0912,R0915,R0913,R0904,R0801,not-context-manager,assignment-from-none
 
 [BASIC]
 property-classes=abc.abstractproperty

--- a/lockfiles/pylint.lock
+++ b/lockfiles/pylint.lock
@@ -10,7 +10,7 @@
 //   ],
 //   "generated_with_requirements": [
 //     "astroid",
-//     "pylint>=2.8.2",
+//     "pylint~=3.1.0",
 //     "setuptools"
 //   ],
 //   "manylinux": "manylinux2014",
@@ -299,7 +299,7 @@
   "prefer_older_binary": false,
   "requirements": [
     "astroid",
-    "pylint>=2.8.2",
+    "pylint~=3.1.0",
     "setuptools"
   ],
   "requires_python": [

--- a/lockfiles/pylint.lock
+++ b/lockfiles/pylint.lock
@@ -10,7 +10,7 @@
 //   ],
 //   "generated_with_requirements": [
 //     "astroid",
-//     "pylint~=2.8.2",
+//     "pylint>=2.8.2",
 //     "setuptools"
 //   ],
 //   "manylinux": "manylinux2014",
@@ -33,23 +33,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e",
-              "url": "https://files.pythonhosted.org/packages/f8/82/a61df6c2d68f3ae3ad1afa0d2e5ba5cfb7386eb80cffb453def7c5757271/astroid-2.5.6-py3-none-any.whl"
+              "hash": "951798f922990137ac090c53af473db7ab4e70c770e6d7fae0cec59f74411819",
+              "url": "https://files.pythonhosted.org/packages/ed/1c/ee18acf9070f77253954b7d71b4c0cf8f5969fb23067d8f1a8793573ba00/astroid-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975",
-              "url": "https://files.pythonhosted.org/packages/bc/72/51d6389690b30adf1ad69993923f81b71b2110b16e02fd0afd378e30c43c/astroid-2.5.6.tar.gz"
+              "hash": "ac248253bfa4bd924a0de213707e7ebeeb3138abeb48d798784ead1e56d419d4",
+              "url": "https://files.pythonhosted.org/packages/a9/b9/f11533eed9b65606fb02f1b0994d8ed0903358bc55a6b9759e42f1134725/astroid-3.1.0.tar.gz"
             }
           ],
           "project_name": "astroid",
           "requires_dists": [
-            "lazy-object-proxy>=1.4.0",
-            "typed-ast<1.5,>=1.4.0; implementation_name == \"cpython\" and python_version < \"3.8\"",
-            "wrapt<1.13,>=1.11"
+            "typing-extensions>=4.0.0; python_version < \"3.11\""
           ],
-          "requires_python": "~=3.6",
-          "version": "2.5.6"
+          "requires_python": ">=3.8.0",
+          "version": "3.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7",
+              "url": "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca",
+              "url": "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz"
+            }
+          ],
+          "project_name": "dill",
+          "requires_dists": [
+            "gprof2dot>=2022.7.29; extra == \"profile\"",
+            "objgraph>=1.7.2; extra == \"graph\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.3.8"
         },
         {
           "artifacts": [
@@ -75,123 +94,92 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d",
-              "url": "https://files.pythonhosted.org/packages/31/8b/94dc8d58704ab87b39faed6f2fc0090b9d90e2e2aa2bbec35c79f3d2a054/lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl"
+              "hash": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
+              "url": "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2297f08f08a2bb0d32a4265e98a006643cd7233fb7983032bd61ac7a02956b3b",
-              "url": "https://files.pythonhosted.org/packages/20/44/7d3b51ada1ddf873b136e2fa1d68bf3ee7b406b0bd9eeb97445932e2bfe1/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "78247b6d45f43a52ef35c25b5581459e85117225408a4128a3daf8bf9648ac69",
-              "url": "https://files.pythonhosted.org/packages/2c/f0/f02e2d150d581a294efded4020094a371bbab42423fe78625ac18854d89b/lazy-object-proxy-1.10.0.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "5ad9e6ed739285919aa9661a5bbed0aaf410aa60231373c5579c6b4801bd883c",
-              "url": "https://files.pythonhosted.org/packages/77/18/b78391424f3e35147b0e4d280dda0320c29ee9930b908e42fbe7920b2492/lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9a3a87cf1e133e5b1994144c12ca4aa3d9698517fe1e2ca82977781b16955658",
-              "url": "https://files.pythonhosted.org/packages/8e/ae/3e15cffacbdb64ac49930cdbc23cb0c67e1bb9e8a8ca7765fd8a8d2510c3/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "18dd842b49456aaa9a7cf535b04ca4571a302ff72ed8740d06b5adcd41fe0757",
-              "url": "https://files.pythonhosted.org/packages/ab/be/d0a76dd4404ee68c7dd611c9b48e58b5c70ac5458e4c951b2c8923c24dd9/lazy_object_proxy-1.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2fc0a92c02fa1ca1e84fc60fa258458e5bf89d90a1ddaeb8ed9cc3147f417255",
-              "url": "https://files.pythonhosted.org/packages/b8/75/4669e1a7e7150e81ac27acc602ae61a37b4cc950c1ed3bd13b8d518bc026/lazy_object_proxy-1.10.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "366c32fe5355ef5fc8a232c5436f4cc66e9d3e8967c01fb2e6302fd6627e3d94",
-              "url": "https://files.pythonhosted.org/packages/bc/2f/b9230d00c2eaa629e67cc69f285bf6b5692cb1d0179a1f8764edd451da86/lazy_object_proxy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9e4ed0518a14dd26092614412936920ad081a424bdcb54cc13349a8e2c6d106a",
-              "url": "https://files.pythonhosted.org/packages/be/11/23bcc3a85c9df7326d332b29172eaa088a3ebecb2674f257de2599e36aeb/lazy_object_proxy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0aefc7591920bbd360d57ea03c995cebc204b424524a5bd78406f6e1b8b2a5d8",
-              "url": "https://files.pythonhosted.org/packages/c8/a2/c99adb712e6ec8387d608c73d5b7a4a459c1c7813f38ee869f605bdc3f38/lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "217138197c170a2a74ca0e05bddcd5f1796c735c37d0eee33e43259b192aa424",
-              "url": "https://files.pythonhosted.org/packages/d4/f8/d2d0d5caadf41c2d1fc9044dfc0e10d2831fb4ab6a077e68d25ea5bbff3b/lazy_object_proxy-1.10.0-cp39-cp39-musllinux_1_1_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "5faf03a7d8942bb4476e3b62fd0f4cf94eaf4618e304a19865abf89a35c0bbee",
-              "url": "https://files.pythonhosted.org/packages/f0/84/efe5dfb7c456bd3baa134dc2a4d7c891e7ce15a14c642cbfbcf50ff038ed/lazy_object_proxy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl"
-            }
-          ],
-          "project_name": "lazy-object-proxy",
-          "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "1.10.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-              "url": "https://files.pythonhosted.org/packages/87/89/479dc97e18549e21354893e4ee4ef36db1d237534982482c3681ee6e7b57/mccabe-0.6.1-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f",
-              "url": "https://files.pythonhosted.org/packages/06/18/fa675aa501e11d6d6ca0ae73a101b2f3571a565e0f7d38e062eec18a91ee/mccabe-0.6.1.tar.gz"
+              "hash": "348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+              "url": "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz"
             }
           ],
           "project_name": "mccabe",
           "requires_dists": [],
-          "requires_python": null,
-          "version": "0.6.1"
+          "requires_python": ">=3.6",
+          "version": "0.7.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "792b38ff30903884e4a9eab814ee3523731abd3c463f3ba48d7b627e87013484",
-              "url": "https://files.pythonhosted.org/packages/b2/97/a584ca733493cba7baca670800e615ced77c7b22e663e2eed6f68c931b87/pylint-2.8.3-py3-none-any.whl"
+              "hash": "17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1",
+              "url": "https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8",
-              "url": "https://files.pythonhosted.org/packages/18/a7/2bf9363ec428818abd27a64ec44c84b13bf1c10df01c402f08391aa1d07c/pylint-2.8.3.tar.gz"
+              "hash": "031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf",
+              "url": "https://files.pythonhosted.org/packages/b2/e4/2856bf61e54d7e3a03dd00d0c1b5fa86e6081e8f262eb91befbe64d20937/platformdirs-4.2.1.tar.gz"
+            }
+          ],
+          "project_name": "platformdirs",
+          "requires_dists": [
+            "appdirs==1.4.4; extra == \"test\"",
+            "covdefaults>=2.3; extra == \"test\"",
+            "furo>=2023.9.10; extra == \"docs\"",
+            "mypy>=1.8; extra == \"type\"",
+            "proselint>=0.13; extra == \"docs\"",
+            "pytest-cov>=4.1; extra == \"test\"",
+            "pytest-mock>=3.12; extra == \"test\"",
+            "pytest>=7.4.3; extra == \"test\"",
+            "sphinx-autodoc-typehints>=1.25.2; extra == \"docs\"",
+            "sphinx>=7.2.6; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.2.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "507a5b60953874766d8a366e8e8c7af63e058b26345cfcb5f91f89d987fd6b74",
+              "url": "https://files.pythonhosted.org/packages/4d/2b/dfcf298607c73c3af47d5a699c3bd84ba580f1b8642a53ba2a53eead7c49/pylint-3.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6a69beb4a6f63debebaab0a3477ecd0f559aa726af4954fc948c51f7a2549e23",
+              "url": "https://files.pythonhosted.org/packages/35/1c/4a8135f77a4ec8c0a6dc1d4543dd6fee55b36bb8bf629e2bcce8a94763a9/pylint-3.1.0.tar.gz"
             }
           ],
           "project_name": "pylint",
           "requires_dists": [
-            "astroid==2.5.6",
-            "colorama; sys_platform == \"win32\"",
-            "isort<6,>=4.2.5",
-            "mccabe<0.7,>=0.6",
-            "toml>=0.7.1"
+            "astroid<=3.2.0-dev0,>=3.1.0",
+            "colorama>=0.4.5; sys_platform == \"win32\"",
+            "dill>=0.2; python_version < \"3.11\"",
+            "dill>=0.3.6; python_version >= \"3.11\"",
+            "dill>=0.3.7; python_version >= \"3.12\"",
+            "gitpython>3; extra == \"testutils\"",
+            "isort!=5.13.0,<6,>=4.2.5",
+            "mccabe<0.8,>=0.6",
+            "platformdirs>=2.2.0",
+            "pyenchant~=3.2; extra == \"spelling\"",
+            "tomli>=1.1.0; python_version < \"3.11\"",
+            "tomlkit>=0.10.1",
+            "typing-extensions>=3.10.0; python_version < \"3.10\""
           ],
-          "requires_python": "~=3.6",
-          "version": "2.8.3"
+          "requires_python": ">=3.8.0",
+          "version": "3.1.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c",
-              "url": "https://files.pythonhosted.org/packages/92/e1/1c8bb3420105e70bdf357d57dd5567202b4ef8d27f810e98bb962d950834/setuptools-69.2.0-py3-none-any.whl"
+              "hash": "c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32",
+              "url": "https://files.pythonhosted.org/packages/f7/29/13965af254e3373bceae8fb9a0e6ea0d0e571171b80d6646932131d6439b/setuptools-69.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e",
-              "url": "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
+              "hash": "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987",
+              "url": "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -215,26 +203,25 @@
             "packaging>=23.2; extra == \"testing-integration\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
+            "pytest!=8.1.1,>=6; extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=2.2; extra == \"testing\"",
             "pytest-home>=0.5; extra == \"testing\"",
-            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-mypy; extra == \"testing\"",
             "pytest-perf; sys_platform != \"cygwin\" and extra == \"testing\"",
             "pytest-ruff>=0.2.1; sys_platform != \"cygwin\" and extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest-xdist>=3; extra == \"testing\"",
             "pytest; extra == \"testing-integration\"",
-            "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
             "sphinx-lint; extra == \"docs\"",
             "sphinx-notfound-page<2,>=1; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx<7.2.5; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
@@ -246,38 +233,61 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.8",
-          "version": "69.2.0"
+          "version": "69.5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-              "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl"
+              "hash": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
-              "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz"
+              "hash": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "url": "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
             }
           ],
-          "project_name": "toml",
+          "project_name": "tomli",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.6",
-          "version": "0.10.2"
+          "requires_python": ">=3.7",
+          "version": "2.0.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7",
-              "url": "https://files.pythonhosted.org/packages/82/f7/e43cefbe88c5fd371f4cf0cf5eb3feccd07515af9fd6cf7dbf1d1793a797/wrapt-1.12.1.tar.gz"
+              "hash": "5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b",
+              "url": "https://files.pythonhosted.org/packages/07/fa/c96545d741f2fd47f565e4e06bfef0962add790cb9c2289d900102b55eca/tomlkit-0.12.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3",
+              "url": "https://files.pythonhosted.org/packages/7d/49/4c0764898ee67618996148bdba4534a422c5e698b4dbf4001f7c6f930797/tomlkit-0.12.4.tar.gz"
             }
           ],
-          "project_name": "wrapt",
+          "project_name": "tomlkit",
           "requires_dists": [],
-          "requires_python": null,
-          "version": "1.12.1"
+          "requires_python": ">=3.7",
+          "version": "0.12.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a",
+              "url": "https://files.pythonhosted.org/packages/01/f3/936e209267d6ef7510322191003885de524fc48d1b43269810cd589ceaf5/typing_extensions-4.11.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+              "url": "https://files.pythonhosted.org/packages/f6/f3/b827b3ab53b4e3d8513914586dcca61c355fa2ce8252dea4da56e67bf8f2/typing_extensions-4.11.0.tar.gz"
+            }
+          ],
+          "project_name": "typing-extensions",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "4.11.0"
         }
       ],
       "platform_tag": null
@@ -289,7 +299,7 @@
   "prefer_older_binary": false,
   "requirements": [
     "astroid",
-    "pylint~=2.8.2",
+    "pylint>=2.8.2",
     "setuptools"
   ],
   "requires_python": [

--- a/pylint_plugins/BUILD
+++ b/pylint_plugins/BUILD
@@ -17,7 +17,7 @@ python_tests(
 python_requirement(
     name="pylint",
     requirements=[
-        "pylint~=2.8.2",
+        "pylint>=2.8.2",
         "setuptools",  # includes pkg_resources
     ],
 )

--- a/pylint_plugins/BUILD
+++ b/pylint_plugins/BUILD
@@ -17,7 +17,7 @@ python_tests(
 python_requirement(
     name="pylint",
     requirements=[
-        "pylint>=2.8.2",
+        "pylint~=3.1.0",
         "setuptools",  # includes pkg_resources
     ],
 )

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -276,9 +276,21 @@ def transform(cls: nodes.ClassDef):
         # Now, we can construct the AST node that we'll add to the API model class.
 
         if property_type == "object":
-            node = nodes.Dict()
+            node = nodes.Dict(
+                property_data_node.lineno,
+                property_data_node.col_offset,
+                parent=property_data_node,
+                end_lineno=property_data_node.end_lineno,
+                end_col_offset=property_data_node.end_col_offset,
+            )
         elif property_type == "array":
-            node = nodes.List()
+            node = nodes.List(
+                property_data_node.lineno,
+                property_data_node.col_offset,
+                parent=property_data_node,
+                end_lineno=property_data_node.end_lineno,
+                end_col_offset=property_data_node.end_col_offset,
+            )
         elif property_type == "integer":
             node = scoped_nodes.builtin_lookup("int")[1][0]
         elif property_type == "number":
@@ -291,11 +303,27 @@ def transform(cls: nodes.ClassDef):
             node = scoped_nodes.builtin_lookup("None")[1][0]
         else:
             # Unknown type
-            node = astroid.ClassDef(property_name)
+            node = astroid.ClassDef(
+                property_name,
+                property_data_node.lineno,
+                property_data_node.col_offset,
+                parent=property_data_node,
+                end_lineno=property_data_node.end_lineno,
+                end_col_offset=property_data_node.end_col_offset,
+            )
 
         # Create a "property = node" assign node
-        assign_node = nodes.Assign(parent=cls)
-        assign_name_node = nodes.AssignName(property_name, parent=assign_node)
+        assign_node = nodes.Assign(
+            cls.lineno,
+            cls.col_offset,
+            parent=cls,
+            end_lineno=cls.end_lineno,
+            end_col_offset=cls.end_col_offset,
+        )
+        # todo: determine what line/offsets should be.
+        assign_name_node = nodes.AssignName(
+            property_name, 0, 0, parent=assign_node, end_lineno=0, end_col_offset=0
+        )
         assign_node.postinit(
             targets=[assign_name_node], value=node, type_annotation=None
         )

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -51,6 +51,7 @@ At this point, we have the schema, so then we:
 Now, we return because Pylint can finally understand our API model objects without
 importing them.
 """
+# pylint: disable=E1120,E1125
 
 import astroid
 
@@ -290,12 +291,14 @@ def transform(cls: nodes.ClassDef):
             node = scoped_nodes.builtin_lookup("None")[1][0]
         else:
             # Unknown type
-            node = astroid.ClassDef(property_name, None)
+            node = astroid.ClassDef(property_name)
 
         # Create a "property = node" assign node
         assign_node = nodes.Assign(parent=cls)
         assign_name_node = nodes.AssignName(property_name, parent=assign_node)
-        assign_node.postinit(targets=[assign_name_node], value=node)
+        assign_node.postinit(
+            targets=[assign_name_node], value=node, type_annotation=None
+        )
 
         # Finally, add the property node as an attribute on the class.
         cls.locals[property_name] = [assign_name_node]

--- a/pylint_plugins/api_models.py
+++ b/pylint_plugins/api_models.py
@@ -314,15 +314,19 @@ def transform(cls: nodes.ClassDef):
 
         # Create a "property = node" assign node
         assign_node = nodes.Assign(
-            cls.lineno,
-            cls.col_offset,
+            property_name_node.lineno,
+            property_name_node.col_offset,
             parent=cls,
-            end_lineno=cls.end_lineno,
-            end_col_offset=cls.end_col_offset,
+            end_lineno=property_data_node.end_lineno,
+            end_col_offset=property_data_node.end_col_offset,
         )
-        # todo: determine what line/offsets should be.
         assign_name_node = nodes.AssignName(
-            property_name, 0, 0, parent=assign_node, end_lineno=0, end_col_offset=0
+            property_name,
+            property_name_node.lineno,
+            property_name_node.col_offset,
+            parent=assign_node,
+            end_lineno=property_name_node.end_lineno,
+            end_col_offset=property_name_node.end_col_offset,
         )
         assign_node.postinit(
             targets=[assign_name_node], value=node, type_annotation=None

--- a/pylint_plugins/api_models_test.py
+++ b/pylint_plugins/api_models_test.py
@@ -19,6 +19,7 @@ from astroid import parse, nodes
 
 import pylint.checkers.typecheck
 import pylint.testutils
+from pylint.interfaces import Confidence
 
 # merely importing this registers it in astroid
 # so parse() will use our predicate and transform functions.
@@ -305,6 +306,13 @@ class TestTypeChecker(pylint.testutils.CheckerTestCase):
                 msg_id="no-member",  # E1101
                 args=("Instance of", "TestAPI", "missing", ""),
                 node=assign_node_missing.value,
+                line=assign_node_missing.lineno,
+                # fixme: +10 is a workaround, need understand why coloffset
+                # is 4 but visit_attribute is coloffset 14.
+                col_offset=assign_node_missing.col_offset+10,
+                end_line=assign_node_missing.end_lineno,
+                end_col_offset=assign_node_missing.end_col_offset,
+                confidence=Confidence(name='INFERENCE', description='Warning based on inference result.'),
             )
         ):
             self.checker.visit_attribute(assign_node_missing.value)

--- a/pylint_plugins/api_models_test.py
+++ b/pylint_plugins/api_models_test.py
@@ -301,7 +301,7 @@ class TestTypeChecker(pylint.testutils.CheckerTestCase):
 
         # accessing a property NOT defined in the schema
         with self.assertAddsMessages(
-            pylint.testutils.Message(
+            pylint.testutils.MessageTest(
                 msg_id="no-member",  # E1101
                 args=("Instance of", "TestAPI", "missing", ""),
                 node=assign_node_missing.value,

--- a/pylint_plugins/api_models_test.py
+++ b/pylint_plugins/api_models_test.py
@@ -306,12 +306,10 @@ class TestTypeChecker(pylint.testutils.CheckerTestCase):
                 msg_id="no-member",  # E1101
                 args=("Instance of", "TestAPI", "missing", ""),
                 node=assign_node_missing.value,
-                line=assign_node_missing.lineno,
-                # fixme: +10 is a workaround, need understand why coloffset
-                # is 4 but visit_attribute is coloffset 14.
-                col_offset=assign_node_missing.col_offset + 10,
-                end_line=assign_node_missing.end_lineno,
-                end_col_offset=assign_node_missing.end_col_offset,
+                line=assign_node_missing.value.lineno,
+                col_offset=assign_node_missing.value.col_offset,
+                end_line=assign_node_missing.value.end_lineno,
+                end_col_offset=assign_node_missing.value.end_col_offset,
                 confidence=Confidence(
                     name="INFERENCE", description="Warning based on inference result."
                 ),

--- a/pylint_plugins/api_models_test.py
+++ b/pylint_plugins/api_models_test.py
@@ -309,10 +309,12 @@ class TestTypeChecker(pylint.testutils.CheckerTestCase):
                 line=assign_node_missing.lineno,
                 # fixme: +10 is a workaround, need understand why coloffset
                 # is 4 but visit_attribute is coloffset 14.
-                col_offset=assign_node_missing.col_offset+10,
+                col_offset=assign_node_missing.col_offset + 10,
                 end_line=assign_node_missing.end_lineno,
                 end_col_offset=assign_node_missing.end_col_offset,
-                confidence=Confidence(name='INFERENCE', description='Warning based on inference result.'),
+                confidence=Confidence(
+                    name="INFERENCE", description="Warning based on inference result."
+                ),
             )
         ):
             self.checker.visit_attribute(assign_node_missing.value)

--- a/pylint_plugins/db_models.py
+++ b/pylint_plugins/db_models.py
@@ -38,12 +38,27 @@ def transform(cls):
     if cls.name == "StormFoundationDB":
         # _fields get added automagically by mongoengine
         if "_fields" not in cls.locals:
-            cls.locals["_fields"] = [nodes.Dict()]
+            cls.locals["_fields"] = [
+                nodes.Dict(
+                    cls.lineno,
+                    cls.col_offset,
+                    parent=cls,
+                    end_lineno=cls.end_lineno,
+                    end_col_offset=cls.end_col_offset,
+                )
+            ]
 
     if cls.name.endswith("DB"):
         # mongoengine explicitly declared "id" field on each class so we teach pylint about that
         property_name = "id"
-        node = astroid.ClassDef(property_name)
+        node = astroid.ClassDef(
+            property_name,
+            cls.lineno,
+            cls.col_offset,
+            parent=cls,
+            end_lineno=cls.end_lineno,
+            end_col_offset=cls.end_col_offset,
+        )
         cls.locals[property_name] = [node]
 
 

--- a/pylint_plugins/db_models.py
+++ b/pylint_plugins/db_models.py
@@ -16,6 +16,7 @@
 """
 Plugin which tells Pylint how to handle mongoengine document classes.
 """
+# pylint: disable=E1120,E1125
 
 import astroid
 
@@ -42,7 +43,7 @@ def transform(cls):
     if cls.name.endswith("DB"):
         # mongoengine explicitly declared "id" field on each class so we teach pylint about that
         property_name = "id"
-        node = astroid.ClassDef(property_name, None)
+        node = astroid.ClassDef(property_name)
         cls.locals[property_name] = [node]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 max-line-length = 100
-target_version = ['py36']
+target_version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/st2actions/st2actions/container/base.py
+++ b/st2actions/st2actions/container/base.py
@@ -210,6 +210,8 @@ class RunnerContainer(object):
         return runner.liveaction
 
     def _do_pause(self, runner):
+        # Initialise to avoid E0601: Use before assignment.
+        status = result = context = None
         try:
             extra = {"runner": runner}
             LOG.debug(
@@ -240,6 +242,8 @@ class RunnerContainer(object):
         return runner.liveaction
 
     def _do_resume(self, runner):
+        # Initialise to avoid E0601: Use before assignment.
+        status = result = context = None
         try:
             extra = {"runner": runner}
             LOG.debug(

--- a/st2common/bin/migrations/v3.5/st2-migrate-db-dict-field-values
+++ b/st2common/bin/migrations/v3.5/st2-migrate-db-dict-field-values
@@ -154,6 +154,7 @@ def migrate_executions(start_dt: datetime.datetime, end_dt: datetime.datetime) -
         if not liveaction_id:
             continue
 
+        liveaction_db = None
         try:
             liveaction_db = LiveAction.get_by_id(liveaction_id)
         except StackStormDBObjectNotFoundError:
@@ -262,6 +263,7 @@ def migrate_workflow_objects(
         print("Will migrate %s TaskExecutionDB objects" % (objects_count))
         print("")
 
+    task_execution_db = None
     for index, task_execution_id in enumerate(task_execution_ids, 1):
         try:
             task_execution_db = TaskExecution.get_by_id(task_execution_id)

--- a/st2common/st2common/services/action.py
+++ b/st2common/st2common/services/action.py
@@ -631,6 +631,6 @@ def is_action_execution_under_action_chain_context(liveaction):
 
 
 def get_requester(requester):
-    if type(requester) == UserDB:
+    if isinstance(requester, UserDB):
         return requester["name"]
     return requester

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 # 7.5 causing errors with orquesta integration tests (probably interaction w/ nose)
 coverage<7.5
 pep8==1.7.1
+# st2flake8 does not support flake8 v5 yet
+flake8==4.0.1
 st2flake8==0.1.0
 astroid==3.1.0
 pylint==3.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,8 @@
 coverage<7.5
 pep8==1.7.1
 st2flake8==0.1.0
-astroid==2.5.6
-pylint==2.8.2
+astroid==2.15.8
+pylint==2.17.7
 pylint-plugin-utils>=0.4
 black==22.3.0
 pre-commit==2.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,8 @@
 coverage<7.5
 pep8==1.7.1
 st2flake8==0.1.0
-astroid==2.15.8
-pylint==2.17.7
+astroid==3.1.0
+pylint==3.1.0
 pylint-plugin-utils>=0.4
 black==22.3.0
 pre-commit==2.1.0


### PR DESCRIPTION
This extracts @nzlosh's pylint-related updates/fixes from #6157.

- update pylint
- Test: Bump pylint and astroid to latest 2.x
- Remove options to fix pylint Unknown option value warning.
- Fix Useless option value for W0142, W0232 and R0201
- Fix E0601: Using variable 'result' before assignment (used-before-assignment)
- fmt
- Fix E721 do not compare types
- Initialise variables to avoid E0601: Use before assignment.
- Bump pylint and astroid to support latest dnspython.
- Update pylint calls for support 3.1
- Fix E0601: used-before-assign lint errors.
- Disable false alert on import error.
