### PR TITLE
Add `ST2TESTS_SYSTEM_USER` env var to set `system_user.user` in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,6 +93,9 @@ jobs:
           gha-cache-key: cache0-py${{ matrix.python-version }}
 
       - name: Test
+        env:
+          # Github Actions uses the 'runner' user, so use that instead of stanley.
+          ST2TESTS_SYSTEM_USER: 'runner'
         # We do not support running pytest everywhere yet. When we do it will be simply:
         #   pants test ::
         # Until then, we need to manually adjust this command line to test what we can.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,11 @@ Added
 * Added a `get_result` method to the `ExecutionResourceManager` Class for st2client
   Contributed by @skiedude
 
+* Added new env var for tests: `ST2TESTS_SYSTEM_USER`. When set, this will override `system_user.user` in st2 conf
+  so that you can run tests on systems that do not have the `stanley` user. When running tests locally, use the
+  following to set system user to the current user: `export ST2TESTS_SYSTEM_USER=$(id -un)` #6242
+  Contributed by @cognifloyd
+
 3.8.1 - December 13, 2023
 -------------------------
 Fixed

--- a/contrib/runners/orquesta_runner/tests/unit/test_basic.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_basic.py
@@ -21,6 +21,7 @@ import mock
 import six
 
 from orquesta import statuses as wf_statuses
+from oslo_config import cfg
 
 import st2tests
 
@@ -108,7 +109,7 @@ class OrquestaRunnerTest(st2tests.ExecutionDbTestCase):
         runners_utils, "invoke_post_run", mock.MagicMock(return_value=None)
     )
     def test_run_workflow(self):
-        username = "stanley"
+        username = cfg.CONF.system_user.user
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         wf_input = {"who": "Thanos"}
         lv_ac_db = lv_db_models.LiveActionDB(

--- a/contrib/runners/orquesta_runner/tests/unit/test_context.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_context.py
@@ -19,6 +19,7 @@ import copy
 import mock
 
 from orquesta import statuses as wf_statuses
+from oslo_config import cfg
 
 import st2tests
 
@@ -125,7 +126,7 @@ class OrquestaContextTest(st2tests.ExecutionDbTestCase):
         expected_st2_ctx = {
             "action_execution_id": str(ac_ex_db.id),
             "api_url": "http://127.0.0.1/v1",
-            "user": "stanley",
+            "user": cfg.CONF.system_user.user,
             "pack": "orquesta_tests",
             "action": "orquesta_tests.runtime-context",
             "runner": "orquesta",
@@ -208,9 +209,10 @@ class OrquestaContextTest(st2tests.ExecutionDbTestCase):
         self.assertEqual(wf_ex_db.status, wf_statuses.SUCCEEDED)
         self.assertEqual(lv_ac_db.status, ac_const.LIVEACTION_STATUS_SUCCEEDED)
 
+        user = cfg.CONF.system_user.user
         # Check result.
         expected_result = {
-            "output": {"msg": "stanley, All your base are belong to us!"}
+            "output": {"msg": f"{user}, All your base are belong to us!"}
         }
 
         self.assertDictEqual(lv_ac_db.result, expected_result)

--- a/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
+++ b/contrib/runners/orquesta_runner/tests/unit/test_error_handling.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import mock
 
 from orquesta import statuses as wf_statuses
+from oslo_config import cfg
 
 import st2tests
 
@@ -954,7 +955,7 @@ class OrquestaErrorHandlingTest(st2tests.WorkflowTestCase):
         mock.MagicMock(side_effect=[RUNNER_RESULT_FAILED]),
     )
     def test_include_result_to_error_log(self):
-        username = "stanley"
+        username = cfg.CONF.system_user.user
         wf_meta = base.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         wf_input = {"who": "Thanos"}
         lv_ac_db = lv_db_models.LiveActionDB(

--- a/pants.toml
+++ b/pants.toml
@@ -239,6 +239,13 @@ config = "@lint-configs/regex-lint.yaml"
 [setuptools]
 install_from_resolve = "st2"
 
+[test]
+extra_env_vars = [
+  # Use this so that the test system does not require the stanley user.
+  # For example: export ST2TESTS_SYSTEM_USER=${USER}
+  "ST2TESTS_SYSTEM_USER",
+]
+
 [twine]
 install_from_resolve = "twine"
 

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 
 import mock
-import os
 
 from oslo_config import cfg
 
@@ -298,8 +297,10 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(result.get("action_params").get("actionstr") == "bar")
 
         # Assert that context is written correctly.
-        system_user = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
-        context = {"user": system_user, "third_party_system": {"ref_id": "1234"}}
+        context = {
+            "user": cfg.CONF.system_user.user,
+            "third_party_system": {"ref_id": "1234"},
+        }
 
         self.assertDictEqual(liveaction_db.context, context)
 

--- a/st2actions/tests/unit/test_runner_container.py
+++ b/st2actions/tests/unit/test_runner_container.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 import mock
+import os
 
 from oslo_config import cfg
 
@@ -297,7 +298,8 @@ class RunnerContainerTest(DbTestCase):
         self.assertTrue(result.get("action_params").get("actionstr") == "bar")
 
         # Assert that context is written correctly.
-        context = {"user": "stanley", "third_party_system": {"ref_id": "1234"}}
+        system_user = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
+        context = {"user": system_user, "third_party_system": {"ref_id": "1234"}}
 
         self.assertDictEqual(liveaction_db.context, context)
 

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -15,7 +15,8 @@
 
 import copy
 import mock
-import os
+
+from oslo_config import cfg
 
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.models.db.execution import ActionExecutionDB
@@ -49,8 +50,6 @@ EXECUTION = ActionExecutionDB(
 )
 
 __all__ = ["AliasExecutionTestCase"]
-
-SYSTEM_USER = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
 
 
 class AliasExecutionTestCase(FunctionalTest):
@@ -243,7 +242,7 @@ class AliasExecutionTestCase(FunctionalTest):
         self.assertIn("source_channel", mock_request.call_args[0][0].context.keys())
         self.assertEqual(actual_context["source_channel"], "chat-channel")
         self.assertEqual(actual_context["api_user"], "chat-user")
-        self.assertEqual(actual_context["user"], SYSTEM_USER)
+        self.assertEqual(actual_context["user"], cfg.CONF.system_user.user)
 
     @mock.patch.object(action_service, "request", return_value=(None, EXECUTION))
     def test_match_and_execute_matches_one_multiple_match(self, mock_request):
@@ -400,7 +399,7 @@ class AliasExecutionTestCase(FunctionalTest):
             "name": alias_execution.name,
             "format": format_str,
             "command": command,
-            "user": SYSTEM_USER,
+            "user": cfg.CONF.system_user.user,
             "source_channel": "test",
             "notification_route": "test",
         }

--- a/st2api/tests/unit/controllers/v1/test_alias_execution.py
+++ b/st2api/tests/unit/controllers/v1/test_alias_execution.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import copy
-
 import mock
+import os
 
 from st2common.constants.action import LIVEACTION_STATUS_SUCCEEDED
 from st2common.models.db.execution import ActionExecutionDB
@@ -49,6 +49,8 @@ EXECUTION = ActionExecutionDB(
 )
 
 __all__ = ["AliasExecutionTestCase"]
+
+SYSTEM_USER = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
 
 
 class AliasExecutionTestCase(FunctionalTest):
@@ -241,7 +243,7 @@ class AliasExecutionTestCase(FunctionalTest):
         self.assertIn("source_channel", mock_request.call_args[0][0].context.keys())
         self.assertEqual(actual_context["source_channel"], "chat-channel")
         self.assertEqual(actual_context["api_user"], "chat-user")
-        self.assertEqual(actual_context["user"], "stanley")
+        self.assertEqual(actual_context["user"], SYSTEM_USER)
 
     @mock.patch.object(action_service, "request", return_value=(None, EXECUTION))
     def test_match_and_execute_matches_one_multiple_match(self, mock_request):
@@ -398,7 +400,7 @@ class AliasExecutionTestCase(FunctionalTest):
             "name": alias_execution.name,
             "format": format_str,
             "command": command,
-            "user": "stanley",
+            "user": SYSTEM_USER,
             "source_channel": "test",
             "notification_route": "test",
         }

