### PR TITLE
Pants: Add BUILD metadata to handle git submodule

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,8 +83,8 @@ jobs:
 
       - name: Fetch repository submodules
         run: |
-          git submodule update --init --recursive --remote
           git submodule status
+          git submodule foreach 'git fetch --all --tags'
           git submodule foreach 'git tag'
 
       - name: 'Set up Python (${{ matrix.python-version }})'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,13 @@ jobs:
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
           submodules: 'true'
+          # sadly, the submodule will only have fetch-depth=1, which is what we want
+          # for st2.git, but not for the submodules. We still want actions/checkout
+          # to do the initial checkout, however, so that it adds auth for fetching
+          # in the submodule.
+
+      - name: Fetch repository submodules
+        run: git submodule update --init --recursive --remote
 
       - name: 'Set up Python (${{ matrix.python-version }})'
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,14 +75,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           # a test uses a submodule, and pants needs access to it to calculate deps.
-          submodules: 'true'
+          submodules: 'recursive'
           # sadly, the submodule will only have fetch-depth=1, which is what we want
           # for st2.git, but not for the submodules. We still want actions/checkout
           # to do the initial checkout, however, so that it adds auth for fetching
           # in the submodule.
 
       - name: Fetch repository submodules
-        run: git submodule update --init --recursive --remote
+        run: |
+          git submodule update --init --recursive --remote
+          git submodule status
+          git submodule foreach 'git tag'
 
       - name: 'Set up Python (${{ matrix.python-version }})'
         uses: actions/setup-python@v5

--- a/BUILD
+++ b/BUILD
@@ -112,7 +112,6 @@ shell_command(
     # if a submodule gets updated to a different repo).
     # Sadly this does not get invalidated if the submodule commit
     # is updated. In our case, that should be rare. To work around
-    # If you update a submodule,
     # this, kill the `pantsd` process after updating a submodule.
     execution_dependencies=[":gitmodules"],
     output_dependencies=[":gitmodules"],

--- a/BUILD
+++ b/BUILD
@@ -102,11 +102,6 @@ files(
     ],
 )
 
