### PR TITLE
Clean up import side effects in tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/st2actions/tests/unit/policies/test_base.py
+++ b/st2actions/tests/unit/policies/test_base.py
@@ -16,9 +16,8 @@
 from __future__ import absolute_import
 import mock
 
-from st2tests import config as test_config
-
-test_config.parse_args()
+# This import must be early for import-time side-effects.
+from st2tests.base import CleanDbTestCase, DbTestCase
 
 import st2common
 from st2common.bootstrap.policiesregistrar import register_policy_types
@@ -28,8 +27,6 @@ from st2common import policies
 from st2common.services import action as action_service
 from st2common.services import policies as policy_service
 from st2common.bootstrap import runnersregistrar as runners_registrar
-from st2tests.base import DbTestCase
-from st2tests.base import CleanDbTestCase
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests.fixturesloader import FixturesLoader
 

--- a/st2actions/tests/unit/policies/test_concurrency.py
+++ b/st2actions/tests/unit/policies/test_concurrency.py
@@ -19,10 +19,9 @@ import mock
 from mock import call
 from six.moves import range
 
+# This import must be early for import-time side-effects.
 # Importing st2actions.scheduler relies on config being parsed :/
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+from st2tests import DbTestCase, EventletTestCase, ExecutionDbTestCase
 
 import st2common
 from st2actions.scheduler import handler as scheduling_queue
@@ -38,8 +37,6 @@ from st2common.services import coordination
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.bootstrap import runnersregistrar as runners_registrar
-from st2tests import DbTestCase, EventletTestCase
-from st2tests import ExecutionDbTestCase
 import st2tests.config as tests_config
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests.fixturesloader import FixturesLoader

--- a/st2actions/tests/unit/policies/test_concurrency_by_attr.py
+++ b/st2actions/tests/unit/policies/test_concurrency_by_attr.py
@@ -18,10 +18,9 @@ from __future__ import absolute_import
 import mock
 from mock import call
 
+# This import must be early for import-time side-effects.
 # Importing st2actions.scheduler relies on config being parsed :/
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+from st2tests import ExecutionDbTestCase, EventletTestCase
 
 import st2common
 from st2actions.scheduler import handler as scheduling_queue
@@ -36,7 +35,6 @@ from st2common.services import coordination
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.bootstrap import runnersregistrar as runners_registrar
-from st2tests import ExecutionDbTestCase, EventletTestCase
 import st2tests.config as tests_config
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests.fixturesloader import FixturesLoader

--- a/st2actions/tests/unit/test_action_runner_worker.py
+++ b/st2actions/tests/unit/test_action_runner_worker.py
@@ -20,14 +20,17 @@ from mock import Mock
 from st2common.transport.consumers import ActionsQueueConsumer
 from st2common.models.db.liveaction import LiveActionDB
 
-from st2tests import config as test_config
-
-test_config.parse_args()
+from st2tests import config as tests_config
 
 __all__ = ["ActionsQueueConsumerTestCase"]
 
 
 class ActionsQueueConsumerTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def test_process_right_dispatcher_is_used(self):
         handler = Mock()
         handler.message_type = LiveActionDB

--- a/st2actions/tests/unit/test_execution_cancellation.py
+++ b/st2actions/tests/unit/test_execution_cancellation.py
@@ -20,10 +20,8 @@ import uuid
 
 from oslo_config import cfg
 
-# XXX: actionsensor import depends on config being setup.
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+# This import must be early for import-time side-effects.
+from st2tests import ExecutionDbTestCase
 
 from st2common.constants import action as action_constants
 from st2common.models.api.action import ActionAPI
@@ -36,7 +34,6 @@ from st2common.services import action as action_service
 from st2common.services import trace as trace_service
 from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
-from st2tests import ExecutionDbTestCase
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests.fixturesloader import FixturesLoader
 from st2tests.mocks.execution import MockExecutionPublisher

--- a/st2actions/tests/unit/test_executions.py
+++ b/st2actions/tests/unit/test_executions.py
@@ -18,10 +18,8 @@ import copy
 
 import mock
 
