### PR TITLE
Fix issue with cd'ing in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ install-runners:
 	@echo "================== INSTALL RUNNERS ===================="
 	@echo ""
 	# NOTE: We use xargs to speed things up by installing runners in parallel
-	echo -e "$(COMPONENTS_RUNNERS)" | tr -d "\n" | xargs -P $(XARGS_CONCURRENCY) -d " " -n1 -i sh -c ". $(VIRTUALENV_DIR)/bin/activate; cd {} ; python setup.py develop --no-deps"
+	echo -e "$(COMPONENTS_RUNNERS)" | tr -d "\n" | xargs -P $(XARGS_CONCURRENCY) -d " " -n1 -i sh -c ". $(VIRTUALENV_DIR)/bin/activate; cd $$(pwd)/{} ; python setup.py develop --no-deps"
 	#@for component in $(COMPONENTS_RUNNERS); do \
 	#	echo "==========================================================="; \
 	#	echo "Installing runner:" $$component; \
@@ -187,7 +187,7 @@ install-mock-runners:
 	@echo "================== INSTALL MOCK RUNNERS ===================="
 	@echo ""
 	# NOTE: We use xargs to speed things up by installing runners in parallel
-	echo -e "$(MOCK_RUNNERS)" | tr -d "\n" | xargs -P $(XARGS_CONCURRENCY) -d " " -n1 -i sh -c ". $(VIRTUALENV_DIR)/bin/activate; cd {} ; python setup.py develop --no-deps"
+	echo -e "$(MOCK_RUNNERS)" | tr -d "\n" | xargs -P $(XARGS_CONCURRENCY) -d " " -n1 -i sh -c ". $(VIRTUALENV_DIR)/bin/activate; cd $$(pwd)/{} ; python setup.py develop --no-deps"
 	#@for component in $(MOCK_RUNNERS); do \
 	#	echo "==========================================================="; \
 	#	echo "Installing mock runner:" $$component; \


### PR DESCRIPTION
When I attempt to run the `Makefile` locally on my M1 MacBook (unsure if that's related) I hit this error:

```
================== INSTALL RUNNERS ====================

# NOTE: We use xargs to speed things up by installing runners in parallel
echo -e "contrib/runners/action_chain_runner contrib/runners/announcement_runner contrib/runners/http_runner contrib/runners/inquirer_runner contrib/runners/local_runner contrib/runners/noop_runner contrib/runners/orquesta_runner contrib/runners/python_runner contrib/runners/remote_runner contrib/runners/winrm_runner" | tr -d "\n" | xargs -P 8 -d " " -n1 -i sh -c ". virtualenv-osx/bin/activate; cd {} ; python setup.py develop --no-deps"
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
sh: line 0: cd: contrib/runners/action_chain_runner: No such file or directory
sh: line 0: cd: contrib/runners/announcement_runner: No such file or directory
sh: line 0: cd: contrib/runners/http_runner: No such file or directory
sh: line 0: cd: contrib/runners/local_runner: No such file or directory
sh: line 0: cd: contrib/runners/inquirer_runner: No such file or directory
sh: line 0: cd: contrib/runners/noop_runner: No such file or directory
sh: line 0: cd: contrib/runners/python_runner: No such file or directory
sh: line 0: cd: contrib/runners/orquesta_runner: No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
sh: line 0: cd: contrib/runners/remote_runner: No such file or directory
sh: line 0: cd: contrib/runners/winrm_runner: No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/sswann/code/st2/setup.py': [Errno 2] No such file or directory
make: *** [install-runners] Error 123
```

Where `make` doesn't seem to be able to `cd` into the `contrib/runners/*` directories.

I fixed this by simply adding `$$(pwd)/` before the `cd` commands to make the path being `cd` the full explicit path and this seems to fix everything.