### PR TITLE
Pants plugins: pack_metadata - python imports rules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259
+  #6254 #6258 #6259 #6260
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/chatops/BUILD
+++ b/contrib/chatops/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/debug/BUILD
+++ b/contrib/debug/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/default/BUILD
+++ b/contrib/default/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/examples/BUILD
+++ b/contrib/examples/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/examples/actions/pythonactions/isprime.py
+++ b/contrib/examples/actions/pythonactions/isprime.py
@@ -15,7 +15,8 @@
 
 import math
 
-from environ import get_environ
+# TODO: extend pants and pants-plugins/pack_metadata to add lib dirs extra_sys_path for pylint
+from environ import get_environ  # pylint: disable=E0401
 from st2common.runners.base_action import Action
 
 

--- a/contrib/hello_st2/BUILD
+++ b/contrib/hello_st2/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/linux/BUILD
+++ b/contrib/linux/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/contrib/packs/BUILD
+++ b/contrib/packs/BUILD
@@ -1,3 +1,5 @@
+__defaults__(all=dict(inject_pack_python_path=True))
+
 pack_metadata(
     name="metadata",
 )

--- a/pants-plugins/pack_metadata/python_rules/BUILD
+++ b/pants-plugins/pack_metadata/python_rules/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/pants-plugins/pack_metadata/python_rules/BUILD
+++ b/pants-plugins/pack_metadata/python_rules/BUILD
@@ -1,1 +1,5 @@
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/pants-plugins/pack_metadata/python_rules/BUILD
+++ b/pants-plugins/pack_metadata/python_rules/BUILD
@@ -3,3 +3,7 @@ python_sources()
 python_tests(
     name="tests",
 )
+
+python_test_utils(
+    name="test_utils",
+)