-# XXX: actionsensor import depends on config being setup.
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+# This import must be early for import-time side-effects.
+from st2tests import ExecutionDbTestCase
 
 import st2common.bootstrap.runnersregistrar as runners_registrar
 from st2common.constants import action as action_constants
@@ -46,7 +44,6 @@ from st2reactor.rules.enforcer import RuleEnforcer
 from local_runner.local_shell_command_runner import LocalShellCommandRunner
 
 from st2tests.fixtures.packs import executions as fixture
-from st2tests import ExecutionDbTestCase
 from st2tests.mocks.liveaction import MockLiveActionPublisher
 
 

--- a/st2actions/tests/unit/test_notifier.py
+++ b/st2actions/tests/unit/test_notifier.py
@@ -19,9 +19,8 @@ import datetime
 import bson
 import mock
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+# This import must be early for import-time side-effects.
+from st2tests.base import CleanDbTestCase
 
 from st2actions.notifier.notifier import Notifier
 from st2common.constants.action import LIVEACTION_COMPLETED_STATES
@@ -40,7 +39,6 @@ from st2common.persistence.policy import Policy
 from st2common.models.system.common import ResourceReference
 from st2common.util import date as date_utils
 from st2common.util import isotime
-from st2tests.base import CleanDbTestCase
 
 ACTION_TRIGGER_TYPE = INTERNAL_TRIGGER_TYPES["action"][0]
 NOTIFY_TRIGGER_TYPE = INTERNAL_TRIGGER_TYPES["action"][1]

--- a/st2actions/tests/unit/test_output_schema.py
+++ b/st2actions/tests/unit/test_output_schema.py
@@ -20,11 +20,8 @@ from http_runner import http_runner
 from python_runner import python_runner
 from orquesta_runner import orquesta_runner
 
+# This import must be early for import-time side-effects.
 import st2tests
-
-import st2tests.config as tests_config
-
-tests_config.parse_args()
 
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar

--- a/st2actions/tests/unit/test_parallel_ssh.py
+++ b/st2actions/tests/unit/test_parallel_ssh.py
@@ -25,8 +25,6 @@ from st2common.runners.paramiko_ssh import ParamikoSSHClient
 from st2common.runners.paramiko_ssh import SSHCommandTimeoutError
 import st2tests.config as tests_config
 
-tests_config.parse_args()
-
 MOCK_STDERR_SUDO_PASSWORD_ERROR = """
 [sudo] password for bar: Sorry, try again.\n
 [sudo] password for bar:' Sorry, try again.\n
@@ -36,6 +34,11 @@ sudo: 2 incorrect password attempts
 
 
 class ParallelSSHTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @patch("paramiko.SSHClient", Mock)
     @patch.object(
         ParamikoSSHClient,

--- a/st2actions/tests/unit/test_paramiko_remote_script_runner.py
+++ b/st2actions/tests/unit/test_paramiko_remote_script_runner.py
@@ -22,8 +22,6 @@ import unittest
 # before importing remote_script_runner classes.
 import st2tests.config as tests_config
 
-tests_config.parse_args()
-
 from st2common.util import jsonify
 from st2common.models.db.action import ActionDB
 from st2common.runners.parallel_ssh import ParallelSSHClient
@@ -48,6 +46,11 @@ ACTION_1 = MODELS["actions"]["a1.yaml"]
 
 
 class ParamikoScriptRunnerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @patch("st2common.runners.parallel_ssh.ParallelSSHClient", Mock)
     @patch.object(jsonify, "json_loads", MagicMock(return_value={}))
     @patch.object(ParallelSSHClient, "run", MagicMock(return_value={}))

--- a/st2actions/tests/unit/test_paramiko_ssh.py
+++ b/st2actions/tests/unit/test_paramiko_ssh.py
@@ -29,12 +29,15 @@ from st2common.runners.paramiko_ssh import ParamikoSSHClient
 from st2tests.fixturesloader import get_resources_base_path
 import st2tests.config as tests_config
 
-tests_config.parse_args()
-
 __all__ = ["ParamikoSSHClientTestCase"]
 
 
 class ParamikoSSHClientTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @patch("paramiko.SSHClient", Mock)
     def setUp(self):
         """

