### PR TITLE
Make unit tests use redis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,18 @@ jobs:
             - 5672:5672/tcp   # AMQP standard port
             - 15672:15672/tcp # Management: HTTP, CLI
 
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --name "redis"
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379/tcp
     env:
       # CI st2.conf (with ST2_CI_USER user instead of stanley)
       ST2_CONF: 'conf/st2.ci.conf'
@@ -163,11 +175,6 @@ jobs:
       - name: Install requirements
         run: |
           ./scripts/ci/install-requirements.sh
-      - name: Run Redis Service Container
-        timeout-minutes: 2
-        run: |
-          docker run --rm --detach -p 127.0.0.1:6379:6379/tcp --name redis redis:latest
-          until [ "$(docker inspect -f {{.State.Running}} redis)" == "true" ]; do sleep 0.1; done
       - name: Setup Tests
         run: |
           # prep a ci-specific dev conf file that uses runner instead of stanley
@@ -234,9 +241,6 @@ jobs:
           name: logs-py${{ matrix.python-version }}
           path: logs.tar.gz
           retention-days: 7
-      - name: Stop Redis Service Container
-        if: "${{ always() }}"
-        run: docker rm --force redis || true
 
   unit-tests:
     needs: pre_job
@@ -287,7 +291,7 @@ jobs:
         image: mongo:4.4
         ports:
           - 27017:27017
-      redis-server:
+      redis:
         # Docker Hub image
         image: redis
         # Set health checks to wait until redis has started
@@ -484,18 +488,18 @@ jobs:
           #- 4369:4369/tcp   # epmd
           #
 
-      #redis-server:
-      #  # Docker Hub image
-      #  image: redis
-      #  # Set health checks to wait until redis has started
-      #  options: >-
-      #    --name "redis"
-      #    --health-cmd "redis-cli ping"
-      #    --health-interval 10s
-      #    --health-timeout 5s
-      #    --health-retries 5
-      #  ports:
-      #    - 6379:6379/tcp
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --name "redis"
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379/tcp
 
     env:
       TASK: '${{ matrix.task }}'
@@ -548,11 +552,6 @@ jobs:
           cp conf/st2.dev.conf "${ST2_CONF}" ; sed -i -e "s/stanley/${ST2_CI_USER}/" "${ST2_CONF}"
 
           sudo -E ./scripts/ci/add-itest-user-key.sh
-      - name: Run Redis Service Container
-        timeout-minutes: 2
-        run: |
-          docker run --rm --detach -p 127.0.0.1:6379:6379/tcp --name redis redis:latest
-          until [ "$(docker inspect -f {{.State.Running}} redis)" == "true" ]; do sleep 0.1; done
       - name: Permissions Workaround
         run: |
           echo "$ST2_CI_REPO_PATH"
@@ -595,9 +594,6 @@ jobs:
           name: logs-py${{ matrix.python-version }}-nose-${{ matrix.nosetests_node_index }}
           path: logs.tar.gz
           retention-days: 7
-      - name: Stop Redis Service Container
-        if: "${{ always() }}"
-        run: docker rm --force redis || true
 
   slack-notification:
     name: Slack notification for failed master builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -487,18 +487,18 @@ jobs:
       # Used for the coordination backend for integration tests
       # NOTE: To speed things up, we only start redis for integration tests
       # where it's needed
-      redis-server:
-        # Docker Hub image
-        image: redis
-        # Set health checks to wait until redis has started
-        options: >-
-          --name "redis"
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379/tcp
+      #redis-server:
+      #  # Docker Hub image
+      #  image: redis
+      #  # Set health checks to wait until redis has started
+      #  options: >-
+      #    --name "redis"
+      #    --health-cmd "redis-cli ping"
+      #    --health-interval 10s
+      #    --health-timeout 5s
+      #    --health-retries 5
+      #  ports:
+      #    - 6379:6379/tcp
 
     env:
       TASK: '${{ matrix.task }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -474,18 +474,18 @@ jobs:
       # Used for the coordination backend for integration tests
       # NOTE: To speed things up, we only start redis for integration tests
       # where it's needed
-      # redis:
-      #   # Docker Hub image
-      #   image: redis
-      #   # Set health checks to wait until redis has started
-      #   options: >-
-      #     --name "redis"
-      #     --health-cmd "redis-cli ping"
-      #     --health-interval 10s
-      #     --health-timeout 5s
-      #     --health-retries 5
-      #   ports:
-      #     - 6379:6379/tcp
+      redis:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --name "redis"
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379/tcp
 
     env:
       TASK: '${{ matrix.task }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -287,6 +287,19 @@ jobs:
         image: mongo:4.4
         ports:
           - 27017:27017