--- a/pants-plugins/pack_metadata/python_rules/conftest.py
+++ b/pants-plugins/pack_metadata/python_rules/conftest.py
@@ -1,0 +1,282 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+import pytest
+from pants.backend.python.dependency_inference.module_mapper import (
+    FirstPartyPythonMappingImpl,
+)
+from pants.backend.python.goals.pytest_runner import PytestPluginSetup
+from pants.backend.python.target_types import (
+    PythonSourceTarget,
+    PythonSourcesGeneratorTarget,
+    PythonTestTarget,
+    PythonTestsGeneratorTarget,
+)
+from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.engine.rules import QueryRule
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import RuleRunner
+
+from pack_metadata.python_rules import (
+    python_module_mapper,
+    python_pack_content,
+    python_path_rules,
+)
+from pack_metadata.python_rules.python_module_mapper import (
+    St2PythonPackContentMappingMarker,
+)
+from pack_metadata.python_rules.python_pack_content import (
+    PackContentPythonEntryPoints,
+    PackContentPythonEntryPointsRequest,
+    PackContentResourceTargetsOfType,
+    PackContentResourceTargetsOfTypeRequest,
+    PackPythonLibs,
+    PackPythonLibsRequest,
+)
+from pack_metadata.python_rules.python_path_rules import (
+    PackPythonPath,
+    PackPythonPathRequest,
+    PytestPackTestRequest,
+)
+from pack_metadata.target_types import (
+    InjectPackPythonPathField,
+    PackContentResourceTarget,
+    PackMetadata,
+)
+
+# some random pack names
+packs = (
+    "foo",  # imports between actions
+    "dr_seuss",  # imports from <pack>/actions/lib
+    "shards",  # imports from <pack>/lib
+    "metals",  # imports the action from a subdirectory
+)
+
+
+@pytest.fixture
+def pack_names() -> tuple[str, ...]:
+    return packs
+
+
+def write_test_files(rule_runner: RuleRunner):
+    for pack in packs:
+        rule_runner.write_files(
+            {
+                f"packs/{pack}/BUILD": dedent(
+                    """
+                    __defaults__(all=dict(inject_pack_python_path=True))
+                    pack_metadata(name="metadata")
+                    """
+                ),
+                f"packs/{pack}/pack.yaml": dedent(
+                    f"""
+                    ---
+                    name: {pack}
+                    version: 1.0.0
+                    author: StackStorm
+                    email: info@stackstorm.com
+                    """
+                ),
+                f"packs/{pack}/config.schema.yaml": "",
+                f"packs/{pack}/{pack}.yaml.example": "",
+                f"packs/{pack}/icon.png": "",
+                f"packs/{pack}/README.md": f"# Pack {pack} README",
+            }
+        )
+
+    def action_metadata_file(action: str, entry_point: str = "") -> str:
+        entry_point = entry_point or f"{action}.py"
+        return dedent(
+            f"""
+            ---
+            name: {action}
+            runner_type: python-script
+            entry_point: {entry_point}
+            """
+        )
+
+    def test_file(module: str, _object: str) -> str:
+        return dedent(
+            f"""
+            from {module} import {_object}
+            def test_{module.replace(".", "_")}() -> None:
+                pass
+            """
+        )
+
+    rule_runner.write_files(
+        {
+            "packs/foo/actions/BUILD": "python_sources()",
+            "packs/foo/actions/get_bar.yaml": action_metadata_file("get_bar"),
+            "packs/foo/actions/get_bar.py": dedent(
+                """
+                RESPONSE_CONSTANT = "foobar_key"
+                class BarAction:
+                    def run(self):
+                        return {RESPONSE_CONSTANT: "bar"}
+                """
+            ),
+            "packs/foo/actions/get_baz.yaml": action_metadata_file("get_baz"),
+            "packs/foo/actions/get_baz.py": dedent(
+                """
+                from get_bar import RESPONSE_CONSTANT
+                class BazAction:
+                    def run(self):
+                        return {RESPONSE_CONSTANT: "baz"}
+                """
+            ),
+            "packs/foo/tests/BUILD": "python_tests()",
+            "packs/foo/tests/test_get_bar_action.py": test_file("get_bar", "BarAction"),
+            "packs/foo/tests/test_get_baz_action.py": test_file("get_baz", "BazAction"),
+            "packs/dr_seuss/actions/lib/BUILD": "python_sources()",
+            "packs/dr_seuss/actions/lib/seuss/__init__.py": "",
+            "packs/dr_seuss/actions/lib/seuss/things.py": dedent(
+                """
+                THING1 = "thing one"
+                THING2 = "thing two"
+                """
+            ),
+            "packs/dr_seuss/actions/BUILD": "python_sources()",
+            "packs/dr_seuss/actions/get_from_actions_lib.yaml": action_metadata_file(
+                "get_from_actions_lib"
+            ),
+            "packs/dr_seuss/actions/get_from_actions_lib.py": dedent(
+                """
+                from seuss.things import THING1, THING2
+                class GetFromActionsLibAction:
+                    def run(self):
+                        return {"things": (THING1, THING2)}
+                """
+            ),
+            "packs/dr_seuss/tests/BUILD": "python_tests()",
+            "packs/dr_seuss/tests/test_get_from_actions_lib_action.py": test_file(
+                "get_from_actions_lib", "GetFromActionsLibAction"
+            ),
+            "packs/shards/lib/stormlight_archive/BUILD": "python_sources()",
+            "packs/shards/lib/stormlight_archive/__init__.py": "",
+            "packs/shards/lib/stormlight_archive/things.py": dedent(
+                """
+                STORM_LIGHT = "Honor"
+                VOID_LIGHT = "Odium"
+                LIFE_LIGHT = "Cultivation"
+                """
+            ),
+            "packs/shards/actions/BUILD": "python_sources()",
+            "packs/shards/actions/get_from_pack_lib.yaml": action_metadata_file(
+                "get_from_pack_lib"
+            ),
+            "packs/shards/actions/get_from_pack_lib.py": dedent(
+                """
+                from stormlight_archive.things import STORM_LIGHT, VOID_LIGHT, LIFE_LIGHT
+                class GetFromPackLibAction:
+                    def run(self):
+                        return {"light_sources": (STORM_LIGHT, VOID_LIGHT, LIFE_LIGHT)}
+                """
+            ),
+            "packs/shards/sensors/BUILD": "python_sources()",
+            "packs/shards/sensors/horn_eater.yaml": dedent(
+                """
+                ---
+                name: horn_eater
+                entry_point: horn_eater.py
+                class_name: HornEaterSensor
+                trigger_types: [{name: horn_eater.saw.spren, payload_schema: {type: object}}]
+                """
+            ),
+            "packs/shards/sensors/horn_eater.py": dedent(
+                """
+                from st2reactor.sensor.base import PollingSensor
+                from stormlight_archive.things import STORM_LIGHT
+                class HornEaterSensor(PollingSensor):
+                    def setup(self): pass
+                    def poll(self):
+                        if STORM_LIGHT in self.config:
+                            self.sensor_service.dispatch(
+                                trigger="horn_eater.saw.spren", payload={"spren_type": STORM_LIGHT}
+                            )
+                    def cleanup(self): pass
+                    def add_trigger(self): pass
+                    def update_trigger(self): pass
+                    def remove_trigger(self): pass
+                """
+            ),
+            "packs/shards/tests/BUILD": "python_tests()",
+            "packs/shards/tests/test_get_from_pack_lib_action.py": test_file(
+                "get_from_pack_lib", "GetFromPackLibAction"
+            ),
+            "packs/shards/tests/test_horn_eater_sensor.py": test_file(
+                "horn_eater", "HornEaterSensor"
+            ),
+            "packs/metals/actions/fly.yaml": action_metadata_file(
+                "fly", "mist_born/fly.py"
+            ),
+            "packs/metals/actions/mist_born/BUILD": "python_sources()",
+            "packs/metals/actions/mist_born/__init__.py": "",
+            "packs/metals/actions/mist_born/fly.py": dedent(
+                """
+                class FlyAction:
+                    def run(self):
+                        return {"metals": ("steel", "iron")}
+                """
+            ),
+            "packs/metals/tests/BUILD": "python_tests()",
+            "packs/metals/tests/test_fly_action.py": test_file(
+                "mist_born.fly", "FlyAction"
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = PythonRuleRunner(
+        rules=[
+            PythonTestsGeneratorTarget.register_plugin_field(
+                InjectPackPythonPathField, as_moved_field=True
+            ),
+            PythonTestTarget.register_plugin_field(InjectPackPythonPathField),
+            *python_target_types_rules(),
+            # TODO: not sure if we need a QueryRule for every rule...
+            *python_pack_content.rules(),
+            QueryRule(
+                PackContentResourceTargetsOfType,
+                (PackContentResourceTargetsOfTypeRequest,),
+            ),
+            QueryRule(
+                PackContentPythonEntryPoints, (PackContentPythonEntryPointsRequest,)
+            ),
+            QueryRule(PackPythonLibs, (PackPythonLibsRequest,)),
+            *python_module_mapper.rules(),
+            QueryRule(
+                FirstPartyPythonMappingImpl, (St2PythonPackContentMappingMarker,)
+            ),
+            *python_path_rules.rules(),
+            QueryRule(PackPythonPath, (PackPythonPathRequest,)),
+            QueryRule(PytestPluginSetup, (PytestPackTestRequest,)),
+        ],
+        target_types=[
+            PackContentResourceTarget,
+            PackMetadata,
+            PythonSourceTarget,
+            PythonSourcesGeneratorTarget,
+            PythonTestTarget,
+            PythonTestsGeneratorTarget,
+        ],
+    )
+    write_test_files(rule_runner)
+    args = ["--source-root-patterns=packs/*"]
+    rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    return rule_runner

--- a/pants-plugins/pack_metadata/python_rules/conftest.py
+++ b/pants-plugins/pack_metadata/python_rules/conftest.py
@@ -91,7 +91,7 @@ def write_test_files(rule_runner: RuleRunner):
                     """
                 ),
                 f"packs/{pack}/config.schema.yaml": "",
-                f"packs/{pack}/{pack}.yaml.example": "",
+                f"packs/{pack}/config.yaml.example": "",
                 f"packs/{pack}/icon.png": "",
                 f"packs/{pack}/README.md": f"# Pack {pack} README",
             }

--- a/pants-plugins/pack_metadata/python_rules/conftest.py
+++ b/pants-plugins/pack_metadata/python_rules/conftest.py
@@ -141,7 +141,7 @@ def write_test_files(rule_runner: RuleRunner):
             "packs/foo/tests/BUILD": "python_tests()",
             "packs/foo/tests/test_get_bar_action.py": test_file("get_bar", "BarAction"),
             "packs/foo/tests/test_get_baz_action.py": test_file("get_baz", "BazAction"),
-            "packs/dr_seuss/actions/lib/BUILD": "python_sources()",
+            "packs/dr_seuss/actions/lib/seuss/BUILD": "python_sources()",
             "packs/dr_seuss/actions/lib/seuss/__init__.py": "",
             "packs/dr_seuss/actions/lib/seuss/things.py": dedent(
                 """

--- a/pants-plugins/pack_metadata/python_rules/python_module_mapper.py
+++ b/pants-plugins/pack_metadata/python_rules/python_module_mapper.py
@@ -56,9 +56,10 @@ async def map_pack_content_to_python_modules(
     )
 
     for pack_content in pack_content_python_entry_points:
-        resolves_to_modules_to_providers[pack_content.resolve][
-            pack_content.module
-        ].append(ModuleProvider(pack_content.python_address, ModuleProviderType.IMPL))
+        for module in pack_content.get_possible_modules():
+            resolves_to_modules_to_providers[pack_content.resolve][module].append(
+                ModuleProvider(pack_content.python_address, ModuleProviderType.IMPL)
+            )
 
     for pack_lib in pack_python_libs:
         provider_type = (

--- a/pants-plugins/pack_metadata/python_rules/python_module_mapper.py
+++ b/pants-plugins/pack_metadata/python_rules/python_module_mapper.py
@@ -1,0 +1,70 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from typing import DefaultDict
+
+from pants.backend.python.dependency_inference.module_mapper import (
+    FirstPartyPythonMappingImpl,
+    FirstPartyPythonMappingImplMarker,
+    ModuleProvider,
+    ModuleProviderType,
+    ResolveName,
+)
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from pack_metadata.python_rules.python_pack_content import (
+    PackContentPythonEntryPoints,
+    PackContentPythonEntryPointsRequest,
+    PackPythonLibs,
+    PackPythonLibsRequest,
+)
+from pack_metadata.target_types import PackMetadata
+
+
+# This is only used to register our implementation with the plugin hook via unions.
+class St2PythonPackContentMappingMarker(FirstPartyPythonMappingImplMarker):
+    pass
+
+
+@rule(
+    desc=f"Creating map of `{PackMetadata.alias}` targets to Python modules in pack content",
+    level=LogLevel.DEBUG,
+)
+async def map_pack_content_to_python_modules(
+    _: St2PythonPackContentMappingMarker,
+) -> FirstPartyPythonMappingImpl:
+    resolves_to_modules_to_providers: DefaultDict[
+        ResolveName, DefaultDict[str, list[ModuleProvider]]
+    ] = defaultdict(lambda: defaultdict(list))
+
+    pack_content_python_entry_points = await Get(
+        PackContentPythonEntryPoints,
+        PackContentPythonEntryPointsRequest(),
+    )
+
+    for pack_content in pack_content_python_entry_points:
+        resolves_to_modules_to_providers[pack_content.resolve][
+            pack_content.module
+        ].append(ModuleProvider(pack_content.python_address, ModuleProviderType.IMPL))
+
+    return FirstPartyPythonMappingImpl.create(resolves_to_modules_to_providers)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(FirstPartyPythonMappingImplMarker, St2PythonPackContentMappingMarker),
+    )

--- a/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pants.testutil.rule_runner import RuleRunner
 
-def test_map_pack_content_to_python_modules() -> None:
+
+def test_map_pack_content_to_python_modules(rule_runner: RuleRunner) -> None:
     pass

--- a/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
@@ -12,8 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pants.backend.python.dependency_inference.module_mapper import (
+    FirstPartyPythonMappingImpl,
+    ModuleProvider,
+    ModuleProviderType,
+)
+from pants.engine.internals.native_engine import Address
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
+
+from pack_metadata.python_rules.python_module_mapper import (
+    St2PythonPackContentMappingMarker,
+)
 
 
 def test_map_pack_content_to_python_modules(rule_runner: RuleRunner) -> None:
-    pass
+    result = rule_runner.request(
+        FirstPartyPythonMappingImpl,
+        (St2PythonPackContentMappingMarker(),),
+    )
+
+    def module_provider(spec_path: str, relative_file_path: str) -> ModuleProvider:
+        return ModuleProvider(
+            Address(spec_path=spec_path, relative_file_path=relative_file_path),
+            ModuleProviderType.IMPL,
+        )
+
+    expected = {
+        "<ignore>": {
+            "get_bar": (module_provider("packs/foo/actions", "get_bar.py"),),
+            "get_baz": (module_provider("packs/foo/actions", "get_baz.py"),),
+            "seuss": (
+                module_provider("packs/dr_seuss/actions/lib/seuss", "__init__.py"),
+            ),
+            "seuss.things": (
+                module_provider("packs/dr_seuss/actions/lib/seuss", "things.py"),
+            ),
+            "get_from_actions_lib": (
+                module_provider("packs/dr_seuss/actions", "get_from_actions_lib.py"),
+            ),
+            "stormlight_archive": (
+                module_provider("packs/shards/lib/stormlight_archive", "__init__.py"),
+            ),
+            "stormlight_archive.things": (
+                module_provider("packs/shards/lib/stormlight_archive", "things.py"),
+            ),
+            "get_from_pack_lib": (
+                module_provider("packs/shards/actions", "get_from_pack_lib.py"),
+            ),
+            "horn_eater": (module_provider("packs/shards/sensors", "horn_eater.py"),),
+            "fly": (module_provider("packs/metals/actions/mist_born", "fly.py"),),
+            "mist_born.fly": (
+                module_provider("packs/metals/actions/mist_born", "fly.py"),
+            ),
+        }
+    }
+    assert isinstance(result, FrozenDict)
+    assert all(isinstance(value, FrozenDict) for value in result.values())
+    # pytest reports dict differences better than FrozenDict
+    assert {resolve: dict(value) for resolve, value in result.items()} == expected

--- a/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_module_mapper_test.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_map_pack_content_to_python_modules() -> None:
+    pass

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content.py
@@ -17,21 +17,26 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import DefaultDict
 
+from pants.backend.python.dependency_inference.module_mapper import (
+    module_from_stripped_path,
+)
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import PythonResolveField
+from pants.backend.python.target_types import PythonResolveField, PythonSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.base.specs import FileLiteralSpec, RawSpecs
+from pants.base.specs import FileLiteralSpec, RawSpecs, RecursiveGlobSpec
 from pants.engine.collection import Collection
 from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Address, Digest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
+    AllUnexpandedTargets,
     HydrateSourcesRequest,
     HydratedSources,
     Target,
     Targets,
 )
+from pants.util.dirutil import fast_relpath
 from pants.util.logging import LogLevel
 
 from pack_metadata.target_types import (
@@ -39,6 +44,7 @@ from pack_metadata.target_types import (
     PackContentResourceTypeField,
     PackContentResourceTypes,
     PackMetadata,
+    PackMetadataSourcesField,
 )
 
 
@@ -88,6 +94,8 @@ class PackContentPythonEntryPointsRequest:
 
 
 def get_possible_modules(path: PurePath) -> list[str]:
+    if path.name in ("__init__.py", "__init__.pyi"):
+        path = path.parent
     module = path.stem if path.suffix == ".py" else path.name
     modules = [module]
 
@@ -195,6 +203,96 @@ async def find_pack_content_python_entry_points(
                 )
 
     return PackContentPythonEntryPoints(pack_content_entry_points)
+
+
+@dataclass(frozen=True)
+class PackPythonLib:
+    pack_path: PurePath
+    lib_dir: str
+    relative_to_lib: PurePath
+    python_address: Address
+    resolve: str
+    module: str
+
+
+class PackPythonLibs(Collection[PackPythonLib]):
+    pass
+
+
+class PackPythonLibsRequest:
+    pass
+
+
+@rule(desc="Find all Pack lib directory python targets", level=LogLevel.DEBUG)
+async def find_python_in_pack_lib_directories(
+    python_setup: PythonSetup,
+    all_unexpanded_targets: AllUnexpandedTargets,
+    _: PackPythonLibsRequest,
+) -> PackPythonLibs:
+    pack_metadata_paths = [
+        PurePath(tgt.address.spec_path)
+        for tgt in all_unexpanded_targets
+        if tgt.has_field(PackMetadataSourcesField)
+    ]
+    pack_lib_directory_targets = await MultiGet(
+        Get(
+            Targets,
+            RawSpecs(
+                recursive_globs=(
+                    RecursiveGlobSpec(str(path / "lib")),
+                    RecursiveGlobSpec(str(path / "actions" / "lib")),
+                ),
+                unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
+                description_of_origin="pack_metadata lib directory lookup",
+            ),
+        )
+        for path in pack_metadata_paths
+    )
+
+    # Maybe this should use this to take codegen into account.
+    # Get(PythonSourceFiles, PythonSourceFilesRequest(targets=lib_directory_targets, include_resources=False)
+    # For now, just take the targets as they are.
+
+    pack_python_libs: list[PackPythonLib] = []
+
+    pack_path: PurePath
+    lib_directory_targets: Targets
+    for pack_path, lib_directory_targets in zip(
+        pack_metadata_paths, pack_lib_directory_targets
+    ):
+        for tgt in lib_directory_targets:
+            if not tgt.has_field(PythonSourceField):
+                # only python targets matter here.
+                continue
+
+            relative_to_pack = PurePath(
+                fast_relpath(tgt[PythonSourceField].file_path, str(pack_path))
+            )
+            if relative_to_pack.parts[0] == "lib":
+                lib_dir = "lib"
+            elif relative_to_pack.parts[:2] == ("actions", "lib"):
+                lib_dir = "actions/lib"
+            else:
+                # This should not happen as it is not in the requested glob.
+                # Use this to tell linters that lib_dir is defined below here.
+                continue
+            relative_to_lib = relative_to_pack.relative_to(lib_dir)
+
+            resolve = tgt[PythonResolveField].normalized_value(python_setup)
+            module = module_from_stripped_path(relative_to_lib)
+
+            pack_python_libs.append(
+                PackPythonLib(
+                    pack_path=pack_path,
+                    lib_dir=lib_dir,
+                    relative_to_lib=relative_to_lib,
+                    python_address=tgt.address,
+                    resolve=resolve,
+                    module=module,
+                )
+            )
+
+    return PackPythonLibs(pack_python_libs)
 
 
 def rules():

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content.py
@@ -1,0 +1,59 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    AllTargets,
+    Targets,
+)
+from pants.util.logging import LogLevel
+
+from pack_metadata.target_types import (
+    PackContentResourceSourceField,
+    PackContentResourceTypeField,
+    PackContentResourceTypes,
+    PackMetadata,
+)
+
+
+@dataclass(frozen=True)
+class PackContentResourceTargetsOfTypeRequest:
+    types: tuple[PackContentResourceTypes, ...]
+
+
+class PackContentResourceTargetsOfType(Targets):
+    pass
+
+
+@rule(
+    desc=f"Find all `{PackMetadata.alias}` targets in project filtered by content type",
+    level=LogLevel.DEBUG,
+)
+async def find_pack_metadata_targets_of_types(
+    request: PackContentResourceTargetsOfTypeRequest, targets: AllTargets
+) -> PackContentResourceTargetsOfType:
+    return PackContentResourceTargetsOfType(
+        tgt
+        for tgt in targets
+        if tgt.has_field(PackContentResourceSourceField)
+        and (
+            not request.types
+            or tgt[PackContentResourceTypeField].value in request.types
+        )
+    )
+
+
+def rules():
+    return (*collect_rules(),)

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content.py
@@ -151,6 +151,21 @@ class PackContentPythonEntryPoint:
 
         return tuple(modules)
 
+    def get_possible_paths(self) -> tuple[str, ...]:
+        """Get paths to add to PYTHONPATH and PEX_EXTRA_SYS_PATH. Mirrors get_possible_modules logic."""
+        path = self.python_file_path
+
+        # st2 adds the parent dir of the python file to sys.path at runtime.
+        paths = [path.parent.as_posix()]
+
+        # By convention, however, just actions/ is on sys.path during tests.
+        # so, also construct the module name from actions/ to support tests.
+        pack_content_dir, _ = self._split_pack_content_path(path)
+        if path.parent != pack_content_dir:
+            paths.append(pack_content_dir.as_posix())
+
+        return tuple(paths)
+
 
 class PackContentPythonEntryPoints(Collection[PackContentPythonEntryPoint]):
     pass
@@ -262,6 +277,10 @@ class PackPythonLib:
     @property
     def module(self) -> str:
         return module_from_stripped_path(self.relative_to_lib)
+
+    @property
+    def lib_path(self) -> PurePath:
+        return self.pack_path / self.lib_dir
 
 
 class PackPythonLibs(Collection[PackPythonLib]):

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content.py
@@ -11,11 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import yaml
+from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import PurePath
+from typing import DefaultDict
 
-from pants.engine.rules import collect_rules, rule
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PythonResolveField
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.base.specs import FileLiteralSpec, RawSpecs
+from pants.engine.collection import Collection
+from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Address, Digest
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
+    HydrateSourcesRequest,
+    HydratedSources,
+    Target,
     Targets,
 )
 from pants.util.logging import LogLevel
@@ -53,6 +67,134 @@ async def find_pack_metadata_targets_of_types(
             or tgt[PackContentResourceTypeField].value in request.types
         )
     )