--- a/st2actions/tests/unit/test_paramiko_ssh_runner.py
+++ b/st2actions/tests/unit/test_paramiko_ssh_runner.py
@@ -30,8 +30,6 @@ from st2common.runners.paramiko_ssh_runner import RUNNER_SSH_PORT
 import st2tests.config as tests_config
 from st2tests.fixturesloader import get_resources_base_path
 
-tests_config.parse_args()
-
 
 class Runner(BaseParallelSSHRunner):
     def run(self):
@@ -39,6 +37,11 @@ class Runner(BaseParallelSSHRunner):
 
 
 class ParamikoSSHRunnerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @mock.patch("st2common.runners.paramiko_ssh_runner.ParallelSSHClient")
     def test_pre_run(self, mock_client):
         # Test case which verifies that ParamikoSSHClient is instantiated with the correct arguments

--- a/st2actions/tests/unit/test_queue_consumers.py
+++ b/st2actions/tests/unit/test_queue_consumers.py
@@ -15,12 +15,11 @@
 
 from __future__ import absolute_import
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 import mock
 from kombu.message import Message
+
+# This import must be early for import-time side-effects.
+from st2tests.base import ExecutionDbTestCase
 
 from st2actions import worker
 from st2actions.scheduler import entrypoint as scheduling
@@ -35,7 +34,6 @@ from st2common.services import executions
 from st2common.transport.publishers import PoolPublisher
 from st2common.util import action_db as action_utils
 from st2common.util import date as date_utils
-from st2tests.base import ExecutionDbTestCase
 from st2tests.fixtures.packs.core.fixture import PACK_PATH as CORE_PACK_PATH
 
 

