### PR TITLE
Refactor some CI scripts

### DIFF
--- a/scripts/github/configure-rabbitmq.sh
+++ b/scripts/github/configure-rabbitmq.sh
@@ -24,7 +24,7 @@ echo enabled RabbitMQ plugins:
 # print plugins list to: (1) ease debugging, (2) pause till rabbitmq is really running
 docker exec rabbitmq rabbitmq-plugins list -e
 echo
-sudo wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
+sudo wget --no-verbose http://guest:guest@localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
 sudo chmod +x /usr/local/bin/rabbitmqadmin
 # print logs from stdout (RABBITMQ_LOGS=-)
 docker logs --tail=100 rabbitmq

--- a/scripts/github/prepare-integration.sh
+++ b/scripts/github/prepare-integration.sh
@@ -10,11 +10,6 @@ fi
 # shellcheck disable=SC1091
 source ./virtualenv/bin/activate
 
-# Enable coordination backend to avoid race conditions with orquesta tests due
-# to the lack of the coordination backend
-sed -i "s#\#url = redis://localhost#url = redis://127.0.0.1#g" ./conf/st2.dev.conf
-sed -i "s#\#url = redis://localhost#url = redis://127.0.0.1#g" ./conf/st2.ci.conf || true
-
 echo "Used config for the tests"
 echo ""
 echo "st2.dev.conf"

--- a/scripts/github/prepare-integration.sh
+++ b/scripts/github/prepare-integration.sh
@@ -6,9 +6,13 @@ if [ "$(whoami)" != 'root' ]; then
     exit 2
 fi
 
+# ./virtualenv is the Makefile managed dir.
+# The workflow should set this to use a pants exported or other venv instead.
+VIRTUALENV_DIR="${VIRTUALENV_DIR:-./virtualenv}"
+
 # Activate the virtualenv created during make requirements phase
-# shellcheck disable=SC1091
-source ./virtualenv/bin/activate
+# shellcheck disable=SC1090,SC1091
+source "${VIRTUALENV_DIR}/bin/activate"
 
 echo "Used config for the tests"
 echo ""
@@ -22,7 +26,9 @@ cat conf/st2.ci.conf || true
 echo ""
 
 # install st2 client
-python ./st2client/setup.py develop
+if [ ! -x "${VIRTUALENV_DIR}/bin/st2" ] || ! st2 --version >/dev/null 2>&1; then
+    python ./st2client/setup.py develop
+fi
 st2 --version
 
 # Clean up old st2 log files
@@ -56,7 +62,7 @@ chmod 777 logs/*
 
 # root needs to access write some lock files when creating virtualenvs
 # o=other; X=only set execute bit if user execute bit is set (eg on dirs)
-chmod -R o+rwX ./virtualenv/
+chmod -R o+rwX "${VIRTUALENV_DIR}/"
 # newer virtualenv versions are putting lock files under ~/.local
 # as this script runs with sudo, HOME is actually the CI user's home
 chmod -R o+rwX "${HOME}/.local/share/virtualenv"

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -110,10 +110,17 @@ function init()
     else
         ST2_REPO=${CURRENT_DIR}/${COMMAND_PATH}/..
     fi
+    ST2_REPO=$(readlink -f ${ST2_REPO})
     ST2_LOGS="${ST2_REPO}/logs"
+    # ST2_REPO/virtualenv is the Makefile managed dir.
+    # The workflow should set this to use a pants exported or other venv instead.
     VIRTUALENV=${VIRTUALENV_DIR:-${ST2_REPO}/virtualenv}
     VIRTUALENV=$(readlink -f ${VIRTUALENV})
     PY=${VIRTUALENV}/bin/python
+    if [ ! -f "${PY}" ]; then
+        eecho "${PY} does not exist"
+        exit 1
+    fi
     PYTHON_VERSION=$(${PY} --version 2>&1)
 
     echo -n "Using virtualenv: "; iecho "${VIRTUALENV}"
@@ -218,9 +225,9 @@ function st2start()
     fi
 
     # activate virtualenv to set PYTHONPATH
-    source ${VIRTUALENV}/bin/activate
+    source "${VIRTUALENV}/bin/activate"
     # set configuration file location.
-    export ST2_CONFIG_PATH=${ST2_CONF};
+    export ST2_CONFIG_PATH="${ST2_CONF}"
 
     # Kill existing st2 terminal multiplexor sessions
     for tmux_session in $(tmux ls 2>/dev/null | awk -F: '/^st2-/ {print $1}')

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -201,19 +201,20 @@ function st2start()
     if [ "$copy_test_packs" = true ]; then
         echo -n "Copying test packs examples and fixtures to "; iecho "$PACKS_BASE_DIR"
         cp -Rp ./contrib/examples $PACKS_BASE_DIR
-        # Clone st2tests in /tmp directory.
-        pushd /tmp
+        # Clone st2tests in a tmp directory.
+        CLONE_TMP_DIR=$(mktemp -d)
+        pushd "${CLONE_TMP_DIR}"
         echo Cloning https://github.com/StackStorm/st2tests.git
         # -q = no progress reporting (better for CI). Errors will still print.
         git clone -q https://github.com/StackStorm/st2tests.git
         ret=$?
         if [ ${ret} -eq 0 ]; then
             cp -Rp ./st2tests/packs/fixtures $PACKS_BASE_DIR
-            rm -R st2tests/
         else
             eecho "Failed to clone st2tests repo"
         fi
         popd
+        rm -Rf "${CLONE_TMP_DIR}"
     fi
 
     # activate virtualenv to set PYTHONPATH


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

This PR just refactors some CI scripts to prepare for (a) running integration tests via pants, and (b) the PR where we enable configuring StackStorm via env vars (a new oslo_config feature). Since this is an internal-only change/refactor, I added the https://github.com/StackStorm/st2/labels/no%20changelog label.

It is probably easiest to review each commit+commit message of this PR as github's diff is confusing in at least one place.