+
+
+@dataclass(frozen=True)
+class PackContentPythonEntryPoint:
+    metadata_address: Address
+    content_type: PackContentResourceTypes
+    entry_point: str
+    python_address: Address
+    resolve: str
+    module: str
+
+
+class PackContentPythonEntryPoints(Collection[PackContentPythonEntryPoint]):
+    pass
+
+
+class PackContentPythonEntryPointsRequest:
+    pass
+
+
+def get_possible_modules(path: PurePath) -> list[str]:
+    module = path.stem if path.suffix == ".py" else path.name
+    modules = [module]
+
+    try:
+        start = path.parent.parts.index("actions") + 1
+    except ValueError:
+        start = path.parent.parts.index("sensors") + 1
+
+    # st2 adds the parent dir of the python file to sys.path at runtime.
+    # by convention, however, just actions/ is on sys.path during tests.
+    # so, also construct the module name from actions/ to support tests.
+    if start < len(path.parent.parts):
+        modules.append(".".join((*path.parent.parts[start:], module)))
+    return modules
+
+
+@rule(desc="Find all Pack Content entry_points that are python", level=LogLevel.DEBUG)
+async def find_pack_content_python_entry_points(
+    python_setup: PythonSetup, _: PackContentPythonEntryPointsRequest
+) -> PackContentPythonEntryPoints:
+    action_or_sensor = (
+        PackContentResourceTypes.action_metadata,
+        PackContentResourceTypes.sensor_metadata,
+    )
+
+    action_and_sensor_metadata_targets = await Get(
+        PackContentResourceTargetsOfType,
+        PackContentResourceTargetsOfTypeRequest(action_or_sensor),
+    )
+    action_and_sensor_metadata_sources = await MultiGet(
+        Get(HydratedSources, HydrateSourcesRequest(tgt[PackContentResourceSourceField]))
+        for tgt in action_and_sensor_metadata_targets
+    )
+    action_and_sensor_metadata_contents = await MultiGet(
+        Get(DigestContents, Digest, source.snapshot.digest)
+        for source in action_and_sensor_metadata_sources
+    )
+
+    # python file path -> list of info about metadata files that refer to it
+    pack_content_entry_points_by_spec: DefaultDict[
+        str, list[tuple[Address, PackContentResourceTypes, str]]
+    ] = defaultdict(list)
+
+    tgt: Target
+    contents: DigestContents
+    for tgt, contents in zip(
+        action_and_sensor_metadata_targets, action_and_sensor_metadata_contents
+    ):
+        content_type = tgt[PackContentResourceTypeField].value
+        if content_type not in action_or_sensor:
+            continue
+        assert len(contents) == 1
+        try:
+            metadata = yaml.safe_load(contents[0].content) or {}
+        except yaml.YAMLError:
+            continue
+        if content_type == PackContentResourceTypes.action_metadata:
+            runner_type = metadata.get("runner_type", "") or ""
+            if runner_type != "python-script":
+                # only python-script has special PYTHONPATH rules
+                continue
+        # get the entry_point to find subdirectory that contains the module
+        entry_point = metadata.get("entry_point", "") or ""
+        if entry_point:
+            # address.filename is basically f"{spec_path}/{relative_file_path}"
+            path = PurePath(tgt.address.filename).parent / entry_point
+            pack_content_entry_points_by_spec[str(path)].append(
+                (tgt.address, content_type, entry_point)
+            )
+
+    python_targets = await Get(
+        Targets,
+        RawSpecs(
+            file_literals=tuple(
+                FileLiteralSpec(spec_path)
+                for spec_path in pack_content_entry_points_by_spec
+            ),
+            unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
+            description_of_origin="pack_metadata python module mapper",
+        ),
+    )
+
+    pack_content_entry_points: list[PackContentPythonEntryPoint] = []
+    for tgt in python_targets:
+        if not tgt.has_field(PythonResolveField):
+            # this is unexpected
+            continue
+        for (
+            metadata_address,
+            content_type,
+            entry_point,
+        ) in pack_content_entry_points_by_spec[tgt.address.filename]:
+            resolve = tgt[PythonResolveField].normalized_value(python_setup)
+
+            for module in get_possible_modules(PurePath(tgt.address.filename)):
+                pack_content_entry_points.append(
+                    PackContentPythonEntryPoint(
+                        metadata_address=metadata_address,
+                        content_type=content_type,
+                        entry_point=entry_point,
+                        python_address=tgt.address,
+                        resolve=resolve,
+                        module=module,
+                    )
+                )
+
+    return PackContentPythonEntryPoints(pack_content_entry_points)
 
 
 def rules():

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
@@ -12,11 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from pants.testutil.rule_runner import RuleRunner
 
