### PR TITLE
Adjust test to use `runner.yaml` file over the symlink

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258
+  #6254 #6258 #6259
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/python_runner/tests/unit/test_output_schema.py
+++ b/contrib/runners/python_runner/tests/unit/test_output_schema.py
@@ -66,7 +66,7 @@ class PythonRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         assert_submodules_are_checked_out()
 
     def test_adherence_to_output_schema(self):
-        config = self.loader(os.path.join(BASE_DIR, "../../runner.yaml"))
+        config = self.loader(os.path.join(BASE_DIR, "../../python_runner/runner.yaml"))
         runner = self._get_mock_runner_obj()
         runner.entry_point = PASCAL_ROW_ACTION_PATH
         runner.pre_run()


### PR DESCRIPTION
This was extracted from #6202 where I'm working on getting pants to run our tests with pytest.

The `runner.yaml` symlink is not registered in pants. So far, the test in this PR is the first file I've found that accesses that symlink. So, this PR makes the test just use the actual file instead of the symlink.

I put this commit in it's own PR because it doesn't fit with any of the other changes, and to see if anyone knows of a reason for the `runner.yaml` symlinks. The symlinks seem pointless to me, so I don't want to rely on them. Is there anything else that relies on these symlinks?