+      redis-server:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --name "redis"
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379/tcp
+
 
       rabbitmq:
         image: rabbitmq:3.8-management
@@ -474,18 +487,18 @@ jobs:
       # Used for the coordination backend for integration tests
       # NOTE: To speed things up, we only start redis for integration tests
       # where it's needed
-      # redis:
-      #   # Docker Hub image
-      #   image: redis
-      #   # Set health checks to wait until redis has started
-      #   options: >-
-      #     --name "redis"
-      #     --health-cmd "redis-cli ping"
-      #     --health-interval 10s
-      #     --health-timeout 5s
-      #     --health-retries 5
-      #   ports:
-      #     - 6379:6379/tcp
+      redis-server:
+        # Docker Hub image
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --name "redis"
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379/tcp
 
     env:
       TASK: '${{ matrix.task }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -474,18 +474,18 @@ jobs:
       # Used for the coordination backend for integration tests
       # NOTE: To speed things up, we only start redis for integration tests
       # where it's needed
-      redis:
-        # Docker Hub image
-        image: redis
-        # Set health checks to wait until redis has started
-        options: >-
-          --name "redis"
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379/tcp
+      # redis:
+      #   # Docker Hub image
+      #   image: redis
+      #   # Set health checks to wait until redis has started
+      #   options: >-
+      #     --name "redis"
+      #     --health-cmd "redis-cli ping"
+      #     --health-interval 10s
+      #     --health-timeout 5s
+      #     --health-retries 5
+      #   ports:
+      #     - 6379:6379/tcp
 
     env:
       TASK: '${{ matrix.task }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -484,9 +484,6 @@ jobs:
           #- 4369:4369/tcp   # epmd
           #
 
-      # Used for the coordination backend for integration tests
-      # NOTE: To speed things up, we only start redis for integration tests
-      # where it's needed
       #redis-server:
       #  # Docker Hub image
       #  image: redis

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Changed
 * Update st2client deps: editor and prompt-toolkit. #6189 (by @nzlosh)
 * Updated dependency oslo.config to prepare for python 3.10 support. #6193 (by @nzlosh)
 
+* Updated unit tests to use redis for coordination instead of the NoOp driver. This will hopefully make CI more stable. #6245
+  Contributed by @FileMagic, @guzzijones, and @cognifloyd
+
 Added
 ~~~~~
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
 REQUIREMENTS := test-requirements.txt requirements.txt
 
 # Redis config for testing
-ST2_OVERRIDE_COORDINATOR_REDIS_HOST := ${REDIS_HOST:-"127.0.0.1"}
-ST2_OVERRIDE_COORDINATOR_REDIS_PORT := ${REDIS_PORT:-"6379"} 
+ST2_OVERRIDE_COORDINATOR_REDIS_HOST := 127.0.0.1
+ST2_OVERRIDE_COORDINATOR_REDIS_PORT := 6379
 
 # Pin common pip version here across all the targets
 # Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
@@ -828,6 +828,8 @@ unit-tests: requirements .unit-tests
 		echo "Running tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
+		 ST2_OVERRIDE_COORDINATOR_REDIS_HOST=$(ST2_OVERRIDE_COORDINATOR_REDIS_HOST) \
+		 ST2_OVERRIDE_COORDINATOR_REDIS_PORT=$(ST2_OVERRIDE_COORDINATOR_REDIS_PORT) \
 		    nosetests $(NOSE_OPTS) -s -v \
 		    $$component/tests/unit || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \

--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,8 @@ endif
 		echo "Running tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
+		 ST2_OVERRIDE_COORDINATOR_REDIS_HOST=$(ST2_OVERRIDE_COORDINATOR_REDIS_HOST) \
+		 ST2_OVERRIDE_COORDINATOR_REDIS_PORT=$(ST2_OVERRIDE_COORDINATOR_REDIS_PORT) \
 		    COVERAGE_FILE=.coverage.unit.$$(echo $$component | tr '/' '.') \
 		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
 
 REQUIREMENTS := test-requirements.txt requirements.txt
 