+from pack_metadata.python_rules.python_pack_content import (
+    PackContentResourceTargetsOfType,
+    PackContentResourceTargetsOfTypeRequest,
+)
+from pack_metadata.target_types import PackContentResourceTypes
 
-def test_find_pack_metadata_targets_of_types(rule_runner: RuleRunner) -> None:
-    pass
+
+@pytest.mark.parametrize(
+    "requested_types,expected_count,expected_file_name",
+    (
+        # one content type
+        ((PackContentResourceTypes.pack_metadata,), 4, "pack.yaml"),
+        ((PackContentResourceTypes.pack_config_schema,), 4, "config.schema.yaml"),
+        ((PackContentResourceTypes.pack_config_example,), 4, "config.yaml.example"),
+        ((PackContentResourceTypes.pack_icon,), 4, "icon.png"),
+        ((PackContentResourceTypes.action_metadata,), 5, ".yaml"),
+        ((PackContentResourceTypes.sensor_metadata,), 1, ".yaml"),
+        ((PackContentResourceTypes.rule_metadata,), 0, ""),
+        ((PackContentResourceTypes.policy_metadata,), 0, ""),
+        ((PackContentResourceTypes.unknown,), 0, ""),
+        # all content types
+        ((), 22, ""),
+        # some content types
+        (
+            (
+                PackContentResourceTypes.action_metadata,
+                PackContentResourceTypes.sensor_metadata,
+            ),
+            6,
+            "",
+        ),
+        (
+            (
+                PackContentResourceTypes.pack_metadata,
+                PackContentResourceTypes.pack_config_schema,
+                PackContentResourceTypes.pack_config_example,
+            ),
+            12,
+            "",
+        ),
+    ),
+)
+def test_find_pack_metadata_targets_of_types(
+    rule_runner: RuleRunner,
+    requested_types: tuple[PackContentResourceTypes, ...],
+    expected_count: int,
+    expected_file_name: str,
+) -> None:
+    result = rule_runner.request(
+        PackContentResourceTargetsOfType,
+        (PackContentResourceTargetsOfTypeRequest(requested_types),),
+    )
+    assert len(result) == expected_count
+    if expected_file_name:
+        for tgt in result:
+            tgt.address.relative_file_path.endswith(expected_file_name)
 
 
 def test_find_pack_content_python_entry_points(rule_runner: RuleRunner) -> None:

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pants.testutil.rule_runner import RuleRunner
 
