### PR TITLE
Bump tooz to 6.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Fixed
 ~~~~~
 * Restore Pack integration testing (it was inadvertently skipped) and stop testing against `bionic` and `el7`. #6135
 * Fix Popen.pid typo in st2tests. #6184
+* Bump tooz package to `6.2.0` to fix TLS. #6220 (@jk464)
 
 Changed
 ~~~~~~~

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -67,7 +67,7 @@ typing-extensions==4.11.0
 sseclient-py==1.8.0
 stevedore==5.2.0
 tenacity==8.2.3
-tooz==6.1.0
+tooz==6.2.0
 # Note: virtualenv embeds wheels for pip, wheel, and setuptools. So pinning virtualenv pins those as well.
 # virtualenv==20.26.0 (<21) has pip==24.0 wheel==0.43.0 setuptools==69.5.1
 # lockfiles/st2.lock has pip==24.0 wheel==0.43.0 setuptools==69.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ st2-auth-ldap@ git+https://github.com/StackStorm/st2-auth-ldap.git@master
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 stevedore==5.2.0
 tenacity==8.2.3
-tooz==6.1.0
+tooz==6.2.0
 typing-extensions==4.11.0
 unittest2
 webob==1.8.7

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -43,7 +43,7 @@ semver==3.0.2
 six==1.16.0
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 tenacity==8.2.3
-tooz==6.1.0
+tooz==6.2.0
 webob==1.8.7
 zake==0.2.2
 zstandard==0.22.0


### PR DESCRIPTION
Bump `tooz` to version `6.2.0` this contains the fix https://github.com/openstack/tooz/commit/d09659ed5b20298234ddc7c1ed75721725dade29 (https://github.com/openstack/tooz/compare/6.1.0...6.2.0) which fixes TLS on Redis Sentinel (which was broken in `6.1.0`)