### PR TITLE
Pants upgrade from 2.22.0 to 2.23.0a0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# See: https://www.mankier.com/5/gitattributes
+
+# lockfile merge conflicts: do not manually merge.
+# The "-merge" makes git leave the current branch's lockfile as-is, like a binary file.
+# To resolve the conflict, resolve any conflicts in requirements files,
+# and then regenerste the lockfile with (resolve names are 'st2', 'black', etc):
+#   pants generate-lockfiles --resolve=<resolve name>
+/lockfiles/*.lock -merge

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/chatops/tests/BUILD
+++ b/contrib/chatops/tests/BUILD
@@ -1,6 +1,11 @@
 # tests can only be dependencies of other tests in this directory
 __dependents_rules__(("*", "/**", "!*"))
 
+__defaults__(
+    {python_test: dict(tags=["pack"])},
+    extend=True,
+)
+
 files(
     name="fixtures",
     sources=["fixtures/*.json"],

--- a/contrib/core/tests/BUILD
+++ b/contrib/core/tests/BUILD
@@ -1,6 +1,11 @@
 # tests can only be dependencies of other tests in this directory
 __dependents_rules__(("*", "/**", "!*"))
 
+__defaults__(
+    {python_test: dict(tags=["pack"])},
+    extend=True,
+)
+
 python_tests(
     skip_pylint=True,
     overrides={

--- a/contrib/examples/tests/BUILD
+++ b/contrib/examples/tests/BUILD
@@ -1,6 +1,11 @@
 # tests can only be dependencies of other tests in this directory
 __dependents_rules__(("*", "/**", "!*"))
 
+__defaults__(
+    {python_test: dict(tags=["pack"])},
+    extend=True,
+)
+
 python_tests(
     skip_pylint=True,
 )

--- a/contrib/linux/tests/BUILD
+++ b/contrib/linux/tests/BUILD
@@ -1,6 +1,11 @@
 # tests can only be dependencies of other tests in this directory
 __dependents_rules__(("*", "/**", "!*"))
 
+__defaults__(
+    {python_test: dict(tags=["pack"])},
+    extend=True,
+)
+
 python_tests(
     skip_pylint=True,
 )

--- a/contrib/packs/tests/BUILD
+++ b/contrib/packs/tests/BUILD
@@ -1,6 +1,11 @@
 # tests can only be dependencies of other tests in this directory
 __dependents_rules__(("*", "/**", "!*"))
 
+__defaults__(
+    {python_test: dict(tags=["pack"])},
+    extend=True,
+)
+
 python_tests(
     skip_pylint=True,
 )

--- a/lockfiles/pants-plugins.lock
+++ b/lockfiles/pants-plugins.lock
@@ -9,8 +9,8 @@
 //     "CPython==3.9.*"
 //   ],
 //   "generated_with_requirements": [
-//     "pantsbuild.pants.testutil==2.22.0",
-//     "pantsbuild.pants==2.22.0"
+//     "pantsbuild.pants.testutil==2.23.0a0",
+//     "pantsbuild.pants==2.23.0a0"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -25,6 +25,7 @@
   "allow_wheels": true,
   "build_isolation": true,
   "constraints": [],
+  "excluded": [],
   "locked_resolves": [
     {
       "locked_requirements": [
@@ -245,6 +246,66 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "d024f44059a853b4b852cfc04fec33e346659d851371e46fc8e7c19de24d3da9",
+              "url": "https://files.pythonhosted.org/packages/71/da/16307f14b47f761235050076e1d2954fc7de9346f1410ba8c67a54a9f40e/libcst-1.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b8ecdba8934632b4dadacb666cd3816627a6ead831b806336972ccc4ba7ca0e9",
+              "url": "https://files.pythonhosted.org/packages/7b/b1/8476fe4fa1061062855459d519ffe2115a891638c230ee3465c69fdbfd7a/libcst-1.4.0-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8e54c777b8d27339b70f304d16fc8bc8674ef1bd34ed05ea874bf4921eb5a313",
+              "url": "https://files.pythonhosted.org/packages/7e/0d/89516795ff2a11be10c060c539895b3781793d46cb7c9b0b7b3c4fa3fbc1/libcst-1.4.0-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb0abf627ee14903d05d0ad9b2c6865f1b21eb4081e2c7bea1033f85db2b8bae",
+              "url": "https://files.pythonhosted.org/packages/95/cf/a2be91d53e4068d4def8b5cc475f20e1c1a7d32c85634ee7d6b3ea2e3c9b/libcst-1.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "061d6855ef30efe38b8a292b7e5d57c8e820e71fc9ec9846678b60a934b53bbb",
+              "url": "https://files.pythonhosted.org/packages/c0/c8/15ca337e5f5604aabed899609ba08abbc0e7815ffdfca37802da52d4d0bf/libcst-1.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "449e0b16604f054fa7f27c3ffe86ea7ef6c409836fe68fe4e752a1894175db00",
+              "url": "https://files.pythonhosted.org/packages/e4/bd/ff41d7a8efc4f60a61d903c3f9823565006f44f2b8b11c99701f552b0851/libcst-1.4.0.tar.gz"
+            }
+          ],
+          "project_name": "libcst",
+          "requires_dists": [
+            "Sphinx>=5.1.1; extra == \"dev\"",
+            "black==23.12.1; extra == \"dev\"",
+            "build>=0.10.0; extra == \"dev\"",
+            "coverage>=4.5.4; extra == \"dev\"",
+            "fixit==2.1.0; extra == \"dev\"",
+            "flake8==7.0.0; extra == \"dev\"",
+            "hypothesis>=4.36.0; extra == \"dev\"",
+            "hypothesmith>=0.0.4; extra == \"dev\"",
+            "jinja2==3.1.4; extra == \"dev\"",
+            "jupyter>=1.0.0; extra == \"dev\"",
+            "maturin<1.6,>=0.8.3; extra == \"dev\"",
+            "nbsphinx>=0.4.2; extra == \"dev\"",
+            "prompt-toolkit>=2.0.9; extra == \"dev\"",
+            "pyre-check==0.9.18; platform_system != \"Windows\" and extra == \"dev\"",
+            "pyyaml>=5.2",
+            "setuptools-rust>=1.5.2; extra == \"dev\"",
+            "setuptools-scm>=6.0.1; extra == \"dev\"",
+            "slotscheck>=0.7.1; extra == \"dev\"",
+            "sphinx-rtd-theme>=0.4.3; extra == \"dev\"",
+            "ufmt==2.6.0; extra == \"dev\"",
+            "usort==1.0.8.post1; extra == \"dev\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "1.4.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "8153270903772b1e59500ced6f0aca0f7bdb021651c27584e9283b7077b4916b",
               "url": "https://files.pythonhosted.org/packages/1a/4b/180481021692a76dc91f46fa6a49cdef4c3e630c77a83b7fda3f4eb7aa04/node_semver-0.9.0-py3-none-any.whl"
             },
@@ -285,23 +346,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "edfcecc959eebfb0c42602b29d7301d96b92d3bbde030ba2c4ce3e775801cbd3",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.22.0/pantsbuild.pants-2.22.0-cp39-cp39-manylinux2014_x86_64.whl"
+              "hash": "f7104cf619c928752041acfe36966742dec5309b171aeef921239d4595ee4161",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.23.0a0/pantsbuild.pants-2.23.0a0-cp39-cp39-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a4b2a095c0d77afa6605ed591dfa334ebbbc2858676a1397dbe1bbc7bf7a1e68",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.22.0/pantsbuild.pants-2.22.0-cp39-cp39-macosx_10_15_x86_64.whl"
+              "hash": "d74b12dd7c4dd4cc9a7c81e55126db298577830c62962a6f8cbb4d875930f9ed",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.23.0a0/pantsbuild.pants-2.23.0a0-cp39-cp39-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "72ff3f0351389688fd031c8cbb77beffd5e1234ea139da24940522e5de6c14f8",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.22.0/pantsbuild.pants-2.22.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "3afee18ce33b16cb3147ed18e190f0e37d4f3561d58354ee1203f7c66cfe1c5f",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.23.0a0/pantsbuild.pants-2.23.0a0-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d68791c067bc8902d2fceef8226c3ac443ec3349ab6463fcfe081d33647c4055",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.22.0/pantsbuild.pants-2.22.0-cp39-cp39-manylinux2014_aarch64.whl"
+              "hash": "6e47e4076e8321005b15afa4bd63f1444e32446de2634043caeafa35853a279c",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.23.0a0/pantsbuild.pants-2.23.0a0-cp39-cp39-manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pantsbuild-pants",
@@ -311,9 +372,10 @@
             "chevron==0.14.0",
             "fasteners==0.16.3",
             "ijson==3.2.3",
+            "libcst==1.4.0",
             "node-semver==0.9.0",
             "packaging==21.3",
-            "pex==2.3.1",
+            "pex==2.16.2",
             "psutil==5.9.8",
             "python-lsp-jsonrpc==1.0.0",
             "setproctitle==1.3.2",
@@ -322,46 +384,46 @@
             "types-PyYAML==6.0.3",
             "types-setuptools==62.6.1",
             "types-toml==0.10.8",
-            "typing-extensions==4.3.0"
+            "typing-extensions~=4.12"
           ],
           "requires_python": "==3.9.*",
-          "version": "2.22.0"
+          "version": "2.23.0a0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4c4a0319e98f4892581887a713a78a2ee37ace5cd1535e5e73164942c59e632a",
-              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.22.0/pantsbuild.pants.testutil-2.22.0-py3-none-any.whl"
+              "hash": "f74af1d1cbac2f8c17e441e2e6c96588fc1816828ecc2665b535dd4ccfbaa6c7",
+              "url": "https://github.com/pantsbuild/pants/releases/download/release_2.23.0a0/pantsbuild.pants.testutil-2.23.0a0-py3-none-any.whl"
             }
           ],
           "project_name": "pantsbuild-pants-testutil",
           "requires_dists": [
-            "pantsbuild.pants==2.22.0",
+            "pantsbuild.pants==2.23.0a0",
             "pytest<7.1.0,>=6.2.4"
           ],
           "requires_python": "==3.9.*",
-          "version": "2.22.0"
+          "version": "2.23.0a0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "64692a5bf6f298403aab930d22f0d836ae4736c5bc820e262e9092fe8c56f830",
-              "url": "https://files.pythonhosted.org/packages/e7/d0/fbda2a4d41d62d86ce53f5ae4fbaaee8c34070f75bb7ca009090510ae874/pex-2.3.1-py2.py3-none-any.whl"
+              "hash": "8610b5bf7731c98d871421ff21e769e8fcf42ea56aa4ac7f8a271f2405733f24",
+              "url": "https://files.pythonhosted.org/packages/de/45/94497d22a1517b2462394f641ea272e7ec624823f223c01a5f0d7e6f571d/pex-2.16.2-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d1264c91161c21139b454744c8053e25b8aad2d15da89232181b4f38f3f54575",
-              "url": "https://files.pythonhosted.org/packages/83/4b/1855a9cd872a5eca4cd385e0f66078845f3561d359fb976be52a2a68b9d1/pex-2.3.1.tar.gz"
+              "hash": "feb2f1e9819a741915759fc221ee6119447acdfc3e0aaa5bbe5800c39fa10003",
+              "url": "https://files.pythonhosted.org/packages/87/cf/a39ace2db568e3bce48c79fd462aa289608208fe4509ff746349162e5196/pex-2.16.2.tar.gz"
             }
           ],
           "project_name": "pex",
           "requires_dists": [
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.13,>=2.7",
-          "version": "2.3.1"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
+          "version": "2.16.2"
         },
         {
           "artifacts": [
@@ -828,19 +890,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+              "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "url": "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
-          "requires_python": ">=3.7",
-          "version": "4.3.0"
+          "requires_python": ">=3.8",
+          "version": "4.12.2"
         },
         {
           "artifacts": [
@@ -926,13 +988,14 @@
   ],
   "only_builds": [],
   "only_wheels": [],
+  "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.3.1",
+  "pex_version": "2.16.2",
   "pip_version": "24.0",
   "prefer_older_binary": false,
   "requirements": [
-    "pantsbuild.pants.testutil==2.22.0",
-    "pantsbuild.pants==2.22.0"
+    "pantsbuild.pants.testutil==2.23.0a0",
+    "pantsbuild.pants==2.23.0a0"
   ],
   "requires_python": [
     "==3.9.*"

--- a/pants.toml
+++ b/pants.toml
@@ -159,7 +159,7 @@ py_editable_in_resolve = ["st2"]
 py_resolve_format = "mutable_virtualenv"
 # By default, pex modifies script shebangs to add '-sE'.
 # This breaks nosetest and anything that needs PYTHONPATH.
-py_hermetic_scripts = false
+py_non_hermetic_scripts_in_resolve = ["st2"]
 # If any targets generate sources/files, include them in the exported venv.
 py_generated_sources_in_resolve = ["st2"]
 

--- a/pants.toml
+++ b/pants.toml
@@ -6,7 +6,7 @@ enabled = false
 repo_id = "de0dea7a-9f6a-4c6e-aa20-6ba5ad969b8a"
 
 [GLOBAL]
-pants_version = "2.22.0"
+pants_version = "2.23.0a0"
 pythonpath = ["%(buildroot)s/pants-plugins"]
 build_file_prelude_globs = ["pants-plugins/macros.py"]
 backend_packages = [

--- a/pants.toml
+++ b/pants.toml
@@ -40,6 +40,7 @@ backend_packages = [
 pants_ignore.add = [
   # TODO: remove these once we start building wheels with pants.
   "dist_utils.py",
+  "test_dist_utils.py",
   "setup.py",
   # keep tailor from using legacy requirements files (not for pants)
   "contrib/examples/requirements.txt",

--- a/st2common/tests/unit/test_dist_utils.py
+++ b/st2common/tests/unit/test_dist_utils.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NB: Pantsbuild ignores this file and any dist_utils.py files.
+# TODO: delete this file when deleting all dist_utils.py files.
+
 import os
 import sys
 


### PR DESCRIPTION
This updates from pants 2.22 to 2.23. The stable version of 2.23 has not been released yet, but with so many features that we need, it's worth using an alpha to unblock other developments.

I also added a `.gitattributes` file to try and improve the UX of fixing lockfile merge conflicts.

I also included 2 minor commits extracted from #6202:
- pants is already configured to ignore `dist_utils.py`, so also ignore `test_dist_utils.py`: 423472495f702f7c19a328dd62b35b0c42ac3a39
- Add `tags=["pack"]` to all of the pack tests so that we can easily run just the pack tests via pants: 77ee17c03accc48cc8d0d0cc28420945772f914f

Follow-up PRs will allow us to run all of the pack and unit tests via pants + pytest.

### Interesting new features in 2.23

- https://github.com/pantsbuild/pants/blob/main/docs/notes/2.23.x.md
- https://github.com/pantsbuild/pants/releases/tag/release_2.23.0a0 

The `[export].py_hermetic_scripts` option is renamed to `[export].py_non_hermetic_scripts_in_resolve` in 2.23:
- https://www.pantsbuild.org/2.23/reference/goals/export#py_non_hermetic_scripts_in_resolve

This release adds the last 2 features we need from pants to get pants+pytest to run all of our unit and pack tests, based on work in #6202:
  - Added a `python_test(entry_point_dependencies={...})` BUILD metadata field. This field was added to resolve issues enabling our runner tests (released in 2.23.0.dev2): https://github.com/pantsbuild/pants/pull/21062

  - Added a pants plugin api `PytestPluginSetup(extra_sys_path=...)` which we need to finish some pack_metadata based dependency inference (released in 2.23.0a0): https://github.com/pantsbuild/pants/pull/21274

v2.23.0a0 also includes the `nfpm` plugin I wrote to replace our `st2-packaging` repo. `nFPM` builds system packages like rpm and deb without the complicated ruby+docker+the-kitchen-sink dance we do in `st2-packaging`.
- https://github.com/pantsbuild/pants/pull/19308
- https://github.com/pantsbuild/pants/pull/21300
- https://github.com/pantsbuild/pants/pull/21297
- https://github.com/pantsbuild/pants/pull/21298
- https://github.com/pantsbuild/pants/pull/21299
- https://github.com/pantsbuild/pants/pull/21310

### pants-plugins lockfile diffs

From 2.22 to 2.23
```
Lockfile diff: lockfiles/pants-plugins.lock [pants-plugins]
                                                                  
==                    Upgraded dependencies                     ==

  pantsbuild-pants               2.22.0       -->   2.23.0a0
  pantsbuild-pants-testutil      2.22.0       -->   2.23.0a0
  pex                            2.3.1        -->   2.16.2
  typing-extensions              4.3.0        -->   4.12.2
                                                                  
==                      Added dependencies                      ==

  libcst                         1.4.0
```