-def test_find_pack_metadata_targets_of_types() -> None:
+
+def test_find_pack_metadata_targets_of_types(rule_runner: RuleRunner) -> None:
     pass
 
 
-def test_find_pack_content_python_entry_points() -> None:
+def test_find_pack_content_python_entry_points(rule_runner: RuleRunner) -> None:
     pass
 
 
-def test_find_python_in_pack_lib_directories() -> None:
+def test_find_python_in_pack_lib_directories(rule_runner: RuleRunner) -> None:
     pass

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_find_pack_metadata_targets_of_types() -> None:
+    pass
+
+
+def test_find_pack_content_python_entry_points() -> None:
+    pass
+
+
+def test_find_python_in_pack_lib_directories() -> None:
+    pass

--- a/pants-plugins/pack_metadata/python_rules/python_path_rules.py
+++ b/pants-plugins/pack_metadata/python_rules/python_path_rules.py
@@ -1,0 +1,131 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Set
+
+from pants.backend.python.goals.pytest_runner import (
+    PytestPluginSetupRequest,
+    PytestPluginSetup,
+)
+from pants.engine.internals.native_engine import Address
+from pants.engine.rules import collect_rules, Get, MultiGet, rule
+from pants.engine.target import Target, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+from pants.util.ordered_set import OrderedSet
+
+from pack_metadata.python_rules.python_pack_content import (
+    PackContentPythonEntryPoints,
+    PackContentPythonEntryPointsRequest,
+    PackPythonLibs,
+    PackPythonLibsRequest,
+)
+from pack_metadata.target_types import InjectPackPythonPathField
+
+
+@dataclass(frozen=True)
+class PackPythonPath:
+    entries: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PackPythonPathRequest:
+    address: Address
+
+
+@rule(
+    desc="Get pack paths that should be added to PYTHONPATH/PEX_EXTRA_SYS_PATH for a target.",
+    level=LogLevel.DEBUG,
+)
+async def get_extra_sys_path_for_pack_dependencies(
+    request: PackPythonPathRequest,
+) -> PackPythonPath:
+    transitive_targets = await Get(
+        TransitiveTargets, TransitiveTargetsRequest((request.address,))
+    )
+
+    dependency_addresses: Set[Address] = {
+        tgt.address for tgt in transitive_targets.closure
+    }
+    if not dependency_addresses:
+        return PackPythonPath()
+
+    pack_content_python_entry_points, pack_python_libs = await MultiGet(
+        Get(PackContentPythonEntryPoints, PackContentPythonEntryPointsRequest()),
+        Get(PackPythonLibs, PackPythonLibsRequest()),
+    )
+
+    # only use addresses of actual dependencies
+    pack_python_content_addresses: Set[Address] = dependency_addresses & {
+        pack_content.python_address for pack_content in pack_content_python_entry_points
+    }
+    pack_python_lib_addresses: Set[Address] = dependency_addresses & {
+        pack_lib.python_address for pack_lib in pack_python_libs
+    }
+
+    if not (pack_python_content_addresses or pack_python_lib_addresses):
+        return PackPythonPath()
+
+    # filter pack_content_python_entry_points and pack_python_libs
+    pack_content_python_entry_points = (
+        pack_content
+        for pack_content in pack_content_python_entry_points
+        if pack_content.python_address in pack_python_content_addresses
+    )
+    pack_python_libs = (
+        pack_lib
+        for pack_lib in pack_python_libs
+        if pack_lib.python_address in pack_python_lib_addresses
+    )
+
+    extra_sys_path_entries = OrderedSet()
+    for pack_content in pack_content_python_entry_points:
+        for path_entry in pack_content.get_possible_paths():
+            extra_sys_path_entries.add(path_entry)
+    for pack_lib in pack_python_libs:
+        extra_sys_path_entries.add(pack_lib.lib_path.as_posix())
+
+    return PackPythonPath(tuple(extra_sys_path_entries))
+
+
+class PytestPackTestRequest(PytestPluginSetupRequest):
+    @classmethod
+    def is_applicable(cls, target: Target) -> bool:
+        if not target.has_field(InjectPackPythonPathField):
+            return False
+        return bool(target.get(InjectPackPythonPathField).value)
+
+
+@rule(
+    desc="Inject pack paths in PYTHONPATH/PEX_EXTRA_SYS_PATH for python tests.",
+    level=LogLevel.DEBUG,
+)
+async def inject_extra_sys_path_for_pack_tests(
+    request: PytestPackTestRequest,
+) -> PytestPluginSetup:
+    pack_python_path = await Get(
+        PackPythonPath, PackPythonPathRequest(request.target.address)
+    )
+    return PytestPluginSetup(
+        # digest=EMPTY_DIGEST,
+        extra_sys_path=pack_python_path.entries,
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(PytestPluginSetupRequest, PytestPackTestRequest),
+    ]

--- a/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import pytest
-from pants.engine.internals.native_engine import Address
+from pants.backend.python.goals.pytest_runner import PytestPluginSetup
+from pants.engine.internals.native_engine import Address, EMPTY_DIGEST
 from pants.testutil.rule_runner import RuleRunner
 
 from pack_metadata.python_rules.python_path_rules import (
     PackPythonPath,
     PackPythonPathRequest,
+    PytestPackTestRequest,
 )
 
 
@@ -120,5 +122,48 @@ def test_get_extra_sys_path_for_pack_dependencies(
     assert pack_python_path.entries == expected
 
 
-def test_inject_extra_sys_path_for_pack_tests(rule_runner: RuleRunner) -> None:
-    pass
+@pytest.mark.xfail(raises=AttributeError, reason="Not implemented in pants yet.")
+@pytest.mark.parametrize(
+    "address,expected",
+    (
+        (
+            Address("packs/foo/tests", relative_file_path="test_get_bar_action.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address("packs/foo/tests", relative_file_path="test_get_baz_action.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address(
+                "packs/dr_seuss/tests",
+                relative_file_path="test_get_from_actions_lib_action.py",
+            ),
+            ("packs/dr_seuss/actions", "packs/dr_seuss/actions/lib"),
+        ),
+        (
+            Address(
+                "packs/shards/tests",
+                relative_file_path="test_get_from_pack_lib_action.py",
+            ),
+            ("packs/shards/actions", "packs/shards/lib"),
+        ),
+        (
+            Address(
+                "packs/shards/tests", relative_file_path="test_horn_eater_sensor.py"
+            ),
+            ("packs/shards/sensors", "packs/shards/lib"),
+        ),
+        (
+            Address("packs/metals/tests", relative_file_path="test_fly_action.py"),
+            ("packs/metals/actions/mist_born", "packs/metals/actions"),
+        ),
+    ),
+)
+def test_inject_extra_sys_path_for_pack_tests(
+    rule_runner: RuleRunner, address: Address, expected: tuple[str, ...]
+) -> None:
+    target = rule_runner.get_target(address)
+    result = rule_runner.request(PytestPluginSetup, (PytestPackTestRequest(target),))
+    assert result.digest == EMPTY_DIGEST
+    assert result.extra_sys_path == expected

--- a/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_get_extra_sys_path_for_pack_dependencies() -> None:
+    pass
+
+
+def test_inject_extra_sys_path_for_pack_tests() -> None:
+    pass

--- a/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
@@ -12,11 +12,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+from pants.engine.internals.native_engine import Address
 from pants.testutil.rule_runner import RuleRunner
 
+from pack_metadata.python_rules.python_path_rules import (
+    PackPythonPath,
+    PackPythonPathRequest,
+)
 
-def test_get_extra_sys_path_for_pack_dependencies(rule_runner: RuleRunner) -> None:
-    pass
+
+@pytest.mark.parametrize(
+    "address,expected",
+    (
+        (
+            Address("packs/foo/actions", relative_file_path="get_bar.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address("packs/foo/actions", relative_file_path="get_baz.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address("packs/foo/tests", relative_file_path="test_get_bar_action.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address("packs/foo/tests", relative_file_path="test_get_baz_action.py"),
+            ("packs/foo/actions",),
+        ),
+        (
+            Address(
+                "packs/dr_seuss/actions/lib/seuss", relative_file_path="__init__.py"
+            ),
+            ("packs/dr_seuss/actions/lib",),
+        ),
+        (
+            Address("packs/dr_seuss/actions/lib/seuss", relative_file_path="things.py"),
+            ("packs/dr_seuss/actions/lib",),
+        ),
+        (
+            Address(
+                "packs/dr_seuss/actions", relative_file_path="get_from_actions_lib.py"
+            ),
+            ("packs/dr_seuss/actions", "packs/dr_seuss/actions/lib"),
+        ),
+        (
+            Address(
+                "packs/dr_seuss/tests",
+                relative_file_path="test_get_from_actions_lib_action.py",
+            ),
+            ("packs/dr_seuss/actions", "packs/dr_seuss/actions/lib"),
+        ),
+        (
+            Address(
+                "packs/shards/lib/stormlight_archive", relative_file_path="__init__.py"
+            ),
+            ("packs/shards/lib",),
+        ),
+        (
+            Address(
+                "packs/shards/lib/stormlight_archive", relative_file_path="things.py"
+            ),
+            ("packs/shards/lib",),
+        ),
+        (
+            Address("packs/shards/actions", relative_file_path="get_from_pack_lib.py"),
+            ("packs/shards/actions", "packs/shards/lib"),
+        ),
+        (
+            Address("packs/shards/sensors", relative_file_path="horn_eater.py"),
+            ("packs/shards/sensors", "packs/shards/lib"),
+        ),
+        (
+            Address(
+                "packs/shards/tests",
+                relative_file_path="test_get_from_pack_lib_action.py",
+            ),
+            ("packs/shards/actions", "packs/shards/lib"),
+        ),
+        (
+            Address(
+                "packs/shards/tests", relative_file_path="test_horn_eater_sensor.py"
+            ),
+            ("packs/shards/sensors", "packs/shards/lib"),
+        ),
+        (
+            Address("packs/metals/actions/mist_born", relative_file_path="__init__.py"),
+            (),  # there are no dependencies, and this is not an action entry point.
+        ),
+        (
+            Address("packs/metals/actions/mist_born", relative_file_path="fly.py"),
+            ("packs/metals/actions/mist_born", "packs/metals/actions"),
+        ),
+        (
+            Address("packs/metals/tests", relative_file_path="test_fly_action.py"),
+            ("packs/metals/actions/mist_born", "packs/metals/actions"),
+        ),
+    ),
+)
+def test_get_extra_sys_path_for_pack_dependencies(
+    rule_runner: RuleRunner, address: Address, expected: tuple[str, ...]
+) -> None:
+    pack_python_path = rule_runner.request(
+        PackPythonPath, (PackPythonPathRequest(address),)
+    )
+    assert pack_python_path.entries == expected
 
 
 def test_inject_extra_sys_path_for_pack_tests(rule_runner: RuleRunner) -> None:

--- a/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_path_rules_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pants.testutil.rule_runner import RuleRunner
 
-def test_get_extra_sys_path_for_pack_dependencies() -> None:
+
+def test_get_extra_sys_path_for_pack_dependencies(rule_runner: RuleRunner) -> None:
     pass
 
 
-def test_inject_extra_sys_path_for_pack_tests() -> None:
+def test_inject_extra_sys_path_for_pack_tests(rule_runner: RuleRunner) -> None:
     pass

--- a/pants-plugins/pack_metadata/register.py
+++ b/pants-plugins/pack_metadata/register.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from pack_metadata import tailor, target_types_rules
+from pack_metadata.python_rules import python_pack_content
 from pack_metadata.target_types import (
     PackContentResourceTarget,
     PackMetadata,
@@ -24,6 +26,7 @@ def rules():
     return [
         *tailor.rules(),
         *target_types_rules.rules(),
+        *python_pack_content.rules(),
     ]
 
 

--- a/pants-plugins/pack_metadata/register.py
+++ b/pants-plugins/pack_metadata/register.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from pack_metadata import tailor, target_types_rules
-from pack_metadata.python_rules import python_pack_content
+from pack_metadata.python_rules import (
+    python_module_mapper,
+    python_pack_content,
+)
 from pack_metadata.target_types import (
     PackContentResourceTarget,
     PackMetadata,
@@ -27,6 +30,7 @@ def rules():
         *tailor.rules(),
         *target_types_rules.rules(),
         *python_pack_content.rules(),
+        *python_module_mapper.rules(),
     ]
 
 

--- a/pants-plugins/pack_metadata/register.py
+++ b/pants-plugins/pack_metadata/register.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pants.backend.python.target_types import (
+    PythonTestTarget,
+    PythonTestsGeneratorTarget,
+)
+
 from pack_metadata import tailor, target_types_rules
 from pack_metadata.python_rules import (
     python_module_mapper,
     python_pack_content,
+    python_path_rules,
 )
 from pack_metadata.target_types import (
+    InjectPackPythonPathField,
     PackContentResourceTarget,
     PackMetadata,
     PackMetadataInGitSubmodule,
@@ -27,10 +34,15 @@ from pack_metadata.target_types import (
 
 def rules():
     return [
+        PythonTestsGeneratorTarget.register_plugin_field(
+            InjectPackPythonPathField, as_moved_field=True
+        ),
+        PythonTestTarget.register_plugin_field(InjectPackPythonPathField),
         *tailor.rules(),
         *target_types_rules.rules(),
         *python_pack_content.rules(),
         *python_module_mapper.rules(),
+        *python_path_rules.rules(),
     ]
 
 

--- a/pants-plugins/pack_metadata/register.py
+++ b/pants-plugins/pack_metadata/register.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from pack_metadata import tailor, target_types_rules
 from pack_metadata.target_types import (
+    PackContentResourceTarget,
     PackMetadata,
     PackMetadataInGitSubmodule,
     PacksGlob,
@@ -28,6 +29,7 @@ def rules():
 
 def target_types():
     return [
+        PackContentResourceTarget,
         PackMetadata,
         PackMetadataInGitSubmodule,
         PacksGlob,

--- a/pants-plugins/pack_metadata/target_types.py
+++ b/pants-plugins/pack_metadata/target_types.py
@@ -16,7 +16,12 @@ from pathlib import PurePath
 from typing import Optional, Sequence, Tuple
 
 from pants.engine.internals.native_engine import Address
-from pants.engine.target import COMMON_TARGET_FIELDS, Dependencies, StringField
+from pants.engine.target import (
+    BoolField,
+    COMMON_TARGET_FIELDS,
+    Dependencies,
+    StringField,
+)
 from pants.core.target_types import (
     ResourceDependenciesField,
     ResourcesGeneratingSourcesField,
@@ -193,3 +198,14 @@ class PacksGlob(GenericTarget):
         "subdirectories (packs) except those listed with ! in dependencies. "
         "This is unfortunately needed by tests that use a glob to load pack fixtures."
     )
+
+
+class InjectPackPythonPathField(BoolField):
+    alias = "inject_pack_python_path"
+    help = (
+        "For pack tests, set this to true to make sure <pack>/lib or actions/ dirs get "
+        "added to PYTHONPATH (actually PEX_EXTRA_SYS_PATH). Use `__defaults__` to enable "
+        "this in the BUILD file where you define pack_metadata, like this: "
+        "`__defaults__(all=dict(inject_pack_python_path=True))`"
+    )
+    default = False

--- a/pants-plugins/pack_metadata/target_types.py
+++ b/pants-plugins/pack_metadata/target_types.py
@@ -86,17 +86,21 @@ class PackContentResourceTypeField(StringField):
         if value is not None:
             return PackContentResourceTypes(value)
         path = PurePath(address.relative_file_path)
-        _yaml_suffixes = ("yaml", "yml")
+        _yaml_suffixes = (".yaml", ".yml")
         if len(path.parent.parts) == 0:
             # in the pack root
-            if path.name == "pack.yaml":
+            if path.stem == "pack" and path.suffix in _yaml_suffixes:
                 return PackContentResourceTypes.pack_metadata
-            if path.stem == "pack.schema" and path.suffix in _yaml_suffixes:
+            if path.stem == "config.schema" and path.suffix in _yaml_suffixes:
                 return PackContentResourceTypes.pack_config_schema
-            if path.suffix == "example" and path.suffixes[0] in _yaml_suffixes:
+            if (
+                path.stem.startswith("config.")
+                and path.suffixes[0] in _yaml_suffixes
+                and path.suffix == ".example"
+            ):
                 return PackContentResourceTypes.pack_config_example
             if path.name == "icon.png":
-                return PackContentResourceTypes.pack_config_example
+                return PackContentResourceTypes.pack_icon
             return PackContentResourceTypes.unknown
         resource_type = _content_type_by_path_parts.get(path.parent.parts, None)
         if resource_type is not None:

--- a/pants-plugins/uses_services/register.py
+++ b/pants-plugins/uses_services/register.py
@@ -28,7 +28,9 @@ from uses_services.target_types import UsesServicesField
 
 def rules():
     return [
-        PythonTestsGeneratorTarget.register_plugin_field(UsesServicesField),
+        PythonTestsGeneratorTarget.register_plugin_field(
+            UsesServicesField, as_moved_field=True
+        ),
         PythonTestTarget.register_plugin_field(UsesServicesField),
         *platform_rules.rules(),
         *mongo_rules.rules(),

--- a/pants.toml
+++ b/pants.toml
@@ -90,9 +90,6 @@ root_patterns = [
   "/contrib/packs",
   "/st2tests/testpacks/checks",
   "/st2tests/testpacks/errorcheck",
-  # pack common lib directories that ST2 adds to the PATH for actions/sensors
-  "/contrib/*/lib",
-  "/contrib/*/actions/lib",
   # other special-cased pack directories
   "/contrib/examples/actions/ubuntu_pkg_info", # python script runs via shell expecting cwd in PYTHONPATH
   # lint plugins


### PR DESCRIPTION
This PR has commits extracted from #6202 where I'm working on getting all of our unit tests to run under pants+pytest.

It is best to review each commit of this PR to make the review manageable (I rewrote history to simplify reviews). If this PR is still too large to review, I can try to split it into multiple PRs.

## Overview

This has pants+pytest run pack tests directly instead of using `st2-run-pack-tests`, which has some issues detailed below.

This enhances `pants-plugins/pack_metadata` (introduced in #5868) so that it can inject the custom `PYTHONPATH` entries that StackStorm adds when running python in packs like actions and sensors. We have several special lib directories to support:
- `<pack>/lib` is the shared lib dir that gets added for both actions and sensors when `[packs].enable_common_libs = True` in `st2.conf`.
- `<pack>/actions/lib` for actions (allowing `import foo` to import `<pack>/actions/lib/foo.py` in an action)
- The `entry_point` parent directory for sensors and actions

That last point is actually not handled correctly in `st2-run-pack-tests` which only adds `<pack>/actions/` and `<pack>/sensors/` to PYTHONPATH, which assumes that the python file is directly in those directories. The python files can, however be in a sub directory, and that sub directory gets added to PYTHONPATH. So, this `pants-plugins/pack_metadata` enhancement allows pants to accurately reflect the logic st2 actually uses. 

Another reason that this does not use `st2-run-pack-tests`, is that it obscures the `PYTHONPATH` logic that pants needs to carefully manage. Pants uses PEX to make sure that tests are run in a hermetic sandbox that cannot be influenced by things like packages installed with `pip install --user`. So, the python dependencies detected by this plugin actually get passed as `PEX_EXTRA_SYS_PATH` not `PYTHONPATH` which is ignored when running python hermetically. 

Eventually, I would like to publish `pants-plugins/pack_metadata` so it can be used in pack repos to run tests with pants+pytest instead of `st2-run-pack-tests`.

## Plugin components

### Developing pants plugins

Pants has extensive documentation on the plugin API, including how to create targets, and how to write rules. Some of the plugin APIs I'm using in this PR are not documented, but these still give the general overview of the rule+target mechanisms used.

- [Plugins overview](https://www.pantsbuild.org/2.23/docs/writing-plugins/overview)
- [The Target API](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-target-api)
    - [Concepts](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-target-api/concepts) _eg: defines targets and fields._
    - [Creating new fields](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-target-api/creating-new-fields)
    - [Creating new targets](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-target-api/creating-new-targets)
- [The Rules API](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-rules-api)
- [Testing Plugins](https://www.pantsbuild.org/2.23/docs/writing-plugins/the-rules-api/testing-plugins)

### Targets and Target Fields

#### `pack_metadata` and `pack_content_resource` Targets and their Fields

The `pack_metadata` target was introduced in #5868, and it was added to BUILD files in #5871. For example, this is the `pack_metadata` target for the `linux` pack:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/contrib/linux/BUILD#L3-L5

Creating this doesn't require manual intervention. If a new pack is added, CI will prompt you to run `pants tailor ::` which generates this target (see #5871). One of my goals with this PR is to preserve this low-maintenance aspect while introducing the features we need.

So, what does the `pack_metadata` target do? It is basically a [`resources`](https://www.pantsbuild.org/2.23/reference/targets/resources) target that generates a [`resource`](https://www.pantsbuild.org/2.23/reference/targets/resource) target for each of the yaml files in the pack: pack.yaml, action metadata, sensor metadata, rules, etc. This is similar to the [`python_sources`](https://www.pantsbuild.org/2.23/reference/targets/python_sources) target which generates a [`python_source`](https://www.pantsbuild.org/2.23/reference/targets/python_source) target for each python file.

In order to calculate the PYTHONPATH entries for python actions and sensors, the plugin has to extract the `entry_point` from the individual metadata files. But, the `pack_metadata` target generated generic `resource` targets that didn't make it easy to distinguish action metadata from `pack.yaml` and other files. So, this PR changes `pack_metadata` so it generates a `pack_content_resource` target for each file instead of just using the generic `resource` target. _Note that the `pack_content_resource` target should not actually show up in any BUILD files. It should only be generated by `pack_metadata`._

This is where the `pack_metadata` target says which target should be generated for each file: 

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L167

This PR adds the `pack_content_resource` target here:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L148-L156

It has the same fields as `resource` target with a couple additions. It extends `ResourceTarget` so that anything that needs a generic resource can still get the file. Part of that is extending the `ResourceSourceField` because targets are often identified by the their fields not by the target itself.

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L111-L112

The other new field is `type`, defined here. The possible values are defined in `PackContentResourceTypes` which is an enum. In nearly all cases, the BUILD files will not have an explicit type for any of these targets, so the `compute_value` method will get `raw_value=None`. It then uses a map to calculate the actual value for `type` based on the file's path (in `address`).

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L71-L84

If a pack has files that do not follow conventions, this PR adds an escape hatch for overriding the calculated type. The `pack_metadata` target now has the `ResourcesOverridesField` to provide this escape hatch. It would be used like this: 

```python
pack_metadata(
    name="metadata",
    overrides={
        "actions/workflows/some-action-chain.yaml": dict(
            type="action_chain_workflow",  # default is orquesta_workflow
        ),
    },
)
```

The conventions for types of metadata files in subdirectories are defined here: 

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L59-L68

If a file doesn't follow any of the conventions, it gets `type="unknown"`, which can be overridden with the overrides field (shown above).

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L108

None of the packs in the st2 repo break with convention, except for maybe some insignificant things in fixture packs. So, I didn't have to add any `overrides` to get pack and unit tests passing.

#### New Field: `python_tests(inject_pack_python_path=...)`

This PR also has to provide a way for `python_tests` targets to opt-in to the PYTHONPATH manipulation. For example, the `linux` pack's BUILD file uses `__defaults__` to enable this for all tests in the pack: 

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/contrib/linux/BUILD#L1

I added this by hand, instead of making `pants tailor ::` add it, because it's not needed for fixture packs. So, I added it only for the main packs that might actually get installed.

This new field is added to `python_tests` and `python_test` targets here:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/register.py#L37-L40

And the field is defined as a simple Boolean field here:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/target_types.py#L207-L215

### Rules

This PR adds the actual PYTHONPATH manipulation logic in 3 sets of rules, with each set in a different file:

- `pack_metadata/python_rules/python_pack_content.py`
- `pack_metadata/python_rules/python_module_mapper.py`
- `pack_metadata/python_rules/python_path_rules.py`

_Note: This PR also adds tests for each of these rules._

I added a long comment that provides an overview of the implementation and how these rules work together:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_pack_content.py#L51-L86

#### `python_pack_content`

The rules in this file are responsible for finding pack content using StackStorm's conventions. Any rules that need to extract something pack metadata files should be in this file (like the rule that extracts `entry_point` from action and sensor metadata files).

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_pack_content.py#L98-L104

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_pack_content.py#L178-L181

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_pack_content.py#L294-L299

#### `python_module_mapper`

This file has a rule to inject StackStorm's custom python module lookup logic into the pants dependency inference, since the standard python import rules cannot identify pack python files. The dependency inference logic influences which files are considered dependencies of other files, and therefore which files need to be in the sandbox when running pytest and other tools on that file.

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_module_mapper.py#L42-L48

#### `python_path_rules`

This file has rules to calculate StackStorm's custom pack PYTHONPATH and then inject that (as PEX_EXTRA_SYS_PATH) when pants runs pytest.

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_path_rules.py#L48-L54

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/pants-plugins/pack_metadata/python_rules/python_path_rules.py#L111-L117

Eventually, I hope to add this PYTHONPATH manipulation for pylint as well (and possibly other utils python runs), but that will require changing pants itself to support that. Since this only affected one file (a file we don't even lint in the soon-to-be-legacy Makefile), I just skipped the pylint error:

https://github.com/StackStorm/st2/blob/b3d8c4c0dd442257fd12622538cb1cb45bed09eb/contrib/examples/actions/pythonactions/isprime.py#L18-L19