### PR TITLE
Misc CI improvements/fixes

### DIFF
--- a/st2common/st2common/content/bootstrap.py
+++ b/st2common/st2common/content/bootstrap.py
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 import os
 import sys
 import logging

--- a/st2common/st2common/util/monkey_patch.py
+++ b/st2common/st2common/util/monkey_patch.py
@@ -45,13 +45,7 @@ def monkey_patch(patch_thread=None):
                          patched unless debugger is used.
     :type patch_thread: ``bool``
     """
-    # Eventlet when patched doesn't throw the standard ssl error on timeout, which can break
-    # some third-party libraries including redis SSL.
-    # See: https://github.com/eventlet/eventlet/issues/692
-    # Therefore set the patched ssl module to use the standard socket.timeout exception
-    from eventlet.green import ssl
     import eventlet
-    from socket import timeout
 
     if patch_thread is None:
         patch_thread = not is_use_debugger_flag_provided()
@@ -60,7 +54,6 @@ def monkey_patch(patch_thread=None):
     eventlet.monkey_patch(
         os=True, select=True, socket=True, thread=patch_thread, time=True
     )
-    ssl.timeout_exc = timeout
 
 
 def use_select_poll_workaround(nose_only=True):

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -119,6 +119,7 @@ function init()
     echo -n "Using virtualenv: "; iecho "${VIRTUALENV}"
     echo -n "Using python: "; iecho "${PY} (${PYTHON_VERSION})"
     echo -n "Log file location: "; iecho "${ST2_LOGS}"
+    echo -n "Using tmux: "; iecho "$(tmux -V)"
 
     if [ -z "$ST2_CONF" ]; then
         ST2_CONF=${ST2_REPO}/conf/st2.dev.conf
@@ -221,7 +222,7 @@ function st2start()
     export ST2_CONFIG_PATH=${ST2_CONF};
 
     # Kill existing st2 terminal multiplexor sessions
-    for tmux_session in $(tmux ls | awk -F: '/^st2-/ {print $1}')
+    for tmux_session in $(tmux ls 2>/dev/null | awk -F: '/^st2-/ {print $1}')
     do
         echo "Kill existing session $tmux_session"
         tmux kill-session -t $tmux_session
@@ -328,7 +329,7 @@ function st2start()
     echo
     for s in "${SESSIONS[@]}"
     do
-        tmux ls | grep "^${s}[[:space:]]" &> /dev/null
+        tmux ls | grep "^${s}:\?[[:space:]]" &> /dev/null
         if [ $? != 0 ]; then
             eecho "ERROR: terminal multiplex session for $s failed to start."
         fi
@@ -356,7 +357,7 @@ function st2start()
 
 function st2stop()
 {
-    for tmux_session in $(tmux ls | awk -F: '/^st2-/ {print $1}')
+    for tmux_session in $(tmux ls 2>/dev/null | awk -F: '/^st2-/ {print $1}')
     do
         echo "Kill existing session $tmux_session"
         tmux kill-session -t $tmux_session


### PR DESCRIPTION
While debugging some GHA instability, I found 3 minor things to improve or cleanup: 
- clean up tmux usage in `tools/launchdev.sh`
- Make sure eventlet patching happens early when running st2-register-content
- drop eventlet bug workaround as the bug was fixed upstream several releases ago.