+# Redis config for testing
+ST2_OVERRIDE_COORDINATOR_REDIS_HOST := ${REDIS_HOST:-"127.0.0.1"}
+ST2_OVERRIDE_COORDINATOR_REDIS_PORT := ${REDIS_PORT:-"6379"} 
+
 # Pin common pip version here across all the targets
 # Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
 PIP_VERSION ?= 24.2

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ COVERAGE_GLOBS_QUOTED := $(foreach glob,$(COVERAGE_GLOBS),'$(glob)')
 REQUIREMENTS := test-requirements.txt requirements.txt
 
 # Redis config for testing
-ST2_OVERRIDE_COORDINATOR_REDIS_HOST := 127.0.0.1
-ST2_OVERRIDE_COORDINATOR_REDIS_PORT := 6379
+ST2TESTS_REDIS_HOST := 127.0.0.1
+ST2TESTS_REDIS_PORT := 6379
 
 # Pin common pip version here across all the targets
 # Note! Periodic maintenance pip upgrades are required to be up-to-date with the latest pip security fixes and updates
@@ -828,8 +828,8 @@ unit-tests: requirements .unit-tests
 		echo "Running tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
-		 ST2_OVERRIDE_COORDINATOR_REDIS_HOST=$(ST2_OVERRIDE_COORDINATOR_REDIS_HOST) \
-		 ST2_OVERRIDE_COORDINATOR_REDIS_PORT=$(ST2_OVERRIDE_COORDINATOR_REDIS_PORT) \
+		 ST2TESTS_REDIS_HOST=$(ST2TESTS_REDIS_HOST) \
+		 ST2TESTS_REDIS_PORT=$(ST2TESTS_REDIS_PORT) \
 		    nosetests $(NOSE_OPTS) -s -v \
 		    $$component/tests/unit || ((failed+=1)); \
 		echo "-----------------------------------------------------------"; \
@@ -854,8 +854,8 @@ endif
 		echo "Running tests in" $$component; \
 		echo "-----------------------------------------------------------"; \
 		. $(VIRTUALENV_DIR)/bin/activate; \
-		 ST2_OVERRIDE_COORDINATOR_REDIS_HOST=$(ST2_OVERRIDE_COORDINATOR_REDIS_HOST) \
-		 ST2_OVERRIDE_COORDINATOR_REDIS_PORT=$(ST2_OVERRIDE_COORDINATOR_REDIS_PORT) \
+		 ST2TESTS_REDIS_HOST=$(ST2TESTS_REDIS_HOST) \
+		 ST2TESTS_REDIS_PORT=$(ST2TESTS_REDIS_PORT) \
 		    COVERAGE_FILE=.coverage.unit.$$(echo $$component | tr '/' '.') \
 		    nosetests $(NOSE_OPTS) -s -v $(NOSE_COVERAGE_FLAGS) \
 		    $(NOSE_COVERAGE_PACKAGES) \

--- a/st2actions/tests/unit/test_policies.py
+++ b/st2actions/tests/unit/test_policies.py
@@ -28,6 +28,7 @@ from st2common.transport.liveaction import LiveActionPublisher
 from st2common.transport.publishers import CUDPublisher
 from st2common.bootstrap import runnersregistrar as runners_registrar
 from st2tests import ExecutionDbTestCase
+from st2tests import config as tests_config
 from st2tests.fixtures.generic.fixture import PACK_NAME as PACK
 from st2tests.fixturesloader import FixturesLoader
 from st2tests.mocks.runners import runner
@@ -36,6 +37,8 @@ from st2tests.mocks.liveaction import MockLiveActionPublisher
 from st2tests.policies.concurrency import FakeConcurrencyApplicator
 from st2tests.policies.mock_exception import RaiseExceptionApplicator
 
+# This needs to run before creating FakeConcurrencyApplicator below.
+tests_config.parse_args()
 
 TEST_FIXTURES = {
     "actions": ["action1.yaml"],

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -27,6 +27,7 @@ import tempfile
 from st2tests.base import DbTestCase
 
 import st2actions.worker as actions_worker
+import st2tests.config as tests_config
 from st2common.constants import action as action_constants
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.models.system.common import ResourceReference
@@ -66,6 +67,11 @@ class WorkerTestCase(DbTestCase):
             fixtures_pack=FIXTURES_PACK, fixtures_dict=TEST_FIXTURES
         )
         WorkerTestCase.local_action_db = models["actions"]["local.yaml"]
