### PR TITLE
added no-store header to st2 nginx configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Fixed
 * Fix Popen.pid typo in st2tests. #6184
 * Bump tooz package to `6.2.0` to fix TLS. #6220 (@jk464)
 * Shells via `pywinrm` are initialized with the 65001 codepage to ensure raw string responses are UTF-8. #6034 (@stealthii)
+* Added no-store header for location / in nginx config to prevent web ui serving cached versions of opened flows. st2web#1030 (@fdrab)
 
 Changed
 ~~~~~~~

--- a/conf/nginx/st2.conf
+++ b/conf/nginx/st2.conf
@@ -157,6 +157,7 @@ server {
   }
 
   location / {
+    add_header             Cache-Control "no-store";
     max_ranges 0;
     root      /opt/stackstorm/static/webui/;
     index     index.html;


### PR DESCRIPTION
Added the no-store cache control header in order to prevent webui from serving cached and not up-to-date versions of opened workflows.