--- a/st2actions/tests/unit/test_remote_runners.py
+++ b/st2actions/tests/unit/test_remote_runners.py
@@ -13,18 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# XXX: FabricRunner import depends on config being setup.
-from __future__ import absolute_import
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from unittest import TestCase
+
+# This import must be early for import-time side-effects.
+import st2tests.config as tests_config
 
 from st2common.models.system.action import RemoteScriptAction
 
 
 class RemoteScriptActionTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def test_parameter_formatting(self):
         # Only named args
         named_args = {

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -19,6 +19,9 @@ import mock
 
 from oslo_config import cfg
 
+# This import must be early for import-time side-effects.
+from st2tests.base import DbTestCase
+
 from st2common.constants import action as action_constants
 from st2common.runners.base import get_runner
 from st2common.exceptions.actionrunner import (
@@ -35,10 +38,6 @@ from st2common.services import executions
 from st2common.util import date as date_utils
 from st2common.transport.publishers import PoolPublisher
 
-from st2tests.base import DbTestCase
-import st2tests.config as tests_config
-
-tests_config.parse_args()
 from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 from st2tests.fixturesloader import FixturesLoader
 

--- a/st2actions/tests/unit/test_scheduler.py
+++ b/st2actions/tests/unit/test_scheduler.py
@@ -19,10 +19,6 @@ import datetime
 import mock
 import eventlet
 
-from st2tests import config as test_config
-
-test_config.parse_args()
-
 import st2common
 from st2tests import ExecutionDbTestCase
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK

--- a/st2actions/tests/unit/test_scheduler_entrypoint.py
+++ b/st2actions/tests/unit/test_scheduler_entrypoint.py
@@ -16,10 +16,6 @@
 import eventlet
 import mock
 
-from st2tests import config as test_config
-
-test_config.parse_args()
-
 from st2actions.cmd.scheduler import _run_scheduler
 from st2actions.scheduler.handler import ActionExecutionSchedulingQueueHandler
 from st2actions.scheduler.entrypoint import SchedulerEntrypoint

--- a/st2actions/tests/unit/test_scheduler_retry.py
+++ b/st2actions/tests/unit/test_scheduler_retry.py
@@ -13,19 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This import must be first for import-time side-effects.
+from st2tests.base import CleanDbTestCase
+
 import eventlet
 import mock
 import pymongo
 import uuid
 
-from st2tests import config as test_config
-
-test_config.parse_args()
-
 from st2actions.scheduler import handler
 from st2common.models.db import execution_queue as ex_q_db
 from st2common.persistence import execution_queue as ex_q_db_access
-from st2tests.base import CleanDbTestCase
 
 
 __all__ = ["SchedulerHandlerRetryTestCase"]

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -14,12 +14,16 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 from bson.errors import InvalidStringData
 import eventlet
 import mock
 import os
 from oslo_config import cfg
 import tempfile
+
+# This import must be early for import-time side-effects.
+from st2tests.base import DbTestCase
 
 import st2actions.worker as actions_worker
 from st2common.constants import action as action_constants
@@ -33,13 +37,9 @@ from st2common.util import date as date_utils
 from st2common.bootstrap import runnersregistrar as runners_registrar
 from local_runner.local_shell_command_runner import LocalShellCommandRunner
 
-from st2tests.base import DbTestCase
 from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 from st2tests.fixturesloader import FixturesLoader
-import st2tests.config as tests_config
 from six.moves import range
-
-tests_config.parse_args()
 
 TEST_FIXTURES = {"actions": ["local.yaml"]}
 

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -18,16 +18,12 @@ from __future__ import absolute_import
 import eventlet
 import mock
 
+# This import must be early for import-time side-effects.
 import st2tests
 
 from orquesta import statuses as wf_statuses
 from oslo_config import cfg
 from tooz import coordination
-
-# XXX: actionsensor import depends on config being setup.
-import st2tests.config as tests_config
-
-tests_config.parse_args()
 
 from st2actions.workflows import workflows
 from st2common.bootstrap import actionsregistrar

--- a/st2common/tests/unit/services/test_policy.py
+++ b/st2common/tests/unit/services/test_policy.py
@@ -15,9 +15,8 @@
 
 from __future__ import absolute_import
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
+# This import must be early for import-time side-effects.
+import st2tests
 
 import st2common
 
@@ -29,7 +28,6 @@ from st2common.models.db import action as action_db_models
 from st2common.services import action as action_service
 from st2common.services import policies as policy_service
 
-import st2tests
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests import fixturesloader as fixtures
 

--- a/st2common/tests/unit/services/test_workflow.py
+++ b/st2common/tests/unit/services/test_workflow.py
@@ -24,10 +24,6 @@ from orquesta import statuses as wf_statuses
 
 import st2tests
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.exceptions import action as action_exc

--- a/st2common/tests/unit/services/test_workflow_cancellation.py
+++ b/st2common/tests/unit/services/test_workflow_cancellation.py
@@ -21,10 +21,6 @@ from orquesta import statuses as wf_statuses
 
 import st2tests
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.models.db import liveaction as lv_db_models

--- a/st2common/tests/unit/services/test_workflow_identify_orphans.py
+++ b/st2common/tests/unit/services/test_workflow_identify_orphans.py
@@ -22,11 +22,6 @@ from oslo_config import cfg
 
 import st2tests
 
-# XXX: actionsensor import depends on config being setup.
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.constants import action as ac_const

--- a/st2common/tests/unit/services/test_workflow_rerun.py
+++ b/st2common/tests/unit/services/test_workflow_rerun.py
@@ -15,6 +15,11 @@
 
 from __future__ import absolute_import
 
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
+
 import mock
 import uuid
 

--- a/st2common/tests/unit/services/test_workflow_rerun.py
+++ b/st2common/tests/unit/services/test_workflow_rerun.py
@@ -23,10 +23,6 @@ from orquesta import statuses as wf_statuses
 
 import st2tests
 
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from local_runner import local_shell_command_runner
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar

--- a/st2common/tests/unit/services/test_workflow_service_retries.py
+++ b/st2common/tests/unit/services/test_workflow_service_retries.py
@@ -30,11 +30,6 @@ from tooz import coordination
 
 import st2tests
 
-# XXX: actionsensor import depends on config being setup.
-import st2tests.config as tests_config
-
-tests_config.parse_args()
-
 from st2common.bootstrap import actionsregistrar
 from st2common.bootstrap import runnersregistrar
 from st2common.constants import action as ac_const

--- a/st2common/tests/unit/test_action_alias_utils.py
+++ b/st2common/tests/unit/test_action_alias_utils.py
@@ -30,6 +30,7 @@ from st2common.models.utils.action_alias_utils import (
     search_regex_tokens,
     inject_immutable_parameters,
 )
+import st2tests.config as tests_config
 
 
 class TestActionAliasParser(TestCase):
@@ -357,6 +358,11 @@ class TestSearchRegexTokens(TestCase):
 
 
 class TestInjectImmutableParameters(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def test_immutable_parameters_are_injected(self):
         action_alias_db = Mock()
         action_alias_db.immutable_parameters = {"env": "dev"}

--- a/st2common/tests/unit/test_executions_util.py
+++ b/st2common/tests/unit/test_executions_util.py
@@ -17,6 +17,9 @@ from __future__ import absolute_import
 import mock
 import six
 
+# This import must be early for import-time side-effects.
+from st2tests.base import CleanDbTestCase
+
 from st2common.constants import action as action_constants
 from st2common.models.api.action import RunnerTypeAPI, ActionAPI, LiveActionAPI
 from st2common.models.api.trigger import TriggerTypeAPI, TriggerAPI, TriggerInstanceAPI
@@ -30,15 +33,12 @@ import st2common.services.executions as executions_util
 import st2common.util.action_db as action_utils
 import st2common.util.date as date_utils
 
-from st2tests.base import CleanDbTestCase
 from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 from st2tests.fixtures.descendants.fixture import PACK_NAME as DESCENDANTS_PACK
 from st2tests.fixturesloader import FixturesLoader
 
-import st2tests.config as tests_config
 from six.moves import range
 
-tests_config.parse_args()
 
 TEST_FIXTURES = {
     "liveactions": [

--- a/st2common/tests/unit/test_jinja_render_data_filters.py
+++ b/st2common/tests/unit/test_jinja_render_data_filters.py
@@ -21,9 +21,15 @@ import yaml
 from st2common.constants.keyvalue import FULL_SYSTEM_SCOPE
 from st2common.util import jinja as jinja_utils
 from st2common.services.keyvalues import KeyValueLookup
+import st2tests.config as tests_config
 
 
 class JinjaUtilsDataFilterTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def test_filter_from_json_string(self):
         env = jinja_utils.get_jinja_environment()
         expected_obj = {"a": "b", "c": {"d": "e", "f": 1, "g": True}}

--- a/st2common/tests/unit/test_jsonify.py
+++ b/st2common/tests/unit/test_jsonify.py
@@ -22,14 +22,13 @@ from bson import ObjectId
 
 import st2tests.config as tests_config
 
-tests_config.parse_args()
-
 import st2common.util.jsonify as jsonify
 
 
 class JsonifyTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        tests_config.parse_args()
         jsonify.DEFAULT_JSON_LIBRARY = "orjson"
 
     @classmethod

--- a/st2common/tests/unit/test_logging_middleware.py
+++ b/st2common/tests/unit/test_logging_middleware.py
@@ -20,11 +20,17 @@ from oslo_config import cfg
 
 from st2common.middleware.logging import LoggingMiddleware
 from st2common.constants.secrets import MASKED_ATTRIBUTE_VALUE
+import st2tests.config as tests_config
 
 __all__ = ["LoggingMiddlewareTestCase"]
 
 
 class LoggingMiddlewareTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @mock.patch("st2common.middleware.logging.LOG")
     @mock.patch("st2common.middleware.logging.Request")
     def test_secret_parameters_are_masked_in_log_message(self, mock_request, mock_log):

--- a/st2common/tests/unit/test_operators.py
+++ b/st2common/tests/unit/test_operators.py
@@ -18,6 +18,7 @@ import unittest
 
 from st2common import operators
 from st2common.util import date as date_utils
+import st2tests.config as tests_config
 
 
 def list_of_dicts_strict_equal(lofd1, lofd2):
@@ -157,6 +158,11 @@ class ListOfDictsStrictEqualTest(unittest.TestCase):
 
 
 class SearchOperatorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     # The search command extends the rules engine into being a recursive descent
     # parser. As such, its tests are much more complex than other commands, so we
     # pull its tests out into their own test case.

--- a/st2common/tests/unit/test_purge_rule_enforcement.py
+++ b/st2common/tests/unit/test_purge_rule_enforcement.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 import bson
 

--- a/st2common/tests/unit/test_purge_task_executions.py
+++ b/st2common/tests/unit/test_purge_task_executions.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 
 from st2common import log as logging

--- a/st2common/tests/unit/test_purge_token.py
+++ b/st2common/tests/unit/test_purge_token.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 import bson
 

--- a/st2common/tests/unit/test_purge_trace.py
+++ b/st2common/tests/unit/test_purge_trace.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 import bson
 

--- a/st2common/tests/unit/test_purge_worklows.py
+++ b/st2common/tests/unit/test_purge_worklows.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+# pytest: make sure monkey_patching happens before importing mongoengine
+from st2common.util.monkey_patch import monkey_patch
+
+monkey_patch()
+
 from datetime import timedelta
 
 from st2common import log as logging

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -15,10 +15,8 @@
 
 from __future__ import absolute_import
 
-# pytest: make sure monkey_patching happens before importing mongoengine
-from st2common.util.monkey_patch import monkey_patch
-
-monkey_patch()
+# This import must be early for import-time side-effects.
+from st2tests import base
 
 import mock
 
@@ -28,11 +26,6 @@ from st2common.util import action_db as action_db_utils
 from st2tests import base
 from st2tests import fixturesloader
 from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
-
-
-from st2tests import config as tests_config
-
-tests_config.parse_args()
 
 
 TEST_FIXTURES = {

--- a/st2common/tests/unit/test_runners_utils.py
+++ b/st2common/tests/unit/test_runners_utils.py
@@ -23,7 +23,6 @@ import mock
 from st2common.runners import utils
 from st2common.services import executions as exe_svc
 from st2common.util import action_db as action_db_utils
-from st2tests import base
 from st2tests import fixturesloader
 from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 

--- a/st2common/tests/unit/test_util_payload.py
+++ b/st2common/tests/unit/test_util_payload.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import unittest
 
 from st2common.util.payload import PayloadLookup
+import st2tests.config as tests_config
 
 __all__ = ["PayloadLookupTestCase"]
 
@@ -32,6 +33,7 @@ class PayloadLookupTestCase(unittest.TestCase):
             }
         )
         super(PayloadLookupTestCase, cls).setUpClass()
+        tests_config.parse_args()
 
     def test_get_key(self):
         self.assertEqual(self.payload.get_value("trigger.pikachu"), ["Has no ears"])

--- a/st2reactor/tests/unit/test_garbage_collector.py
+++ b/st2reactor/tests/unit/test_garbage_collector.py
@@ -20,14 +20,18 @@ import unittest
 
 from oslo_config import cfg
 
+# This import must be early for import-time side-effects.
 import st2tests.config as tests_config
-
-tests_config.parse_args()
 
 from st2reactor.garbage_collector import base as garbage_collector
 
 
 class GarbageCollectorServiceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def tearDown(self):
         # Reset gc_max_idle_sec with a value of 1 to reenable for other tests.
         cfg.CONF.set_override("gc_max_idle_sec", 1, group="workflow_engine")

--- a/st2reactor/tests/unit/test_process_container.py
+++ b/st2reactor/tests/unit/test_process_container.py
@@ -27,8 +27,6 @@ from st2common.persistence.pack import Pack
 
 import st2tests.config as tests_config
 
-tests_config.parse_args()
-
 MOCK_PACK_DB = PackDB(
     ref="wolfpack",
     name="wolf pack",
@@ -38,6 +36,11 @@ MOCK_PACK_DB = PackDB(
 
 
 class ProcessContainerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     def test_no_sensors_dont_quit(self):
         process_container = ProcessSensorContainer(None, poll_interval=0.1)
         process_container_thread = concurrency.spawn(process_container.run)


### PR DESCRIPTION
When pants runs tests via pytest, it runs each file separately to facilitate fine-grained caching of test results (that can be invalidated based on the inferred deps of that test file). This revealed a variety of areas where tests rely on import-time side effects that happen when previous tests ran. So, this cleans up those side effects so that each test file can run in isolation.

In some cases, I was able to move the side effects from import-time to `setUpClass` time which feels cleaner to me.

As I identified imports with side-effects, I reviewed other places they were imported to consistently import them early with a comment explaining the dependency on import side-effects.

These commits were extracted from my wip work in #6202.