+
+    @staticmethod
+    def reparse_config():
+        tests_config.reset()
+        tests_config.parse_args()
 
     def _get_liveaction_model(self, action_db, params):
         status = action_constants.LIVEACTION_STATUS_REQUESTED
@@ -117,6 +123,7 @@ class WorkerTestCase(DbTestCase):
             )
 
     def test_worker_shutdown(self):
+        self.reparse_config()
         cfg.CONF.set_override(
             name="graceful_shutdown", override=False, group="actionrunner"
         )
@@ -175,6 +182,7 @@ class WorkerTestCase(DbTestCase):
         mock.MagicMock(return_value=coordination.NoOpAsyncResult("member-1")),
     )
     def test_worker_graceful_shutdown_with_multiple_runners(self):
+        self.reparse_config()
         cfg.CONF.set_override(
             name="graceful_shutdown", override=True, group="actionrunner"
         )
@@ -244,6 +252,7 @@ class WorkerTestCase(DbTestCase):
         shutdown_thread.kill()
 
     def test_worker_graceful_shutdown_with_single_runner(self):
+        self.reparse_config()
         cfg.CONF.set_override(
             name="graceful_shutdown", override=True, group="actionrunner"
         )
@@ -321,6 +330,7 @@ class WorkerTestCase(DbTestCase):
         mock.MagicMock(return_value=coordination.NoOpAsyncResult("member-1")),
     )
     def test_worker_graceful_shutdown_exit_timeout(self):
+        self.reparse_config()
         cfg.CONF.set_override(
             name="graceful_shutdown", override=True, group="actionrunner"
         )

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -20,6 +20,7 @@ import eventlet
 import mock
 import os
 from oslo_config import cfg
+from tooz.drivers.redis import RedisDriver
 import tempfile
 
 # This import must be early for import-time side-effects.
@@ -169,13 +170,22 @@ class WorkerTestCase(DbTestCase):
         runner_thread.wait()
 
     @mock.patch.object(
-        coordination.NoOpDriver,
+        RedisDriver,
         "get_members",
         mock.MagicMock(return_value=coordination.NoOpAsyncResult("member-1")),
     )
     def test_worker_graceful_shutdown_with_multiple_runners(self):
         cfg.CONF.set_override(
             name="graceful_shutdown", override=True, group="actionrunner"
+        )
+        cfg.CONF.set_override(
+            name="service_registry", override=True, group="coordination"
+        )
+        cfg.CONF.set_override(
+            name="exit_still_active_check", override=10, group="actionrunner"
+        )
+        cfg.CONF.set_override(
+            name="still_active_check_interval", override=1, group="actionrunner"
         )
         action_worker = actions_worker.get_worker()
         temp_file = None
@@ -237,6 +247,16 @@ class WorkerTestCase(DbTestCase):
         cfg.CONF.set_override(
             name="graceful_shutdown", override=True, group="actionrunner"
         )
