### PR TITLE
correct bcrypt to fix the known issue with 4.1.2

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -35,7 +35,6 @@ oslo.config==9.4.0
 oslo.utils==7.1.0
 # paramiko 2.11.0 is needed by cryptography > 37.0.0
 paramiko==3.4.0
-passlib==1.7.4
 # 202403: bump to 3.0.43 for py3.10 support
 prompt-toolkit==3.0.43
 pyinotify==0.9.6 ; platform_system=="Linux"
@@ -75,7 +74,8 @@ virtualenv==20.26.1
 webob==1.8.7
 zake==0.2.2
 # test requirements below
-bcrypt==4.1.2
+bcrypt==4.0.1
+passlib[bcrypt]
 jinja2==3.1.3
 mock==5.1.0
 nose-timer==1.0.1


### PR DESCRIPTION
I was testing st23.9 dev on Rhel9, st2auth fails to startup with following error. Downgrading bcrypt to fix the [known bug in 4.1.2 ](https://github.com/langflow-ai/langflow/issues/1173)
<img width="1723" alt="Screenshot 2024-05-31 at 6 53 24 PM" src="https://github.com/StackStorm/st2/assets/96410422/a5d3589c-7f5e-416f-929e-85f2d9be816e">