--- a/st2api/tests/unit/controllers/v1/test_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_auth.py
@@ -15,6 +15,7 @@
 
 import uuid
 import datetime
+import os
 
 import bson
 import mock
@@ -29,7 +30,7 @@ from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 from st2tests.fixturesloader import FixturesLoader
 
 OBJ_ID = bson.ObjectId()
-USER = "stanley"
+USER = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
 USER_DB = UserDB(name=USER)
 TOKEN = uuid.uuid4().hex
 NOW = date_utils.get_datetime_utc_now()

--- a/st2api/tests/unit/controllers/v1/test_auth.py
+++ b/st2api/tests/unit/controllers/v1/test_auth.py
@@ -15,7 +15,6 @@
 
 import uuid
 import datetime
-import os
 
 import bson
 import mock
@@ -30,7 +29,7 @@ from st2tests.fixtures.generic.fixture import PACK_NAME as FIXTURES_PACK
 from st2tests.fixturesloader import FixturesLoader
 
 OBJ_ID = bson.ObjectId()
-USER = os.environ.get("ST2TESTS_SYSTEM_USER", "") or "stanley"
+USER = cfg.CONF.system_user.user
 USER_DB = UserDB(name=USER)
 TOKEN = uuid.uuid4().hex
 NOW = date_utils.get_datetime_utc_now()

--- a/st2api/tests/unit/controllers/v1/test_executions.py
+++ b/st2api/tests/unit/controllers/v1/test_executions.py
@@ -704,7 +704,10 @@ class ActionExecutionControllerTestCase(
             delete_resp = self._do_delete(self._get_actionexecution_id(post_resp))
             self.assertEqual(delete_resp.status_int, 200)
             self.assertEqual(delete_resp.json["status"], "canceled")
-            expected_result = {"message": "Action canceled by user.", "user": SYSTEM_USER}
+            expected_result = {
+                "message": "Action canceled by user.",
+                "user": SYSTEM_USER,
+            }
             self.assertDictEqual(delete_resp.json["result"], expected_result)
 
     def test_post_delete_trace(self):

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -104,6 +104,9 @@ def _override_common_opts():
     CONF.set_override(name="api_url", override="http://127.0.0.1", group="auth")
     CONF.set_override(name="mask_secrets", override=True, group="log")
     CONF.set_override(name="stream_output", override=False, group="actionrunner")
+    system_user = os.environ.get("ST2TESTS_SYSTEM_USER", "")
+    if system_user:
+        CONF.set_override(name="user", override=system_user, group="system_user")
 
 
 def _override_api_opts():


### PR DESCRIPTION
Adds a new env var for tests: `ST2TESTS_SYSTEM_USER`. When set, this will override `system_user.user` in st2 conf so that you can run tests on systems that do not have the `stanley` user. When running tests locally, use the following to set system user to the current user:

```
export ST2TESTS_SYSTEM_USER=$(id -un)
```

This follows the naming convention for test vars introduced in #5707 which introduced `ST2TESTS_PARALLEL_SLOT`.

These commits were extracted from my wip work in https://github.com/StackStorm/st2/pull/6202.