### PR TITLE
Pants: Add BUILD metadata for integration tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,7 +69,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259 #6260 #6269
+  #6254 #6258 #6259 #6260 #6269 #6275
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/local_runner/tests/integration/test_localrunner.py
+++ b/contrib/runners/local_runner/tests/integration/test_localrunner.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 import os
+import unittest
 import uuid
 
 import mock
@@ -44,6 +45,8 @@ from local_runner.local_shell_command_runner import LocalShellCommandRunner
 from local_runner.local_shell_script_runner import LocalShellScriptRunner
 
 __all__ = ["LocalShellCommandRunnerTestCase", "LocalShellScriptRunnerTestCase"]
+
+ST2_CI = os.environ.get("ST2_CI", "false").lower() == "true"
 
 MOCK_EXECUTION = mock.Mock()
 MOCK_EXECUTION.id = "598dbf0c0640fd54bffc688b"
@@ -94,6 +97,11 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(output_dbs[0].output_type, "stdout")
         self.assertEqual(output_dbs[0].data, "10\n")
 
+    # This test depends on passwordless sudo. Don't require that for local development.
+    @unittest.skipIf(
+        not ST2_CI,
+        'Skipping tests because ST2_CI environment variable is not set to "true"',
+    )
     def test_timeout(self):
         models = self.fixtures_loader.load_models(
             fixtures_pack=GENERIC_PACK, fixtures_dict={"actions": ["local.yaml"]}
@@ -141,8 +149,13 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
         self.assertEqual(status, action_constants.LIVEACTION_STATUS_SUCCEEDED)
         self.assertEqual(result["stdout"].strip(), "mock-token")
 
+    # This test depends on passwordless sudo. Don't require that for local development.
+    @unittest.skipIf(
+        not ST2_CI,
+        'Skipping tests because ST2_CI environment variable is not set to "true"',
+    )
     def test_sudo_and_env_variable_preservation(self):
-        # Verify that the environment environment are correctly preserved when running as a
+        # Verify that the environment vars are correctly preserved when running as a
         # root / non-system user
         # Note: This test will fail if SETENV option is not present in the sudoers file
         models = self.fixtures_loader.load_models(
@@ -297,6 +310,11 @@ class LocalShellCommandRunnerTestCase(RunnerTestCase, CleanDbTestCase):
             self.assertEqual(output_dbs[db_index_1].data, mock_stderr[0])
             self.assertEqual(output_dbs[db_index_2].data, mock_stderr[1])
 
+    # This test depends on passwordless sudo. Don't require that for local development.
+    @unittest.skipIf(
+        not ST2_CI,
+        'Skipping tests because ST2_CI environment variable is not set to "true"',
+    )
     def test_shell_command_sudo_password_is_passed_to_sudo_binary(self):
         # Verify that sudo password is correctly passed to sudo binary via stdin
         models = self.fixtures_loader.load_models(

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -5,5 +5,5 @@ __defaults__(
 
 python_tests(
     name="tests",
-    uses=["redis"],
+    uses=["mongo", "rabbitmq", "redis", "system_user"],
 )

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -11,6 +11,13 @@ remote_provider = "experimental-github-actions-cache"
 remote_cache_read = true
 remote_cache_write = true
 
+# https://www.pantsbuild.org/stable/reference/global-options#ignore_warnings
+ignore_warnings = [
+    # remote cache errors caused by GitHub rate-limits are not helpful
+    "Failed to read from remote cache",
+    "Failed to write to remote cache",
+]
+
 [stats]
 # "print metrics of your cache's performance at the end of the run,
 # including the number of cache hits and the total time saved thanks

--- a/pants.toml
+++ b/pants.toml
@@ -244,6 +244,8 @@ extra_env_vars = [
   "ST2TESTS_REDIS_HOST",
   "ST2TESTS_REDIS_PORT",
 ]
+# 10 min should be more than enough even for integration tests.
+timeout_default = 600 # seconds
 
 [twine]
 install_from_resolve = "twine"

--- a/st2actions/tests/integration/BUILD
+++ b/st2actions/tests/integration/BUILD
@@ -5,4 +5,8 @@ __defaults__(
 
 python_tests(
     name="tests",
+    uses=["rabbitmq"],
+    stevedore_namespaces=[
+        "st2common.metrics.driver",
+    ],
 )

--- a/st2api/tests/integration/BUILD
+++ b/st2api/tests/integration/BUILD
@@ -7,5 +7,13 @@ python_tests(
     name="tests",
     dependencies=[
         "conf/st2.tests.conf:st2_tests_conf",
+        "st2api/st2api/wsgi.py",
+        "st2auth/st2auth/wsgi.py",
     ],
+    stevedore_namespaces=[
+        "st2auth.sso.backends",
+        "st2common.metrics.driver",
+        "st2common.rbac.backend",
+    ],
+    uses=["mongo", "rabbitmq", "redis"],
 )

--- a/st2common/tests/fixtures/BUILD
+++ b/st2common/tests/fixtures/BUILD
@@ -1,5 +1,6 @@
 python_sources()
 
-shell_sources(
+st2_shell_sources_and_resources(
     name="shell",
+    sources=["*.sh"],
 )

--- a/st2common/tests/integration/BUILD
+++ b/st2common/tests/integration/BUILD
@@ -5,19 +5,46 @@ __defaults__(
 
 python_tests(
     name="tests",
-    dependencies=[
-        # used by test_register_content_script
-        "conf/st2.tests.conf:st2_tests_conf",
-        "conf/st2.tests1.conf:st2_tests_conf",
-    ],
     stevedore_namespaces=[
         "orquesta.expressions.functions",
         "st2common.runners.runner",
         "st2common.rbac.backend",
         "st2common.metrics.driver",
     ],
+    uses=["mongo", "rabbitmq", "redis"],
+    overrides={
+        "test_logging.py": dict(
+            dependencies=[
+                "./log_unicode_data.py",
+            ],
+        ),
+        "test_register_content_script.py": dict(
+            dependencies=[
+                "conf/st2.tests.conf:st2_tests_conf",
+                "conf/st2.tests1.conf:st2_tests_conf",
+                "st2common/bin/st2-register-content",
+            ],
+        ),
+        "test_service_setup_log_level_filtering.py": dict(
+            dependencies=[
+                "st2api/bin/st2api",
+            ],
+        ),
+        "test_util_green.py": dict(
+            dependencies=[
+                "st2common/tests/fixtures/print_to_stdout_stderr_sleep.sh:shell_resources",
+            ],
+        ),
+    },
 )
 
 python_test_utils(
     sources=["*.py", "!test_*.py"],
+    overrides={
+        "log_unicode_data.py": dict(
+            dependencies=[
+                "st2tests/st2tests/fixtures/conf:st2.tests.conf",
+            ],
+        ),
+    },
 )

--- a/st2reactor/tests/integration/BUILD
+++ b/st2reactor/tests/integration/BUILD
@@ -3,10 +3,50 @@ __defaults__(
     extend=True,
 )
 
+_conf_deps = [
+    "conf/st2.tests.conf:st2_tests_conf",
+    "conf/st2.tests2.conf:st2_tests_conf",
+]
+
 python_tests(
     name="tests",
-    dependencies=[
-        "conf/st2.tests.conf:st2_tests_conf",
-        "conf/st2.tests2.conf:st2_tests_conf",
-    ],
+    dependencies=_conf_deps,
+    uses=["mongo", "rabbitmq", "redis"],
+    overrides={
+        "test_garbage_collector.py": dict(
+            dependencies=[
+                *_conf_deps,
+                "st2reactor/bin/st2garbagecollector",
+            ],
+            stevedore_namespaces=[
+                "st2common.metrics.driver",
+            ],
+            entry_point_dependencies={
+                "contrib/runners/inquirer_runner": ["st2common.runners.runner"],
+            },
+        ),
+        "test_rules_engine.py": dict(
+            dependencies=[
+                *_conf_deps,
+                "st2reactor/bin/st2timersengine",
+            ],
+            stevedore_namespaces=[
+                "st2common.metrics.driver",
+            ],
+        ),
+        "test_sensor_container.py": dict(
+            dependencies=[
+                *_conf_deps,
+                "st2reactor/bin/st2sensorcontainer",
+                "contrib/examples/sensors",
+                "contrib/examples:metadata",
+            ],
+            stevedore_namespaces=[
+                "st2common.metrics.driver",
+            ],
+        ),
+        "test_sensor_watcher.py": dict(
+            uses=["rabbitmq"],
+        ),
+    },
 )

--- a/st2tests/integration/orquesta/BUILD
+++ b/st2tests/integration/orquesta/BUILD
@@ -1,6 +1,6 @@
 python_tests(
     name="tests",
-    uses=["redis"],
+    uses=["mongo", "rabbitmq", "redis", "system_user"],
 )
 
 python_test_utils(


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

This PR primarily makes this change, plus a few other minor things:
- BUILD metadata for integration tests, including explicit dependencies that could not be inferred and `uses=` config for our `pants-plugins/uses_services` plugin.

The other minor things I included are:
- Silence pants' remote cache warnings. GitHub Actions Caching has a really low API rate limit that we hit regularly. When we hit that, we get 429 errors that pants displays as warnings (LOTS of warnings). The warnings are not actionable--we can't do anything about GitHub's paltry rate limit--and there is basically no impact on our CI--pants just runs the process if it can't find it in the cache or the cache returns an error. All of those warnings were obscuring the actual test output, so this silences them.
- I couldn't run some tests locally because they require passwordless sudo, which I don't want to configure. So, I skipped those tests, leaving them to run only in CI.
- Add a generous timeout for pants to run each test file. I set `[test].timeout_default=600` (ie 10min in seconds) so that pants doesn't hang running integration tests if something goes wrong. If a test times out, pants will just retry it up to 3 times, so this just serves to speed up CI when we run into edge cases.