### PR TITLE
Bump GHA actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Add CHANGELOG.rst
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Changelog check
         # https://github.com/marketplace/actions/changelog-checker
         uses: Zomzog/changelog-checker@v1.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           ./scripts/github/setup-environment.sh
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
@@ -181,7 +181,7 @@ jobs:
         run: |
           ./scripts/github/setup-environment.sh
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
@@ -385,7 +385,7 @@ jobs:
         run: |
           ./scripts/github/setup-environment.sh
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
@@ -605,7 +605,7 @@ jobs:
         run: |
           ./scripts/github/setup-environment.sh
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -102,7 +102,7 @@ jobs:
           #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache
@@ -185,7 +185,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -199,7 +199,7 @@ jobs:
             ${{ runner.os }}-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache
@@ -389,7 +389,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -405,7 +405,7 @@ jobs:
           #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache
@@ -609,7 +609,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -625,7 +625,7 @@ jobs:
           #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,11 +57,11 @@ jobs:
           - name: 'Lint Checks (black, flake8, etc.)'
             task: 'ci-checks'
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Compile (pip deps, pylint, etc.)'
             task: 'ci-compile'
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Lint Checks (black, flake8, etc.)'
             task: 'ci-checks'
             python-version-short: '3.9'
@@ -314,13 +314,13 @@ jobs:
             nosetests_node_total: 2
             nosetests_node_index: 0
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Unit Tests (chunk 2)'
             task: 'ci-unit'
             nosetests_node_total: 2
             nosetests_node_index: 1
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Unit Tests (chunk 1)'
             task: 'ci-unit'
             nosetests_node_total: 2
@@ -489,19 +489,19 @@ jobs:
             nosetests_node_total: 1
             nosetests_node_index: 0
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Integration Tests (chunk 1)'
             task: 'ci-integration'
             nosetests_node_total: 2
             nosetests_node_index: 0
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Integration Tests (chunk 2)'
             task: 'ci-integration'
             nosetests_node_total: 2
             nosetests_node_index: 1
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Pack Tests'
             task: 'ci-packs-tests'
             nosetests_node_total: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,11 +95,11 @@ jobs:
           # TODO: maybe make the virtualenv a partial cache to exclude st2*?
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
-          key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           # Don't use alternative key as if requirements.txt has altered we
           # don't want to retrieve previous cache
           #restore-keys: |
-          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          #  ${{ runner.os }}-v5-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v4
@@ -194,7 +194,7 @@ jobs:
           # TODO: maybe make the virtualenv a partial cache to exclude st2*?
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
-          key: ${{ runner.os }}-v3-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           restore-keys: |
             ${{ runner.os }}-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
@@ -398,11 +398,11 @@ jobs:
           # TODO: maybe make the virtualenv a partial cache to exclude st2*?
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
-          key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           # Don't use alternative key as if requirements.txt has altered we
           # don't want to retrieve previous cache
           #restore-keys: |
-          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          #  ${{ runner.os }}-v5-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v4
@@ -618,11 +618,11 @@ jobs:
           # TODO: maybe make the virtualenv a partial cache to exclude st2*?
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
-          key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           # Don't use alternative key as if requirements.txt has altered we
           # don't want to retrieve previous cache
           #restore-keys: |
-          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          #  ${{ runner.os }}-v5-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,9 +106,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v7-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}
@@ -203,9 +203,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v5-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v5-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}
@@ -409,9 +409,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v5-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v5-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}
@@ -629,9 +629,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v5-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v5-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,7 +286,7 @@ jobs:
           tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs-py${{ matrix.python-version }}
           path: logs.tar.gz
@@ -695,7 +695,7 @@ jobs:
           tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
         if: ${{ failure() && env.TASK == 'ci-integration' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs-py${{ matrix.python-version }}-nose-${{ matrix.nosetests_node_index }}
           path: logs.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
       PYLINT_CONCURRENCY: '6'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Custom Environment Setup
         run: |
           ./scripts/github/setup-environment.sh
@@ -176,7 +176,7 @@ jobs:
       TESTS_TO_SKIP: "tests.test_quickstart_rules tests.test_run_pack_tests_tool"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Custom Environment Setup
         run: |
           ./scripts/github/setup-environment.sh
@@ -380,7 +380,7 @@ jobs:
       PATH: /home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Custom Environment Setup
         run: |
           ./scripts/github/setup-environment.sh
@@ -600,7 +600,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Custom Environment Setup
         run: |
           ./scripts/github/setup-environment.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -83,7 +83,7 @@ jobs:
           pants lint ::
 
       - name: Upload pants log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pants-log-py${{ matrix.python-version }}
           path: .pants.d/pants.log

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
           submodules: 'true'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,7 @@ jobs:
 
       #- name: Cache APT Dependencies
       #  id: cache-apt-deps
-      #  uses: actions/cache@v2
+      #  uses: actions/cache@v4
       #  with:
       #    path: |
       #      ~/apt_cache

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -57,7 +57,7 @@ jobs:
           ./scripts/github/install-apt-packages-use-cache.sh
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@v6-scie-pants
+        uses: pantsbuild/actions/init-pants@v8
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,9 +44,9 @@ jobs:
       #  with:
       #    path: |
       #      ~/apt_cache
-      #    key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+      #    key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
       #    restore-keys: |
-      #      ${{ runner.os }}-apt-v7-
+      #      ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: 'false' # cache doesn't work

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -80,7 +80,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -93,7 +93,7 @@ jobs:
           #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -86,11 +86,11 @@ jobs:
             ~/.cache/pip
             virtualenv
             ~/virtualenv
-          key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           # Don't use alternative key as if requirements.txt has altered we
           # don't want to retrieve previous cache
           #restore-keys: |
-          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          #  ${{ runner.os }}-v5-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v4

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -120,7 +120,7 @@ jobs:
         run: |
           script -e -c "make ${TASK}" && exit 0
       - name: Upload Histograms
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark_histograms
           path: benchmark_histograms/

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -39,7 +39,7 @@ jobs:
             nosetests_node_total: 1
             nosetests_node_index: 0
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Microbenchmarks'
             task: 'micro-benchmarks'
             nosetests_node_total: 1

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -97,9 +97,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v7-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Dependencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}

--- a/.github/workflows/microbenchmarks.yaml
+++ b/.github/workflows/microbenchmarks.yaml
@@ -74,7 +74,7 @@ jobs:
       PATH: /home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Set up Python (${{ matrix.python-version }})'
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -152,9 +152,9 @@ jobs:
         with:
           path: |
             ~/apt_cache
-          key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+          key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
           restore-keys: |
-            ${{ runner.os }}-apt-v7-
+            ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: ${{steps.cache-apt-deps.outputs.cache-hit}}

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -141,11 +141,11 @@ jobs:
           # TODO: maybe make the virtualenv a partial cache to exclude st2*?
           # !virtualenv/lib/python*/site-packages/st2*
           # !virtualenv/bin/st2*
-          key: ${{ runner.os }}-v4-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
+          key: ${{ runner.os }}-v5-python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'lockfiles/*.lock') }}
           # Don't use alternative key as if requirements.txt has altered we
           # don't want to retrieve previous cache
           #restore-keys: |
