### PR TITLE
pants: Add `system_user` detection to `pants-plugins/uses_services` (+ `mongo` detection improvements)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -5,6 +5,18 @@ __defaults__(
 
 python_tests(
     name="tests",
+    overrides={
+        (
+            "test_basic.py",
+            "test_cancel.py",
+            "test_context.py",
+            "test_error_handling.py",
+            "test_pause_and_resume.py",
+            "test_with_items.py",
+        ): dict(
+            uses=["system_user"],
+        ),
+    },
 )
 
 python_test_utils(

--- a/pants-plugins/uses_services/BUILD
+++ b/pants-plugins/uses_services/BUILD
@@ -17,5 +17,6 @@ python_tests(
     #    "mongo_rules_test.py": dict(uses=["mongo"]),
     #    "rabbitmq_rules_test.py": dict(uses=["rabbitmq"]),
     #    "redis_rules_test.py": dict(uses=["redis"]),
+    #    "system_user_test.py": dict(uses=["system_user"]),
     # },
 )

--- a/pants-plugins/uses_services/register.py
+++ b/pants-plugins/uses_services/register.py
@@ -16,7 +16,13 @@ from pants.backend.python.target_types import (
     PythonTestsGeneratorTarget,
 )
 
-from uses_services import mongo_rules, platform_rules, rabbitmq_rules, redis_rules
+from uses_services import (
+    mongo_rules,
+    platform_rules,
+    rabbitmq_rules,
+    redis_rules,
+    system_user_rules,
+)
 from uses_services.target_types import UsesServicesField
 
 
@@ -28,4 +34,5 @@ def rules():
         *mongo_rules.rules(),
         *rabbitmq_rules.rules(),
         *redis_rules.rules(),
+        *system_user_rules.rules(),
     ]

--- a/pants-plugins/uses_services/scripts/has_system_user.py
+++ b/pants-plugins/uses_services/scripts/has_system_user.py
@@ -1,0 +1,43 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+import pwd
+import sys
+
+
+def _has_system_user(system_user: str) -> bool:
+    """Make sure the system_user exists.
+
+    This should not import the st2 code as it should be self-contained.
+    """
+    try:
+        pwd.getpwnam(system_user)
+    except KeyError:
+        # put current user (for use in error msg instructions)
+        print(pwd.getpwuid(os.getuid()).pw_name)
+        return False
+    print(system_user)
+    return True
+
+
+if __name__ == "__main__":
+    args = dict((k, v) for k, v in enumerate(sys.argv))
+
+    system_user = args.get(1, "stanley")
+
+    is_running = _has_system_user(system_user)
+    exit_code = 0 if is_running else 1
+    sys.exit(exit_code)

--- a/pants-plugins/uses_services/scripts/is_mongo_running.py
+++ b/pants-plugins/uses_services/scripts/is_mongo_running.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import sys
 
 
@@ -48,8 +49,11 @@ if __name__ == "__main__":
     args = dict((k, v) for k, v in enumerate(sys.argv))
     db_host = args.get(1, "127.0.0.1")
     db_port = args.get(2, 27017)
-    db_name = args.get(3, "st2-test")
+    db_name = args.get(3, "st2-test{}")
     connection_timeout_ms = args.get(4, 3000)
+
+    slot_var = args.get(5, "ST2TESTS_PARALLEL_SLOT")
+    db_name = db_name.format(os.environ.get(slot_var) or "")
 
     is_running = _is_mongo_running(
         db_host, int(db_port), db_name, int(connection_timeout_ms)

--- a/pants-plugins/uses_services/system_user_rules.py
+++ b/pants-plugins/uses_services/system_user_rules.py
@@ -1,0 +1,158 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+
+from pants.backend.python.goals.pytest_runner import (
+    PytestPluginSetupRequest,
+    PytestPluginSetup,
+)
+from pants.backend.python.target_types import Executable
+from pants.backend.python.util_rules.pex import (
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+    rules as pex_rules,
+)
+from pants.core.goals.test import TestExtraEnv
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.rules import collect_rules, Get, rule
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope
+from pants.engine.target import Target
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from uses_services.exceptions import ServiceMissingError
+from uses_services.platform_rules import Platform
+from uses_services.scripts.has_system_user import (
+    __file__ as has_system_user_full_path,
+)
+from uses_services.target_types import UsesServicesField
+
+
+@dataclass(frozen=True)
+class UsesSystemUserRequest:
+    """One or more targets need the system_user (like stanley) using these settings.
+
+    The system_user attributes represent the system_user.user settings from st2.conf.
+    In st2 code, they come from:
+        oslo_config.cfg.CONF.system_user.user
+    """
+
+    system_user: str = "stanley"
+
+
+@dataclass(frozen=True)
+class HasSystemUser:
+    pass
+
+
+class PytestUsesSystemUserRequest(PytestPluginSetupRequest):
+    @classmethod
+    def is_applicable(cls, target: Target) -> bool:
+        if not target.has_field(UsesServicesField):
+            return False
+        uses = target.get(UsesServicesField).value
+        return uses is not None and "system_user" in uses
+
+
+@rule(
+    desc="Ensure system_user is present before running tests.",
+    level=LogLevel.DEBUG,
+)
+async def has_system_user_for_pytest(
+    request: PytestUsesSystemUserRequest,
+    test_extra_env: TestExtraEnv,
+) -> PytestPluginSetup:
+    system_user = test_extra_env.env.get("ST2TESTS_SYSTEM_USER", "stanley")
+
+    # this will raise an error if system_user is not present
+    _ = await Get(HasSystemUser, UsesSystemUserRequest(system_user=system_user))
+
+    return PytestPluginSetup()
+
+
+@rule(
+    desc="Test to see if system_user is present.",
+    level=LogLevel.DEBUG,
+)
+async def has_system_user(
+    request: UsesSystemUserRequest, platform: Platform
+) -> HasSystemUser:
+    script_path = "./has_system_user.py"
+
+    # pants is already watching this directory as it is under a source root.
+    # So, we don't need to double watch with PathGlobs, just open it.
+    with open(has_system_user_full_path, "rb") as script_file:
+        script_contents = script_file.read()
+
+    script_digest = await Get(
+        Digest, CreateDigest([FileContent(script_path, script_contents)])
+    )
+    script_pex = await Get(
+        VenvPex,
+        PexRequest(
+            output_filename="script.pex",
+            internal_only=True,
+            sources=script_digest,
+            main=Executable(script_path),
+        ),
+    )
+
+    result = await Get(
+        FallibleProcessResult,
+        VenvPexProcess(
+            script_pex,
+            argv=(request.system_user,),
+            description="Checking to see if system_user is present.",
+            # this can change from run to run, so don't cache results.
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            level=LogLevel.DEBUG,
+        ),
+    )
+    has_user = result.exit_code == 0
+
+    if has_user:
+        return HasSystemUser()
+
+    current_user = result.stdout.decode().strip()
+
+    # system_user is not present, so raise an error with instructions.
+    raise ServiceMissingError(
+        service="system_user",
+        platform=platform,
+        msg=dedent(
+            f"""\
+            The system_user ({request.system_user}) does not seem to be present!
+
+            Please export the ST2TESTS_SYSTEM_USER env var to specify which user
+            tests should use as the system_user. This user must be present on
+            your system.
+
+            To use your current user ({current_user}) as the system_user, run:
+
+            export ST2TESTS_SYSTEM_USER=$(id -un)
+            """
+        ),
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(PytestPluginSetupRequest, PytestUsesSystemUserRequest),
+        *pex_rules(),
+    ]

--- a/pants-plugins/uses_services/system_user_rules_test.py
+++ b/pants-plugins/uses_services/system_user_rules_test.py
@@ -1,0 +1,96 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pants.engine.internals.scheduler import ExecutionError
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .data_fixtures import platform, platform_samples
+from .exceptions import ServiceMissingError
+from .system_user_rules import (
+    HasSystemUser,
+    UsesSystemUserRequest,
+    rules as system_user_rules,
+)
+from .platform_rules import Platform
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *system_user_rules(),
+            QueryRule(HasSystemUser, (UsesSystemUserRequest, Platform)),
+        ],
+        target_types=[],
+    )
+
+
+def run_has_system_user(
+    rule_runner: RuleRunner,
+    uses_system_user_request: UsesSystemUserRequest,
+    mock_platform: Platform,
+    *,
+    extra_args: list[str] | None = None,
+) -> HasSystemUser:
+    rule_runner.set_options(
+        [
+            "--backend-packages=uses_services",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME", "ST2TESTS_SYSTEM_USER"},
+    )
+    result = rule_runner.request(
+        HasSystemUser,
+        [uses_system_user_request, mock_platform],
+    )
+    return result
+
+
+# Warning this requires that system_user is present
+def test_system_user_is_present(rule_runner: RuleRunner) -> None:
+    request = UsesSystemUserRequest(
+        system_user=os.environ.get("ST2TESTS_SYSTEM_USER", "stanley")
+    )
+    mock_platform = platform(os="TestMock")
+
+    # we are asserting that this does not raise an exception
+    has_user = run_has_system_user(rule_runner, request, mock_platform)
+    assert has_user
+
+
+@pytest.mark.parametrize("mock_platform", platform_samples)
+def test_system_user_is_absent(
+    rule_runner: RuleRunner, mock_platform: Platform
+) -> None:
+    request = UsesSystemUserRequest(
+        system_user="bogus-stanley",
+    )
+
+    with pytest.raises(ExecutionError) as exception_info:
+        run_has_system_user(rule_runner, request, mock_platform)
+
+    execution_error = exception_info.value
+    assert len(execution_error.wrapped_exceptions) == 1
+
+    exc = execution_error.wrapped_exceptions[0]
+    assert isinstance(exc, ServiceMissingError)
+
+    assert exc.service == "system_user"
+    assert "The system_user (bogus-stanley) does not seem to be present" in str(exc)
+    assert not exc.instructions

--- a/pants-plugins/uses_services/target_types.py
+++ b/pants-plugins/uses_services/target_types.py
@@ -14,7 +14,7 @@
 from pants.engine.target import StringSequenceField
 
 
-supported_services = ("mongo", "rabbitmq", "redis")
+supported_services = ("mongo", "rabbitmq", "redis", "system_user")
 
 
 class UsesServicesField(StringSequenceField):

--- a/st2actions/tests/unit/BUILD
+++ b/st2actions/tests/unit/BUILD
@@ -5,4 +5,13 @@ __defaults__(
 
 python_tests(
     name="tests",
+    overrides={
+        (
+            "test_execution_cancellation.py",
+            "test_runner_container.py",
+            "test_worker.py",
+        ): dict(
+            uses=["system_user"],
+        ),
+    },
 )

--- a/st2api/tests/unit/controllers/v1/BUILD
+++ b/st2api/tests/unit/controllers/v1/BUILD
@@ -1,3 +1,14 @@
 python_tests(
     name="tests",
+    overrides={
+        (
+            "test_alias_execution.py",
+            "test_auth.py",
+            "test_auth_api_keys.py",
+            "test_executions.py",
+            "test_inquiries.py",
+        ): dict(
+            uses=["system_user"],
+        ),
+    },
 )

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -19,6 +19,9 @@ python_tests(
                 "st2tests/st2tests/policies/meta",
             ],
         ),
+        "test_param_utils.py": dict(
+            uses=["system_user"],
+        ),
     },
 )
 