+        cfg.CONF.set_override(
+            name="service_registry", override=True, group="coordination"
+        )
+        cfg.CONF.set_override(
+            name="exit_still_active_check", override=10, group="actionrunner"
+        )
+        cfg.CONF.set_override(
+            name="still_active_check_interval", override=1, group="actionrunner"
+        )
+
         action_worker = actions_worker.get_worker()
         temp_file = None
 

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -332,7 +332,7 @@ class WorkerTestCase(DbTestCase):
         shutdown_thread.kill()
 
     @mock.patch.object(
-        coordination.NoOpDriver,
+        RedisDriver,
         "get_members",
         mock.MagicMock(return_value=coordination.NoOpAsyncResult(("member-1",))),
     )

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -201,7 +201,7 @@ class WorkerTestCase(DbTestCase):
     @mock.patch.object(
         RedisDriver,
         "get_members",
-        mock.MagicMock(return_value=coordination.NoOpAsyncResult("member-1")),
+        mock.MagicMock(return_value=coordination.NoOpAsyncResult(("member-1", "member-2"))),
     )
     def test_worker_graceful_shutdown_with_multiple_runners(self):
         self.reset_config(
@@ -334,7 +334,7 @@ class WorkerTestCase(DbTestCase):
     @mock.patch.object(
         coordination.NoOpDriver,
         "get_members",
-        mock.MagicMock(return_value=coordination.NoOpAsyncResult("member-1")),
+        mock.MagicMock(return_value=coordination.NoOpAsyncResult(("member-1",))),
     )
     def test_worker_graceful_shutdown_exit_timeout(self):
         self.reset_config(exit_still_active_check=5)

--- a/st2actions/tests/unit/test_worker.py
+++ b/st2actions/tests/unit/test_worker.py
@@ -201,7 +201,9 @@ class WorkerTestCase(DbTestCase):
     @mock.patch.object(
         RedisDriver,
         "get_members",
-        mock.MagicMock(return_value=coordination.NoOpAsyncResult(("member-1", "member-2"))),
+        mock.MagicMock(
+            return_value=coordination.NoOpAsyncResult(("member-1", "member-2"))
+        ),
     )
     def test_worker_graceful_shutdown_with_multiple_runners(self):
         self.reset_config(

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -145,7 +145,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
 
     @mock.patch.object(RedisDriver, "get_lock")
     def test_process_error_handling(self, mock_get_lock):
-        tests_config.parse_args()
+        # tests_config.parse_args()  # maybe call self.reset()
         cfg.CONF.set_override(
             name="service_registry", override=True, group="coordination"
         )

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -215,7 +215,6 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta["name"])
 
-
         lv_ac_db, ac_ex_db = action_service.request(lv_ac_db)
 
         # Assert action execution is running.
@@ -279,7 +278,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         cfg.CONF.set_override(
             name="still_active_check_interval", override=1, group="workflow_engine"
         )
- 
+
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta["name"])
         lv_ac_db, ac_ex_db = action_service.request(lv_ac_db)

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -104,7 +104,9 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         tests_config.parse_args()
         if graceful_shutdown is not None:
             cfg.CONF.set_override(
-                name="graceful_shutdown", override=graceful_shutdown, group="actionrunner"
+                name="graceful_shutdown",
+                override=graceful_shutdown,
+                group="actionrunner",
             )
         if exit_still_active_check is not None:
             cfg.CONF.set_override(
@@ -361,7 +363,9 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
     @mock.patch.object(
         RedisDriver,
         "get_members",
-        mock.MagicMock(return_value=coordination_service.NoOpAsyncResult(("member-1",))),
+        mock.MagicMock(
+            return_value=coordination_service.NoOpAsyncResult(("member-1",))
+        ),
     )
     def test_workflow_engine_shutdown_with_multiple_members(self):
         self.reset_config(service_registry=True)

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -145,6 +145,10 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
 
     @mock.patch.object(RedisDriver, "get_lock")
     def test_process_error_handling(self, mock_get_lock):
+        tests_config.parse_args()
+        cfg.CONF.set_override(
+            name="service_registry", override=True, group="coordination"
+        )
         expected_errors = [
             {
                 "message": "Execution failed. See result for details.",
@@ -158,7 +162,6 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
                 "route": 0,
             },
         ]
-
         mock_get_lock.side_effect = coordination_service.NoOpLock(name="noop")
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta["name"])
@@ -179,8 +182,6 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
             task_execution=str(t1_ex_db.id)
         )[0]
         mock_get_lock.side_effect = [
-            coordination.ToozConnectionError("foobar"),
-            coordination.ToozConnectionError("foobar"),
             coordination.ToozConnectionError("foobar"),
             coordination.ToozConnectionError("foobar"),
             coordination.ToozConnectionError("foobar"),
@@ -213,6 +214,8 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         mock_get_lock.side_effect = coordination_service.NoOpLock(name="noop")
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta["name"])
+
+
         lv_ac_db, ac_ex_db = action_service.request(lv_ac_db)
 
         # Assert action execution is running.
@@ -263,15 +266,20 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_CANCELED)
 
-    @mock.patch.object(
-        RedisDriver,
-        "get_members",
-        mock.MagicMock(return_value=coordination_service.NoOpAsyncResult("")),
-    )
     def test_workflow_engine_shutdown(self):
+        cfg.CONF.set_override(
+            name="graceful_shutdown", override=True, group="actionrunner"
+        )
         cfg.CONF.set_override(
             name="service_registry", override=True, group="coordination"
         )
+        cfg.CONF.set_override(
+            name="exit_still_active_check", override=4, group="workflow_engine"
+        )
+        cfg.CONF.set_override(
+            name="still_active_check_interval", override=1, group="workflow_engine"
+        )
+ 
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
         lv_ac_db = lv_db_models.LiveActionDB(action=wf_meta["name"])
         lv_ac_db, ac_ex_db = action_service.request(lv_ac_db)
