### PR TITLE
Pants: Minor test refactor to support running under pants+pytest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,7 +59,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -8,5 +8,9 @@ python_requirements(
 )
 
 python_sources(
-    dependencies=[":metadata"],
+    dependencies=[
+        ":metadata",
+        "./actions",
+        "./actions/send_mail:send_mail_resources",
+    ],
 )

--- a/contrib/core/actions/send_mail/BUILD
+++ b/contrib/core/actions/send_mail/BUILD
@@ -1,4 +1,5 @@
-shell_source(
-    source="send_mail",
+st2_shell_sources_and_resources(
+    name="send_mail",
+    sources=["send_mail"],
     skip_shellcheck=True,
 )

--- a/st2common/tests/unit/services/test_packs.py
+++ b/st2common/tests/unit/services/test_packs.py
@@ -43,6 +43,7 @@ from st2tests.fixtures.packs.dummy_pack_23.fixture import (
 from st2tests.fixtures.packs.orquesta_tests.fixture import (
     PACK_NAME as TEST_SOURCE_WORKFLOW_PACK,
 )
+import st2tests.config as tests_config
 
 SOURCE_ACTION_WITH_PYTHON_SCRIPT_RUNNER = {
     "description": "Action which injects a new trigger in the system.",
@@ -416,6 +417,8 @@ class DeleteActionMetadataFilesErrorTest(unittest.TestCase):
 class CloneActionDBAndFilesTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
         action_files_path = os.path.join(TEST_DEST_PACK_PATH, "actions")
         workflow_files_path = os.path.join(action_files_path, "workflows")
         if not os.path.isdir(action_files_path):
@@ -588,6 +591,11 @@ class CloneActionDBAndFilesTestCase(unittest.TestCase):
 
 
 class CloneActionFilesBackupTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        tests_config.parse_args()
+
     @classmethod
     def tearDownClass(cls):
         action_files_path = os.path.join(TEST_DEST_PACK_PATH, "actions")

--- a/st2common/tests/unit/test_db.py
+++ b/st2common/tests/unit/test_db.py
@@ -112,7 +112,7 @@ class DbConnectionTestCase(DbTestCase):
     @classmethod
     def tearDownClass(cls):
         # since tearDown discconnects, dropping the database in tearDownClass
-        # fails withotu establishing a new connection.
+        # fails without establishing a new connection.
         cls._establish_connection_and_re_create_db()
         super().tearDownClass()
 

--- a/st2common/tests/unit/test_util_file_system.py
+++ b/st2common/tests/unit/test_util_file_system.py
@@ -27,21 +27,21 @@ ST2TESTS_DIR = os.path.join(CURRENT_DIR, "../../../st2tests/st2tests")
 
 class FileSystemUtilsTestCase(unittest.TestCase):
     def test_get_file_list(self):
+        # NB: Make sure to exclude BUILD files as pants will not include them in the sandbox,
+        #     but the BUILD files will be present if you directly run the tests.
+        basic_excludes = ["*.pyc", "__pycache__", "*BUILD"]
+
         # Standard exclude pattern
         directory = os.path.join(ST2TESTS_DIR, "policies")
         expected = [
-            "BUILD",
             "mock_exception.py",
             "concurrency.py",
             "__init__.py",
-            "meta/BUILD",
             "meta/mock_exception.yaml",
             "meta/concurrency.yaml",
             "meta/__init__.py",
         ]
-        result = get_file_list(
-            directory=directory, exclude_patterns=["*.pyc", "__pycache__"]
-        )
+        result = get_file_list(directory=directory, exclude_patterns=basic_excludes)
         # directory listings are sorted because the item order must be exact for assert
         # to validate equivalence.  Directory item order doesn't matter in general and may
         # even change on different platforms or locales.
@@ -55,7 +55,7 @@ class FileSystemUtilsTestCase(unittest.TestCase):
             "meta/__init__.py",
         ]
         result = get_file_list(
-            directory=directory, exclude_patterns=["*.pyc", "*.yaml", "*BUILD"]
+            directory=directory, exclude_patterns=["*.yaml"] + basic_excludes
         )
         # directory listings are sorted because the item order must be exact for assert
         # to validate equivalence.  Directory item order doesn't matter in general and may

--- a/st2tests/st2tests/policies/meta/BUILD
+++ b/st2tests/st2tests/policies/meta/BUILD
@@ -1,3 +1,9 @@
 resources(
-    sources=["*.yaml"],
+    sources=[
+        "*.yaml",
+        # pants ignores empty __init__.py files.
+        # However, the tests for st2common.util.file_system need it to be present,
+        # so we treat it as a resource instead of a python source file.
+        "__init__.py",
+    ],
 )


### PR DESCRIPTION
This has a couple of commits extracted from #6202 where I'm working on getting all of our unit tests to run under pants+pytest.

1 test relied on `tests_config.parse_args()` happening when nose imported or ran earlier tests (similar to changes in #6241).

For the other test, pants does not copy BUILD files into the sandbox, so we need to completely ignore the BUILD files when they exist (ie when running nosetest or pytest directly instead of letting pants run it in a sandbox).

Plus there are a few file dep changes in BUILD metadata to support these.