-run_shell_command(
-    name="git_submodules_fetch",
-    command="git submodule foreach 'git fetch --all'",
-)
-
 shell_command(
     name="capture_git_modules",
     environment="in_repo_workspace",
@@ -116,10 +111,7 @@ shell_command(
     # of this command if the .gitmodules file changes (for example:
     # if a submodule gets updated to a different commit).
     # Theoretically, nothing else should modify .git/modules/.
-    execution_dependencies=[
-        ":gitmodules",
-        ":git_submodules_fetch",
-    ],
+    execution_dependencies=[":gitmodules"],
     output_dependencies=[":gitmodules"],
     output_directories=[".git/modules"],
     workdir="/",

--- a/BUILD
+++ b/BUILD
@@ -102,6 +102,11 @@ files(
     ],
 )
 
+run_shell_command(
+    name="git_submodules_fetch",
+    command="git submodule foreach 'git fetch --all'",
+)
+
 shell_command(
     name="capture_git_modules",
     environment="in_repo_workspace",
@@ -111,7 +116,10 @@ shell_command(
     # of this command if the .gitmodules file changes (for example:
     # if a submodule gets updated to a different commit).
     # Theoretically, nothing else should modify .git/modules/.
-    execution_dependencies=[":gitmodules"],
+    execution_dependencies=[
+        ":gitmodules",
+        ":git_submodules_fetch",
+    ],
     output_dependencies=[":gitmodules"],
     output_directories=[".git/modules"],
     workdir="/",

--- a/BUILD
+++ b/BUILD
@@ -93,3 +93,26 @@ file(
     name="logs_directory",
     source="logs/.gitignore",
 )
+
+files(
+    name="gitmodules",
+    sources=[
+        ".gitmodules",
+        "**/.git",
+    ],
+)
+
+shell_command(
+    name="capture_git_modules",
+    environment="in_repo_workspace",
+    command="cp -r .git/modules {chroot}/.git",
+    tools=["cp"],
+    # execution_dependencies allows pants to invalidate the output
+    # of this command if the .gitmodules file changes (for example:
+    # if a submodule gets updated to a different commit).
+    # Theoretically, nothing else should modify .git/modules/.
+    execution_dependencies=[":gitmodules"],
+    output_dependencies=[":gitmodules"],
+    output_directories=[".git/modules"],
+    workdir="/",
+)

--- a/BUILD
+++ b/BUILD
@@ -109,8 +109,11 @@ shell_command(
     tools=["cp"],
     # execution_dependencies allows pants to invalidate the output
     # of this command if the .gitmodules file changes (for example:
-    # if a submodule gets updated to a different commit).
-    # Theoretically, nothing else should modify .git/modules/.
+    # if a submodule gets updated to a different repo).
+    # Sadly this does not get invalidated if the submodule commit
+    # is updated. In our case, that should be rare. To work around
+    # If you update a submodule,
+    # this, kill the `pantsd` process after updating a submodule.
     execution_dependencies=[":gitmodules"],
     output_dependencies=[":gitmodules"],
     output_directories=[".git/modules"],

--- a/BUILD.environment
+++ b/BUILD.environment
@@ -11,7 +11,7 @@ experimental_workspace_environment(
     name="in_repo_workspace",
     description=(
         """
-        This allows shell_command and similar to in the repo, instead of in a sandbox.
+        This allows shell_command and similar to run in the repo, instead of in a sandbox.
         Only use this environment for commands or goals that are idempotent.
         Ideally, such commands do NOT change anything in the repo.
 

--- a/BUILD.environment
+++ b/BUILD.environment
@@ -1,0 +1,23 @@
+# Everything listed in pants.toml [evironments-preview.names] should be defined here.
+# Relevant docs:
+# - https://www.pantsbuild.org/stable/docs/using-pants/environments
+# - https://www.pantsbuild.org/stable/reference/targets/experimental_workspace_environment
+# - https://www.pantsbuild.org/stable/reference/targets/local_environment
+# - https://www.pantsbuild.org/stable/reference/targets/docker_environment
+
+# This file MUST NOT use any macros.
+
+experimental_workspace_environment(
+    name="in_repo_workspace",
+    description=(
+        """
+        This allows shell_command and similar to in the repo, instead of in a sandbox.
+        Only use this environment for commands or goals that are idempotent.
+        Ideally, such commands do NOT change anything in the repo.
+
+        If you need to capture output, note that output gets captured from a temporary
+        sandbox, not from the repo root. So, you may need to copy output files into
+        the sandbox with something like `cp path/to/file {chroot}/path/to/file`.
+        """
+    ),
+)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,7 +64,8 @@ Added
 * Continue introducing `pants <https://www.pantsbuild.org/docs>`_ to improve DX (Developer Experience)
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
-  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253 #6254
+  #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
+  #6254 #6258
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/python_runner/tests/unit/BUILD
+++ b/contrib/runners/python_runner/tests/unit/BUILD
@@ -9,11 +9,13 @@ python_tests(
         "test_output_schema.py": dict(
             dependencies=[
                 "st2tests/st2tests/resources/packs/pythonactions/actions/pascal_row.py",
+                "//:capture_git_modules",
             ],
         ),
         "test_pythonrunner.py": dict(
             dependencies=[
                 "st2tests/st2tests/resources/packs/pythonactions/actions",
+                "//:capture_git_modules",
             ],
             stevedore_namespaces=[
                 "st2common.metrics.driver",

--- a/pants.toml
+++ b/pants.toml
@@ -249,5 +249,9 @@ extra_env_vars = [
 [twine]
 install_from_resolve = "twine"
 
+[environments-preview.names]
+# https://www.pantsbuild.org/stable/docs/using-pants/environments
+in_repo_workspace = "//:in_repo_workspace"
+
 [cli.alias]
 --all-changed = "--changed-since=HEAD --changed-dependents=transitive"

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -8,8 +8,10 @@ pack_metadata_in_git_submodule(
     sources=[
         "test_content_version/pack.yaml",
         "test_content_version/**/*.yaml",
+        "!test_content_version/.github/workflows/*.yaml",
         "test_content_version/icon.png",
         "test_content_version/requirements.txt",
+        "test_content_version/.git",  # file that is git ignored, but used by the tests
     ],
 )
 

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -8,11 +8,10 @@ pack_metadata_in_git_submodule(
     sources=[
         "test_content_version/pack.yaml",
         "test_content_version/**/*.yaml",
-        "!test_content_version/.github/workflows/*.yaml",
         "test_content_version/icon.png",
         "test_content_version/requirements.txt",
-        "test_content_version/.git",  # file that is git ignored, but used by the tests
     ],
+    # NOTE: If you need the git metadata, make sure to depend on //:capture_git_modules
 )
 
 st2_shell_sources_and_resources(


### PR DESCRIPTION
This PR has commits extracted from #6202 where I'm working on getting all of our unit tests to run under pants+pytest.

This PR focuses on managing the git submodule we use to test pack features, especially the content version selection that relies on `git worktree`. Pants runs processes like pytest in a sandbox, but the `.git` directory does not get copied into the sandbox. Plus, `.git` is generally ignored, so I had to find a way to work around the pants assumptions that ignore `.git` and copy the submodule bits into the sandbox.

This is the target that copies the `.git` directory for the submodule: 

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD#L105-L109

This relies on a few pants features, some of which are experimental (which means the interface can change in a future release of pants):
- `shell_command(...)`: This target tells pants to run a command when another target depends on this one. See [the docs](https://www.pantsbuild.org/2.23/reference/targets/shell_command). For example, this is a test that depends on this target: 

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/contrib/runners/python_runner/tests/unit/BUILD#L15-L18

- `environment=...`: Environments is a newer, experimental feature in pants. Typically things run in the `local` environment, but they can also run remotely or in docker depending on the config. See [the docs](https://www.pantsbuild.org/2.23/docs/using-pants/environments) for this feature, and [the blog post](https://www.pantsbuild.org/blog/2023/03/28/environments-simpler-multi-platform-workflows) about it.
- `"in_repo_workspace"`: this is the name of the environment we're using. To define the environment, I had to register it in `pants.toml` and add a `BUILD` target. Here is the snippet from `pants.toml` (note that environments are an experimental/preview feature):

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/pants.toml#L252-L254

The `"in_repo_workspace"` environment uses an even newer experimental feature, the `experimental_workspace_environment(...)` target. See [the docs overview](https://www.pantsbuild.org/2.23/docs/using-pants/environments#in-workspace-execution-experimental_workspace_environment) and [the docs reference](https://www.pantsbuild.org/prerelease/reference/targets/experimental_workspace_environment). This environment is the key to capturing `.git`, because it allows us to run the `shell_command` in the repo (in the workspace) instead of running in a sandbox. Pants could run a command using another target like `run_shell_command`, but they either don't allow capturing output files for use in other sandboxed tasks, or they were more cumbersome. I tried to add plenty of documentation to the new `BUILD.environment` file. In the future we might add one or more `docker_environment` targets as well. Here is the target definition: 

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD.environment#L10-L14

Returning to the `shell_command`, with `command="cp -r .git/modules {chroot}/.git"`:
- Here, `{chroot}` is very important. Though the command does not run in a sandbox (aka "chroot"), the command _still_ has a sandbox that can contain generated files, or, for our purposes, files captured as "outputs" that can be placed, as "inputs", in the sandbox of targets that depend on the command. The [`run_shell_command` docs](https://www.pantsbuild.org/2.23/reference/targets/shell_command) are helpful in understanding this.
- This is where the `shell_command` defines the files to capture from its sandbox. The command merely copies the files we need (which are very small because the test repo is tiny) into the sandbox so they can be captured: 

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD#L118

- And this is where I defined some dependencies of the command. `execution_dependencies` makes pants copy stuff into the sandbox, and more importantly, tells pants it has to rerun the command if the files change. `output_dependencies` gets passed onto any targets that depend on the command, so they also transitively depend on the files.

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD#L116-L117

- The `gitmodules` target is defined here. Note that `.git` is a file, not a directory, in the submodule. It points git to the actual location of the git metadata in the st2 repo's `.git` directory. We can't directly capture `.git/modules` like this, because the `.git` directory is ignored.

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD#L97-L103

- Sadly, I couldn't find a clean way to make pants invalidate cached results of the process when someone updates the commit in the submodule. So, I left this note with the workaround:

https://github.com/StackStorm/st2/blob/a25bcfd9b7b04405cd6a64f631595a0d4ec024f3/BUILD#L110-L115

Finally, the last piece of getting these tests to run with pytest+pants in #6202 was working around a quirk of cloning in GHA. The actions/checkout module only fetches 1 commit, which is great for st2.git, but it is not enough for the submodule which needs the full history and git tags. So, I updated The pants test GHA workflow to work around this.