@@ -284,11 +292,10 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         )[0]
         self.assertEqual(wf_ex_db.status, action_constants.LIVEACTION_STATUS_RUNNING)
         workflow_engine = workflows.get_engine()
-
         eventlet.spawn(workflow_engine.shutdown)
 
         # Sleep for few seconds to ensure execution transitions to pausing.
-        eventlet.sleep(5)
+        eventlet.sleep(8)
 
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_PAUSING)
@@ -481,14 +488,14 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         self.assertEqual(wf_ex_db.status, action_constants.LIVEACTION_STATUS_RUNNING)
         workflow_engine = workflows.get_engine()
 
+        RedisDriver.get_members = mock.MagicMock(
+            return_value=coordination_service.NoOpAsyncResult("member-1")
+        )
+
         workflow_engine._delay = 0
         # Initiate start first
         eventlet.spawn(workflow_engine.start, True)
         eventlet.spawn_after(1, workflow_engine.shutdown)
-
-        RedisDriver.get_members = mock.MagicMock(
-            return_value=coordination_service.NoOpAsyncResult("member-1")
-        )
 
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
 

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -24,6 +24,7 @@ import st2tests
 from orquesta import statuses as wf_statuses
 from oslo_config import cfg
 from tooz import coordination
+from tooz.drivers.redis import RedisDriver
 
 from st2actions.workflows import workflows
 from st2common.bootstrap import actionsregistrar
@@ -142,7 +143,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         lv_ac_db = lv_db_access.LiveAction.get_by_id(str(lv_ac_db.id))
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
 
-    @mock.patch.object(coordination_service.NoOpDriver, "get_lock")
+    @mock.patch.object(RedisDriver, "get_lock")
     def test_process_error_handling(self, mock_get_lock):
         expected_errors = [
             {
@@ -200,7 +201,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_FAILED)
 
     @mock.patch.object(
-        coordination_service.NoOpDriver,
+        RedisDriver,
         "get_lock",
     )
     @mock.patch.object(
@@ -263,7 +264,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_CANCELED)
 
     @mock.patch.object(
-        coordination_service.NoOpDriver,
+        RedisDriver,
         "get_members",
         mock.MagicMock(return_value=coordination_service.NoOpAsyncResult("")),
     )
@@ -325,7 +326,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         )
 
     @mock.patch.object(
-        coordination_service.NoOpDriver,
+        RedisDriver,
         "get_members",
         mock.MagicMock(return_value=coordination_service.NoOpAsyncResult("member-1")),
     )
@@ -399,7 +400,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         self.assertEqual(lv_ac_db.status, action_constants.LIVEACTION_STATUS_RUNNING)
 
     @mock.patch.object(
-        coordination_service.NoOpDriver,
+        RedisDriver,
         "get_lock",
         mock.MagicMock(return_value=coordination_service.NoOpLock(name="noop")),
     )
@@ -456,7 +457,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         )
 
     @mock.patch.object(
-        coordination_service.NoOpDriver,
+        RedisDriver,
         "get_lock",
         mock.MagicMock(return_value=coordination_service.NoOpLock(name="noop")),
     )
@@ -485,7 +486,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         eventlet.spawn(workflow_engine.start, True)
         eventlet.spawn_after(1, workflow_engine.shutdown)
 