### PR DESCRIPTION
Some of the tests require the `system_user.user` as an actual local user on the machine running pytest. That is now configurable with the `ST2TESTS_SYSTEM_USER` env var added in #6242. If someone forgot to set--or did not know they could set--the `ST2TESTS_SYSTEM_USER` env var, they will get really odd errors that are difficult to interpret and debug. So, this PR adds a pants-plugin feature to fail with an error message about setting that env var before pytest even runs tests that require the system_user.

This improves on the `pants-plugins/uses_services` plugin, which was added in these PRs (the PR descriptions can be helpful in understanding the `uses_services` plugin):
- #5864
- #5884
- #5893
- #5898

### `has_system_user.py` script and the rule that runs it

[`has_system_user.py`](https://github.com/StackStorm/st2/pull/6244/files#diff-718b51f3e25bc66cb47cff3a238e7782cca573220db0d4c9733b1246448ef5d5) is the part that checks to see if the system_user is present on the system.

The `has_system_user.py` script gets opened and run in a pex with the similar rule logic to the `mongo`, `redis`, and `rabbitmq` detection rules.

Only `system_user` has to be passed to the `has_system_user.py` script to check for that user:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L46-L55

Here is the definition of the rule that runs `has_system_user.py`:
https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L92-L94

So, when another rule Gets `HasSystemUser` with a `UsesSystemUserRequest`, pants will also run the rule that generates `Platform` (described in #5864), and then it will run this `has_system_user` rule.

The `has_system_user` rule either returns `HasSystemUser()` if the user is present, or raises `ServiceMissingError` if it is not (the same error that the other uses_services rules raise). By raising an error, this actually breaks a convention for pants rules. Exceptions stop everything and get shown to the user right away, and for most goals, pants wants to see some dataclass returned that has something like a `succeeded` boolean instead. But, we want to error as early as possible, so this breaks that convention on purpose.

### wiring up the `test` goal so it runs `has_system_user` when `pytest` runs on a target with the `uses` field.

The last piece that ties this all together is a rule that makes sure the `has_system_user` rule runs before `pytest` runs (if pants is running it on a target with the `uses` field). Here is the definition of the `has_system_user_for_pytest` rule:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L76-L79

This rule is fairly simple. It looks up the system_user based on the `[test].extra_env_vars` setting defined here:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants.toml#L242-L247

Then it just triggers running the `has_system_user` rule, passing in the system_user:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L80-L85

This rule needs the `PytestUsesSystemUserRequest` which selects targets that have the `uses` field.

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L63-L69

This request will be made by the pants-internal pytest rules thanks to this `UnionRule`, which is a way to declare that our class "implements" the `PytestPluginSetupRequest`:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/system_user_rules.py#L156

If we need to add `uses` support to other targets, we will need to find similar UnionRules where we can inject our rule logic. For now, I've only wired this up so our `uses` rules will run for pytest.

### update mongo bits to use pants idiom

This PR also updates the mongo detection rules to use pants to grab the `ST2TESTS_PARALLEL_SLOT` env var. I learned about how to do this recently, so I included that update here.

Pants is configured to use `ST2TESTS_PARALLEL_SLOT` here:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants.toml#L229-L234

So, the `mongo_is_running_for_pytest` rule passes that var name here:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/mongo_rules.py#L110-L113

And this line tells pants to include the var in the env used when running `is_mongo_running.py` here:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/mongo_rules.py#L157

Finally the db name calculation is moved into `is_mongo_running.py` here:

https://github.com/StackStorm/st2/blob/1413e11fb2e6f497fff7ddf6cf02e1e8e04ba78a/pants-plugins/uses_services/scripts/is_mongo_running.py#L52-L56