-          #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
+          #  ${{ runner.os }}-v5-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
         uses: actions/cache@v4

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -123,7 +123,7 @@ jobs:
       PATH: /home/runner/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Custom Environment Setup
         run: |
           ./scripts/github/setup-environment.sh

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -128,7 +128,7 @@ jobs:
         run: |
           ./scripts/github/setup-environment.sh
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -132,7 +132,7 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Cache Python Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -148,7 +148,7 @@ jobs:
           #  ${{ runner.os }}-v4-python-${{ matrix.python }}-
       - name: Cache APT Dependencies
         id: cache-apt-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/apt_cache

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -213,7 +213,7 @@ jobs:
           exit 1
       - name: Upload StackStorm services Logs
         #if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: logs/
@@ -223,7 +223,7 @@ jobs:
           tar cvzpf logs.tar.gz logs/*
       - name: Upload StackStorm services Logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: logs.tar.gz

--- a/.github/workflows/orquesta-integration-tests.yaml
+++ b/.github/workflows/orquesta-integration-tests.yaml
@@ -60,7 +60,7 @@ jobs:
             nosetests_node_total: 1
             nosetests_node_index: 0
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Integration Tests (Orquesta)'
             task: 'ci-orquesta'
             nosetests_node_total: 1

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
           submodules: 'true'

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -56,7 +56,7 @@ jobs:
           pants tailor --check update-build-files --check ::
 
       - name: Upload pants log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pants-log-py${{ matrix.python-version }}
           path: .pants.d/pants.log

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -30,7 +30,7 @@ jobs:
           submodules: 'true'
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@v6-scie-pants
+        uses: pantsbuild/actions/init-pants@v8
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
           ./scripts/github/install-apt-packages-use-cache.sh
 
       - name: Initialize Pants and its GHA caches
-        uses: pantsbuild/actions/init-pants@v6-scie-pants
+        uses: pantsbuild/actions/init-pants@v8
         # This action adds an env var to make pants use both pants.ci.toml & pants.toml.
         # This action also creates 3 GHA caches (1 is optional).
         # - `pants-setup` has the bootsrapped pants install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
           pants test pylint_plugins/:: pants-plugins/::
 
       - name: Upload pants log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pants-log-py${{ matrix.python-version }}
           path: .pants.d/pants.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
         include:
           - name: 'Test (pants runs: pytest)'
             python-version-short: '3.8'
-            python-version: '3.8.18'
+            python-version: '3.8.10'
           - name: 'Test (pants runs: pytest)'
             python-version-short: '3.9'
             python-version: '3.9.14'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,7 @@ jobs:
           submodules: 'true'
 
       - name: 'Set up Python (${{ matrix.python-version }})'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,7 @@ jobs:
 
       #- name: Cache APT Dependencies
       #  id: cache-apt-deps
-      #  uses: actions/cache@v2
+      #  uses: actions/cache@v4
       #  with:
       #    path: |
       #      ~/apt_cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,9 +89,9 @@ jobs:
       #  with:
       #    path: |
       #      ~/apt_cache
-      #    key: ${{ runner.os }}-apt-v7-${{ hashFiles('scripts/github/apt-packages.txt') }}
+      #    key: ${{ runner.os }}-v8-apt-${{ hashFiles('scripts/github/apt-packages.txt') }}
       #    restore-keys: |
-      #      ${{ runner.os }}-apt-v7-
+      #      ${{ runner.os }}-v8-apt-
       - name: Install APT Depedencies
         env:
           CACHE_HIT: 'false' # cache doesn't work

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
           submodules: 'true'


### PR DESCRIPTION
- Revert "bump py 3.8.10->3.8.18 to workaround GHA failure"
- bump gha setup-python action to v5
- bump gha checkout action to v4
- bump gha cache action to v4
- bump gha upload-artifact action to v4
- bump gha pantsbuild/actions/init-pants action to v8
- GHA: bust python caches and account for full venv lock
- GHA: bust apt caches
