### PR TITLE
Fix `packs.get` action

### DIFF
--- a/contrib/packs/actions/get.yaml
+++ b/contrib/packs/actions/get.yaml
@@ -9,3 +9,8 @@ parameters:
     type: "string"
     description: "Name of pack to lookup"
     required: true
+  branch:
+    type: "string"
+    description: "The primary branch of this pack repo"
+    required: false
+    default: "master"

--- a/contrib/packs/actions/pack_mgmt/get_installed.py
+++ b/contrib/packs/actions/pack_mgmt/get_installed.py
@@ -29,10 +29,11 @@ from st2common.constants.pack import MANIFEST_FILE_NAME
 class GetInstalled(Action):
     """Get information about installed pack."""
 
-    def run(self, pack):
+    def run(self, pack, branch):
         """
         :param pack: Installed Pack Name to get info about
         :type pack: ``str``
+        :type branch: ``str``
         """
         packs_base_paths = get_packs_base_paths()
 
@@ -69,9 +70,8 @@ class GetInstalled(Action):
                 repo.git.status().split("\n")[0],
                 "\n".join([remote.url for remote in repo.remotes]),
             )
-
             ahead_behind = repo.git.rev_list(
-                "--left-right", "--count", "HEAD...origin/master"
+                "--left-right", "--count", f"HEAD...origin/{branch}"
             ).split()
             # Dear god.
             if ahead_behind != ["0", "0"]:


### PR DESCRIPTION
Addresses #6225. This should allow users to specify a branch when using the `packs.get` command. This addresses the assumption in the code that the primary branch of a git repository corresponding to an action is `master`.

* Add `branch` parameter to `get.yaml`. Default to `master` to maintain current functionality/expectations.
* Update `run` in `pack_mgmt.get_install.py`. Now accepts `branch` param and uses an `fstring` to represent the in `git rev list`.