-        coordination_service.NoOpDriver.get_members = mock.MagicMock(
+        RedisDriver.get_members = mock.MagicMock(
             return_value=coordination_service.NoOpAsyncResult("member-1")
         )
 

--- a/st2actions/tests/unit/test_workflow_engine.py
+++ b/st2actions/tests/unit/test_workflow_engine.py
@@ -334,7 +334,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
     @mock.patch.object(
         RedisDriver,
         "get_members",
-        mock.MagicMock(return_value=coordination_service.NoOpAsyncResult("member-1")),
+        mock.MagicMock(return_value=coordination_service.NoOpAsyncResult(("member-1",))),
     )
     def test_workflow_engine_shutdown_with_multiple_members(self):
         cfg.CONF.set_override(
@@ -488,7 +488,7 @@ class WorkflowExecutionHandlerTest(st2tests.WorkflowTestCase):
         workflow_engine = workflows.get_engine()
 
         RedisDriver.get_members = mock.MagicMock(
-            return_value=coordination_service.NoOpAsyncResult("member-1")
+            return_value=coordination_service.NoOpAsyncResult(("member-1",))
         )
 
         workflow_engine._delay = 0

--- a/st2common/tests/unit/services/test_workflow_service_retries.py
+++ b/st2common/tests/unit/services/test_workflow_service_retries.py
@@ -27,6 +27,7 @@ import tempfile
 
 from orquesta import statuses as wf_statuses
 from tooz import coordination
+from tooz.drivers.redis import RedisDriver
 
 import st2tests
 
@@ -123,7 +124,7 @@ class OrquestaServiceRetryTest(st2tests.WorkflowTestCase):
         for pack in PACKS:
             actions_registrar.register_from_pack(pack)
 
-    @mock.patch.object(coord_svc.NoOpDriver, "get_lock")
+    @mock.patch.object(RedisDriver, "get_lock")
     def test_recover_from_coordinator_connection_error(self, mock_get_lock):
         mock_get_lock.side_effect = coord_svc.NoOpLock(name="noop")
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")
@@ -157,7 +158,7 @@ class OrquestaServiceRetryTest(st2tests.WorkflowTestCase):
         tk1_ex_db = wf_db_access.TaskExecution.get_by_id(tk1_ex_db.id)
         self.assertEqual(tk1_ex_db.status, wf_statuses.SUCCEEDED)
 
-    @mock.patch.object(coord_svc.NoOpDriver, "get_lock")
+    @mock.patch.object(RedisDriver, "get_lock")
     def test_retries_exhausted_from_coordinator_connection_error(self, mock_get_lock):
         mock_get_lock.side_effect = coord_svc.NoOpLock(name="noop")
         wf_meta = self.get_wf_fixture_meta_data(TEST_PACK_PATH, "sequential.yaml")

--- a/st2common/tests/unit/services/test_workflow_service_retries.py
+++ b/st2common/tests/unit/services/test_workflow_service_retries.py
@@ -197,7 +197,6 @@ class OrquestaServiceRetryTest(st2tests.WorkflowTestCase):
         mock.MagicMock(
             side_effect=[
                 mongoengine.connection.ConnectionFailure(),
-                mongoengine.connection.ConnectionFailure(),
                 None,
             ]
         ),

--- a/st2common/tests/unit/test_service_setup.py
+++ b/st2common/tests/unit/test_service_setup.py
@@ -217,6 +217,7 @@ class ServiceSetupTestCase(CleanFilesTestCase):
         members = coordinator.get_members(service.encode("utf-8"))
         self.assertEqual(len(list(members.get())), 1)
         service_setup.deregister_service(service)
+        members = coordinator.get_members(service.encode("utf-8"))
         self.assertEqual(len(list(members.get())), 0)
 
     def test_deregister_service_when_service_registry_disables(self):

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -140,15 +140,10 @@ def _override_scheduler_opts():
 def _override_coordinator_opts(noop=False):
     driver = None if noop else "zake://"
 
-    ST2_OVERRIDE_COORDINATOR_REDIS_HOST = os.environ.get(
-        "ST2_OVERRIDE_COORDINATOR_REDIS_HOST", False
-    )
-    if ST2_OVERRIDE_COORDINATOR_REDIS_HOST:
-
-        ST2_OVERRIDE_COORDINATOR_REDIS_PORT = os.environ.get(
-            "ST2_OVERRIDE_COORDINATOR_REDIS_PORT", "6379"
-        )
-        driver = f"redis://{ST2_OVERRIDE_COORDINATOR_REDIS_HOST}:{ST2_OVERRIDE_COORDINATOR_REDIS_PORT}"
+    redis_host = os.environ.get("ST2TESTS_REDIS_HOST", False)
+    if redis_host:
+        redis_port = os.environ.get("ST2TESTS_REDIS_PORT", "6379")
+        driver = f"redis://{redis_host}:{redis_port}"
 
     CONF.set_override(name="url", override=driver, group="coordination")
     CONF.set_override(name="lock_timeout", override=1, group="coordination")

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -145,15 +145,13 @@ def _override_coordinator_opts(noop=False):
 
         ST2_OVERRIDE_COORDINATOR_REDIS_PORT = os.environ.get("ST2_OVERRIDE_COORDINATOR_REDIS_PORT", "6379")
         driver=f"redis://{ST2_OVERRIDE_COORDINATOR_REDIS_HOST}:{ST2_OVERRIDE_COORDINATOR_REDIS_PORT}"
-        assert False
-        print(f"Redis is being used with the following cord: {driver}")
 
     CONF.set_override(name="url", override=driver, group="coordination")
     CONF.set_override(name="lock_timeout", override=1, group="coordination")
 
 
 def _override_workflow_engine_opts():
-    cfg.CONF.set_override("retry_stop_max_msec", 500, group="workflow_engine")
+    cfg.CONF.set_override("retry_stop_max_msec", 200, group="workflow_engine")
     cfg.CONF.set_override("retry_wait_fixed_msec", 100, group="workflow_engine")
     cfg.CONF.set_override("retry_max_jitter_msec", 100, group="workflow_engine")
     cfg.CONF.set_override("gc_max_idle_sec", 1, group="workflow_engine")

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -140,11 +140,15 @@ def _override_scheduler_opts():
 def _override_coordinator_opts(noop=False):
     driver = None if noop else "zake://"
 
-    ST2_OVERRIDE_COORDINATOR_REDIS_HOST = os.environ.get("ST2_OVERRIDE_COORDINATOR_REDIS_HOST", False)
+    ST2_OVERRIDE_COORDINATOR_REDIS_HOST = os.environ.get(
+        "ST2_OVERRIDE_COORDINATOR_REDIS_HOST", False
+    )
     if ST2_OVERRIDE_COORDINATOR_REDIS_HOST:
 
-        ST2_OVERRIDE_COORDINATOR_REDIS_PORT = os.environ.get("ST2_OVERRIDE_COORDINATOR_REDIS_PORT", "6379")
-        driver=f"redis://{ST2_OVERRIDE_COORDINATOR_REDIS_HOST}:{ST2_OVERRIDE_COORDINATOR_REDIS_PORT}"
+        ST2_OVERRIDE_COORDINATOR_REDIS_PORT = os.environ.get(
+            "ST2_OVERRIDE_COORDINATOR_REDIS_PORT", "6379"
+        )
+        driver = f"redis://{ST2_OVERRIDE_COORDINATOR_REDIS_HOST}:{ST2_OVERRIDE_COORDINATOR_REDIS_PORT}"
 
     CONF.set_override(name="url", override=driver, group="coordination")
     CONF.set_override(name="lock_timeout", override=1, group="coordination")

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -139,6 +139,15 @@ def _override_scheduler_opts():
 
 def _override_coordinator_opts(noop=False):
     driver = None if noop else "zake://"
+
+    ST2_OVERRIDE_COORDINATOR_REDIS_HOST = os.environ.get("ST2_OVERRIDE_COORDINATOR_REDIS_HOST", False)
+    if ST2_OVERRIDE_COORDINATOR_REDIS_HOST:
+
+        ST2_OVERRIDE_COORDINATOR_REDIS_PORT = os.environ.get("ST2_OVERRIDE_COORDINATOR_REDIS_PORT", "6379")
+        driver=f"redis://{ST2_OVERRIDE_COORDINATOR_REDIS_HOST}:{ST2_OVERRIDE_COORDINATOR_REDIS_PORT}"
+        assert False
+        print(f"Redis is being used with the following cord: {driver}")
+
     CONF.set_override(name="url", override=driver, group="coordination")
     CONF.set_override(name="lock_timeout", override=1, group="coordination")
 


### PR DESCRIPTION
The graceful_shutdown tests have been very flaky using the `NoOpDriver`. Switching from `NoOpDriver` to `RedisDriver` will hopefully make our CI more stable.

This was discussed in a [TSC meeting](https://github.com/StackStorm/community/issues/141) and implemented by @FileMagic (#6223) and @guzzijones (#6236). I cherry-picked the redis-related parts of their excellent work. After stumbling through the cherry-picks (I missed a few things, and had to rebase/cherry-pick a few times), I refactored a few things:
- GHA: use the `redis` container defined in `services`, dropping the tasks that managed it manually.
- use `ST2TESTS_REDIS_*` as the format for new env vars instead of `ST2_OVERRIDE_COORDINATOR_REDIS_*`.
- fix a regression I added in #6241 that only became apparent once we stopped using NoOpDriver. It's surprising and scary how many of our tests rely on import-time side-effects.
- refactored tests to ensure each test got clean config. Several tests were relying on the config changes previous tests made, making them somewhat brittle. This will hopefully make that better.

:clap: Thank you @FileMagic and @guzzijones for getting this figured out! I have high hopes for more stable CI thanks to your excellent work! :tada: