### PR TITLE
Pants: Add more dependency-related BUILD metadata

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,36 @@ python_requirements(
                 "st2auth/st2auth/backends/constants.py",
             ]
         ),
+        # make sure anything that uses st2-rbac-backend gets its deps
+        "st2-rbac-backend": dict(
+            dependencies=[
+                # alphabetical order
+                "st2common/st2common/config.py",
+                "st2common/st2common/constants/keyvalue.py",
+                "st2common/st2common/constants/triggers.py",
+                "st2common/st2common/content/loader.py",
+                "st2common/st2common/exceptions/db.py",
+                "st2common/st2common/exceptions/rbac.py",
+                "st2common/st2common/log.py",
+                "st2common/st2common/models/api/rbac.py",
+                "st2common/st2common/models/db/action.py",
+                "st2common/st2common/models/db/auth.py",
+                "st2common/st2common/models/db/pack.py",
+                "st2common/st2common/models/db/rbac.py",
+                "st2common/st2common/models/db/webhook.py",
+                "st2common/st2common/models/system/common.py",
+                "st2common/st2common/persistence/auth.py",
+                "st2common/st2common/persistence/execution.py",
+                "st2common/st2common/persistence/rbac.py",
+                "st2common/st2common/rbac/backends/__init__.py",
+                "st2common/st2common/rbac/backends/base.py",
+                "st2common/st2common/rbac/types.py",
+                "st2common/st2common/script_setup.py",
+                "st2common/st2common/util/action_db.py",
+                "st2common/st2common/util/misc.py",
+                "st2common/st2common/util/uid.py",
+            ]
+        ),
     },
 )
 
@@ -35,6 +65,13 @@ target(
     dependencies=[
         "//:reqs#st2-auth-backend-flat-file",
         "//:reqs#st2-auth-ldap",
+    ],
+)
+
+target(
+    name="rbac_backends",
+    dependencies=[
+        "//:reqs#st2-rbac-backend",
     ],
 )
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,7 +64,7 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253 #6254
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/chatops/actions/BUILD
+++ b/contrib/chatops/actions/BUILD
@@ -1,1 +1,7 @@
-python_sources()
+python_sources(
+    overrides={
+        "format_execution_result.py": dict(
+            dependencies=["./templates"],
+        ),
+    },
+)

--- a/contrib/chatops/actions/templates/BUILD
+++ b/contrib/chatops/actions/templates/BUILD
@@ -1,0 +1,3 @@
+resources(
+    sources=["*.j2"],
+)

--- a/contrib/chatops/tests/BUILD
+++ b/contrib/chatops/tests/BUILD
@@ -13,6 +13,9 @@ files(
 
 python_tests(
     name="tests",
-    dependencies=[":fixtures"],
+    dependencies=[
+        ":fixtures",
+        "contrib/chatops:metadata",
+    ],
     skip_pylint=True,
 )

--- a/contrib/core/tests/BUILD
+++ b/contrib/core/tests/BUILD
@@ -16,6 +16,7 @@ python_tests(
                 # Use contrib/core as the canonical copy.
                 "contrib/core:reqs#mail-parser",
             ],
+            uses=["mongo"],
         ),
     },
 )

--- a/contrib/packs/tests/BUILD
+++ b/contrib/packs/tests/BUILD
@@ -8,4 +8,22 @@ __defaults__(
 
 python_tests(
     skip_pylint=True,
+    overrides={
+        "test_action_aliases.py": dict(
+            dependencies=[
+                # test needs the pack and aliases metadata
+                "contrib/packs:metadata",
+            ],
+        ),
+        "test_action_unload.py": dict(
+            stevedore_namespaces=[
+                "st2common.metrics.driver",
+            ],
+            entry_point_dependencies={
+                "contrib/runners/http_runner": ["st2common.runners.runner"],
+                "contrib/runners/local_runner": ["st2common.runners.runner"],
+                "contrib/runners/python_runner": ["st2common.runners.runner"],
+            },
+        ),
+    },
 )

--- a/contrib/runners/action_chain_runner/tests/BUILD
+++ b/contrib/runners/action_chain_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/action_chain_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -5,4 +5,15 @@ __defaults__(
 
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.rbac.backend",
+        "st2common.metrics.driver",
+        # TODO: we only need THIS runner, but this pulls in all.
+        "st2common.runners.runner",
+    ],
+    uses=["mongo"],
+    # TODO: need st2common.runners.runner stevedore namespace, but only this runner!
+    #dependencies=[
+    #    "contrib/runners/action_chain_runner",
+    #],
 )

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -8,13 +8,8 @@ python_tests(
     stevedore_namespaces=[
         "st2common.rbac.backend",
         "st2common.metrics.driver",
-        # TODO: we only need THIS runner, but this pulls in all.
+        # the core pack uses all runners.
         "st2common.runners.runner",
     ],
     uses=["mongo"],
-    # TODO: this will allow us to depend only on this runner once we upgrade to pants 2.23
-    #       https://github.com/pantsbuild/pants/pull/21062
-    #entry_point_dependencies={
-    #    "contrib/runners/action_chain_runner": ["st2common.runners.runner"],
-    #},
 )

--- a/contrib/runners/action_chain_runner/tests/unit/BUILD
+++ b/contrib/runners/action_chain_runner/tests/unit/BUILD
@@ -12,8 +12,9 @@ python_tests(
         "st2common.runners.runner",
     ],
     uses=["mongo"],
-    # TODO: need st2common.runners.runner stevedore namespace, but only this runner!
-    #dependencies=[
-    #    "contrib/runners/action_chain_runner",
-    #],
+    # TODO: this will allow us to depend only on this runner once we upgrade to pants 2.23
+    #       https://github.com/pantsbuild/pants/pull/21062
+    #entry_point_dependencies={
+    #    "contrib/runners/action_chain_runner": ["st2common.runners.runner"],
+    #},
 )

--- a/contrib/runners/announcement_runner/tests/BUILD
+++ b/contrib/runners/announcement_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/announcement_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/http_runner/tests/BUILD
+++ b/contrib/runners/http_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/http_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/inquirer_runner/tests/BUILD
+++ b/contrib/runners/inquirer_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/inquirer_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/local_runner/tests/BUILD
+++ b/contrib/runners/local_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/local_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/noop_runner/tests/BUILD
+++ b/contrib/runners/noop_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/noop_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/orquesta_runner/tests/BUILD
+++ b/contrib/runners/orquesta_runner/tests/BUILD
@@ -2,7 +2,10 @@ __defaults__(
     all=dict(
         skip_pylint=True,
         entry_point_dependencies={
-            "contrib/runners/orquesta_runner": ["st2common.runners.runner"],
+            "contrib/runners/orquesta_runner": [
+                "st2common.runners.runner",
+                "orquesta.expressions.functions",
+            ],
         },
     )
 )

--- a/contrib/runners/orquesta_runner/tests/BUILD
+++ b/contrib/runners/orquesta_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/orquesta_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/orquesta_runner/tests/unit/BUILD
+++ b/contrib/runners/orquesta_runner/tests/unit/BUILD
@@ -5,6 +5,13 @@ __defaults__(
 
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.metrics.driver",
+        "st2common.rbac.backend",
+        # the core pack uses all runners.
+        "st2common.runners.runner",
+        "orquesta.expressions.functions",
+    ],
     overrides={
         (
             "test_basic.py",
@@ -15,6 +22,9 @@ python_tests(
             "test_with_items.py",
         ): dict(
             uses=["system_user"],
+        ),
+        "test_policies.py": dict(
+            dependencies=["st2actions/st2actions/policies/retry.py"]
         ),
     },
 )

--- a/contrib/runners/python_runner/tests/BUILD
+++ b/contrib/runners/python_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/python_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/python_runner/tests/integration/BUILD
+++ b/contrib/runners/python_runner/tests/integration/BUILD
@@ -5,4 +5,9 @@ __defaults__(
 
 python_tests(
     name="tests",
+    overrides={
+        "test_python_action_process_wrapper.py": dict(
+            dependencies=["contrib/examples/actions/noop.py"]
+        )
+    },
 )

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -5,4 +5,16 @@ __defaults__(
 
 python_tests(
     name="tests",
+    overrides={
+        "test_output_schema.py": dict(
+            dependencies=[
+                "st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py",
+            ],
+        ),
+        "test_pythonrunner.py": dict(
+            dependencies=[
+                "st2tests/st2tests/resources/packs/pythonactions/actions",
+            ],
+        ),
+    },
 )

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -15,6 +15,9 @@ python_tests(
             dependencies=[
                 "st2tests/st2tests/resources/packs/pythonactions/actions",
             ],
+            stevedore_namespaces=[
+                "st2common.metrics.driver",
+            ],
         ),
     },
 )

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -17,6 +17,7 @@ python_tests(
             ],
             stevedore_namespaces=[
                 "st2common.metrics.driver",
+                "st2common.rbac.backend",
             ],
         ),
     },

--- a/contrib/runners/remote_runner/tests/BUILD
+++ b/contrib/runners/remote_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/remote_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/contrib/runners/winrm_runner/tests/BUILD
+++ b/contrib/runners/winrm_runner/tests/BUILD
@@ -1,6 +1,9 @@
 __defaults__(
     all=dict(
         skip_pylint=True,
+        entry_point_dependencies={
+            "contrib/runners/winrm_runner": ["st2common.runners.runner"],
+        },
     )
 )
 

--- a/st2actions/tests/unit/BUILD
+++ b/st2actions/tests/unit/BUILD
@@ -5,13 +5,30 @@ __defaults__(
 
 python_tests(
     name="tests",
+    uses=["mongo"],
     overrides={
         (
             "test_execution_cancellation.py",
             "test_runner_container.py",
             "test_worker.py",
         ): dict(
-            uses=["system_user"],
+            uses=["mongo", "system_user"],
+        ),
+        (
+            "test_execution*.py",
+            "test_notifier.py",
+            "test_output_schema.py",
+            "test_policies.py",
+            "test_queue_consumers.py",
+            "test_runner_container.py",
+            "test_scheduler*.py",
+            "test_worker.py",
+            "test_workflow_engine.py",
+        ): dict(
+            stevedore_namespaces=[
+                "st2common.runners.runner",
+                "st2common.metrics.driver",
+            ],
         ),
     },
 )

--- a/st2actions/tests/unit/policies/BUILD
+++ b/st2actions/tests/unit/policies/BUILD
@@ -1,3 +1,8 @@
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.runners.runner",
+        "st2common.metrics.driver",
+    ],
+    uses=["mongo"],
 )

--- a/st2api/tests/unit/BUILD
+++ b/st2api/tests/unit/BUILD
@@ -5,4 +5,9 @@ __defaults__(
 
 python_tests(
     name="tests",
+    dependencies=["//:rbac_backends"],
+    stevedore_namespaces=[
+        "st2common.rbac.backend",
+    ],
+    uses=["mongo"],
 )

--- a/st2api/tests/unit/controllers/BUILD
+++ b/st2api/tests/unit/controllers/BUILD
@@ -1,3 +1,7 @@
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.metrics.driver",
+    ],
+    uses=["mongo"],
 )

--- a/st2api/tests/unit/controllers/v1/BUILD
+++ b/st2api/tests/unit/controllers/v1/BUILD
@@ -1,5 +1,11 @@
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.runners.runner",
+        "st2common.rbac.backend",
+        "st2common.metrics.driver",
+    ],
+    uses=["mongo"],
     overrides={
         (
             "test_alias_execution.py",
@@ -8,7 +14,12 @@ python_tests(
             "test_executions.py",
             "test_inquiries.py",
         ): dict(
-            uses=["system_user"],
+            uses=["mongo", "system_user"],
+        ),
+        "test_webhooks.py": dict(
+            dependencies=[
+                "st2common/st2common/models/api/webhook.py",
+            ],
         ),
     },
 )

--- a/st2auth/tests/unit/BUILD
+++ b/st2auth/tests/unit/BUILD
@@ -5,4 +5,6 @@ __defaults__(
 
 python_tests(
     name="tests",
+    dependencies=["//:auth_backends"],
+    uses=["mongo"],
 )

--- a/st2auth/tests/unit/controllers/v1/BUILD
+++ b/st2auth/tests/unit/controllers/v1/BUILD
@@ -1,3 +1,8 @@
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2auth.sso.backends",
+        "st2common.metrics.driver",
+    ],
+    uses=["mongo"],
 )

--- a/st2common/tests/fixtures/local_runner/BUILD
+++ b/st2common/tests/fixtures/local_runner/BUILD
@@ -1,1 +1,8 @@
-python_sources()
+resources(
+    name="command_strings",
+    sources=["escaping_test_command_*.txt"],
+)
+
+python_sources(
+    dependencies=[":command_strings"],
+)

--- a/st2common/tests/unit/BUILD
+++ b/st2common/tests/unit/BUILD
@@ -13,7 +13,7 @@ python_tests(
     ],
     uses=["mongo", "rabbitmq"],
     overrides={
-        "test_util_file_system.py": dict(
+        ("test_util_file_system.py", "test_policies_registrar.py",): dict(
             dependencies=[
                 "st2tests/st2tests/policies",
                 "st2tests/st2tests/policies/meta",

--- a/st2common/tests/unit/services/BUILD
+++ b/st2common/tests/unit/services/BUILD
@@ -7,4 +7,12 @@ python_tests(
         "st2common.metrics.driver",
     ],
     uses=["mongo", "rabbitmq"],
+    overrides={
+        "test_packs.py": dict(
+            # use the fixture to resolve ambiguous import (ambiguous due to symlink of core pack)
+            dependencies=[
+                "st2tests/st2tests/fixtures/packs/core/actions/inject_trigger.py"
+            ],
+        ),
+    },
 )

--- a/st2reactor/tests/unit/BUILD
+++ b/st2reactor/tests/unit/BUILD
@@ -5,4 +5,20 @@ __defaults__(
 
 python_tests(
     name="tests",
+    uses=["mongo"],
+    overrides={
+        "test_enforce.py": dict(
+            stevedore_namespaces=[
+                "st2common.rbac.backend",
+                "st2common.runners.runner",
+                "st2common.metrics.driver",
+            ],
+        ),
+        "test_rule_engine.py": dict(
+            stevedore_namespaces=[
+                "st2common.runners.runner",
+                "st2common.metrics.driver",
+            ],
+        ),
+    },
 )

--- a/st2stream/tests/unit/controllers/v1/BUILD
+++ b/st2stream/tests/unit/controllers/v1/BUILD
@@ -1,5 +1,11 @@
 python_tests(
     name="tests",
+    stevedore_namespaces=[
+        "st2common.rbac.backend",
+        "st2common.runners.runner",
+        "st2common.metrics.driver",
+    ],
+    uses=["mongo"],
 )
 
 python_test_utils(

--- a/st2tests/st2tests/fixtures/generic/BUILD
+++ b/st2tests/st2tests/fixtures/generic/BUILD
@@ -3,6 +3,12 @@ pack_metadata(
     dependencies=[
         "./actions:shell",
         "./actions:shell_resources",
+        # policytypes/fake_policy_type_1.py needs:
+        "//st2tests/st2tests/policies/concurrency.py",
+        # policytypes/fake_policy_type_2.py needs:
+        "//st2tests/st2tests/policies/mock_exception.py",
+        # policytypes/fake_policy_type_3.py needs:
+        "//st2actions/st2actions/policies/concurrency_by_attr.py",
     ],
 )
 


### PR DESCRIPTION
This PR has commits extracted from #6202 where I'm working on getting all of our unit tests to run under pants+pytest.

This PR adds dependency-related BUILD metadata required to run various tests. In general, this includes:

- `uses=[...]`: Makes our `pants-plugins/uses_services` plugin check for running services before running the tests.
- `stevedore_namespaces=[...]`: Includes all plugins of each type (each stevedore namespace) listed. For example, `stevedore_namespaces=["st2common.runners.runner"]` would make all runners available when running a set of tests.
- `entry_point_dependencies=[...]`: A more fine-grained version of steveore_namespaces. Instead of including every plugin that provide a given type, this includes selected entry points. This is especially helpful for runner tests, so that `noop_runner` tests only require the noop runner, instead of _all_ of the runners. _This feature is part of pants 2.23. It is one of the reasons we updated to 2.23 alpha in #6229 instead of waiting for a stable release._
- `dependencies=[...]`: some tests depend on various files that pants cannot infer based on pants dependencies. For example, when a test runs an action via the API, there is no import that tells pants which action the test needs.
- `resources(...)`: some tests needed files that were not covered by any of the BUILD targets, so I added the files as `resources`.

It can be beneficial to step through the commits. That will show you which tests needed the metadata.