### PR TITLE
Pantsbuild: Add BUILD dependencies for logging.conf

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -51,3 +51,8 @@ file(
 shell_sources(
     name="root",
 )
+
+file(
+    name="logs_directory",
+    source="logs/.gitignore",
+)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -139,7 +139,7 @@ def st2_logging_conf_files(**kwargs):
     deps = kwargs.pop("dependencies", []) or []
     deps = list(deps) + list(_st2common_logging_deps)
     kwargs["dependencies"] = tuple(deps)
-    files(**kwargs)
+    files(**kwargs)  # noqa: F821
 
 
 def st2_logging_conf_file(**kwargs):
@@ -147,7 +147,7 @@ def st2_logging_conf_file(**kwargs):
     deps = kwargs.pop("dependencies", []) or []
     deps = list(deps) + list(_st2common_logging_deps)
     kwargs["dependencies"] = tuple(deps)
-    file(**kwargs)
+    file(**kwargs)  # noqa: F821
 
 
 def st2_logging_conf_resources(**kwargs):
@@ -155,4 +155,4 @@ def st2_logging_conf_resources(**kwargs):
     deps = kwargs.pop("dependencies", []) or []
     deps = list(deps) + list(_st2common_logging_deps)
     kwargs["dependencies"] = tuple(deps)
-    resources(**kwargs)
+    resources(**kwargs)  # noqa: F821

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -125,3 +125,34 @@ def st2_shell_sources_and_resources(**kwargs):
 
     kwargs["name"] += "_resources"
     resources(**kwargs)  # noqa: F821
+
+
+# these are referenced by the logging.*.conf files.
+_st2common_logging_deps = (
+    "//st2common/st2common/log.py",
+    "//st2common/st2common/logging/formatters.py",
+)
+
+
+def st2_logging_conf_files(**kwargs):
+    """This creates a files target with logging dependencies."""
+    deps = kwargs.pop("dependencies", []) or []
+    deps = list(deps) + list(_st2common_logging_deps)
+    kwargs["dependencies"] = tuple(deps)
+    files(**kwargs)
+
+
+def st2_logging_conf_file(**kwargs):
+    """This creates a file target with logging dependencies."""
+    deps = kwargs.pop("dependencies", []) or []
+    deps = list(deps) + list(_st2common_logging_deps)
+    kwargs["dependencies"] = tuple(deps)
+    file(**kwargs)
+
+
+def st2_logging_conf_resources(**kwargs):
+    """This creates a resources target with logging dependencies."""
+    deps = kwargs.pop("dependencies", []) or []
+    deps = list(deps) + list(_st2common_logging_deps)
+    kwargs["dependencies"] = tuple(deps)
+    resources(**kwargs)

--- a/st2actions/conf/BUILD
+++ b/st2actions/conf/BUILD
@@ -1,9 +1,9 @@
-file(
+st2_logging_conf_file(
     name="logging_console",
     source="console.conf",
 )
 
-files(
+st2_logging_conf_files(
     name="logging",
     sources=["logging*.conf"],
     overrides={
@@ -15,7 +15,7 @@ files(
     },
 )
 
-files(
+st2_logging_conf_files(
     name="logging_syslog",
     sources=["syslog*.conf"],
 )

--- a/st2actions/conf/BUILD
+++ b/st2actions/conf/BUILD
@@ -6,9 +6,11 @@ st2_logging_conf_file(
 st2_logging_conf_files(
     name="logging",
     sources=["logging*.conf"],
+    dependencies=["//:logs_directory"],
     overrides={
         "logging.conf": dict(
             dependencies=[
+                "//:logs_directory",
                 "//:reqs#python-json-logger",
             ],
         ),

--- a/st2api/conf/BUILD
+++ b/st2api/conf/BUILD
@@ -6,11 +6,13 @@ st2_logging_conf_file(
 st2_logging_conf_file(
     name="logging",
     source="logging.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(

--- a/st2api/conf/BUILD
+++ b/st2api/conf/BUILD
@@ -1,19 +1,19 @@
-file(
+st2_logging_conf_file(
     name="logging_console",
     source="console.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging",
     source="logging.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_syslog",
     source="syslog.conf",
 )

--- a/st2auth/conf/BUILD
+++ b/st2auth/conf/BUILD
@@ -16,11 +16,13 @@ st2_logging_conf_file(
 st2_logging_conf_file(
     name="logging",
     source="logging.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(

--- a/st2auth/conf/BUILD
+++ b/st2auth/conf/BUILD
@@ -8,22 +8,22 @@ file(
     source="htpasswd_dev",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_console",
     source="console.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging",
     source="logging.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_syslog",
     source="syslog.conf",
 )

--- a/st2reactor/conf/BUILD
+++ b/st2reactor/conf/BUILD
@@ -6,6 +6,7 @@ st2_logging_conf_file(
 st2_logging_conf_files(
     name="logging",
     sources=["logging*.conf"],
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_files(

--- a/st2reactor/conf/BUILD
+++ b/st2reactor/conf/BUILD
@@ -1,14 +1,14 @@
-file(
+st2_logging_conf_file(
     name="logging_console",
     source="console.conf",
 )
 
-files(
+st2_logging_conf_files(
     name="logging",
     sources=["logging*.conf"],
 )
 
-files(
+st2_logging_conf_files(
     name="logging_syslog",
     sources=["syslog*.conf"],
 )

--- a/st2stream/conf/BUILD
+++ b/st2stream/conf/BUILD
@@ -6,11 +6,13 @@ st2_logging_conf_file(
 st2_logging_conf_file(
     name="logging",
     source="logging.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
+    dependencies=["//:logs_directory"],
 )
 
 st2_logging_conf_file(

--- a/st2stream/conf/BUILD
+++ b/st2stream/conf/BUILD
@@ -1,19 +1,19 @@
-file(
+st2_logging_conf_file(
     name="logging_console",
     source="console.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging",
     source="logging.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_gunicorn",
     source="logging.gunicorn.conf",
 )
 
-file(
+st2_logging_conf_file(
     name="logging_syslog",
     source="syslog.conf",
 )

--- a/st2tests/conf/BUILD
+++ b/st2tests/conf/BUILD
@@ -8,12 +8,12 @@ file(
     source="st2_kvstore_tests.crypto.key.json",
 )
 
-file(
+st2_logging_conf_file(
     name="logging.conf",
     source="logging.conf",
 )
 
-files(
+st2_logging_conf_files(
     name="other_logging_conf",
     sources=["logging.*.conf"],
 )

--- a/st2tests/st2tests/fixtures/conf/BUILD
+++ b/st2tests/st2tests/fixtures/conf/BUILD
@@ -1,10 +1,15 @@
+st2_logging_conf_resources(
+    name="logging",
+    sources=["logging.*.conf"],
+)
+
 resources(
     name="st2.tests.conf",
     sources=[
         "st2.tests*.conf",
-        "logging.*.conf",  # used by st2.tests*.conf
     ],
     dependencies=[
+        ":logging",  # used by st2.tests*.conf
         "st2tests/conf:other_logging_conf",
         # depending on st2auth from st2tests is not nice.
         "st2auth/conf:htpasswd",


### PR DESCRIPTION
This PR has commits cherry-picked from #6202 

I'm working towards getting pants to run our tests via pytest. While running unit tests, I found that the logging.conf files depend on python code, but pants cannot infer dependencies in conf files.

For example, this logging.conf snippet uses 3 classes from `st2common.logging.formatters`:
https://github.com/StackStorm/st2/blob/b534bf2089502ea865f5da654c16e21f781121e2/st2stream/conf/logging.conf#L32-L44

And this snippet uses `st2common.log.ConfigurableSyslogHandler`:
https://github.com/StackStorm/st2/blob/b534bf2089502ea865f5da654c16e21f781121e2/st2stream/conf/syslog.conf#L14-L18

Recording these dependencies for every conf file would be very repetitive, though, so I added 3 pants macros to simplify defining the dependencies in BUILD metadata:

- `st2_logging_conf_file`
- `st2_logging_conf_files`
- `st2_logging_conf_resources`
