### PR TITLE
Add support for overriding `st2.conf` settings via env vars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,6 +86,13 @@ Added
   following to set system user to the current user: `export ST2TESTS_SYSTEM_USER=$(id -un)` #6242
   Contributed by @cognifloyd
 
+* Added experimental support for setting conf vars via environment variables. All settings in `st2.conf` can be
+  overriden via enviornment vars in the format: `ST2_<conf section>__<option name>` (env vars are upper cased)
+  For example, the `[database].password` setting in `st2.conf` could be overriden using `ST2_DATABASE__PASSWORD`.
+  This new feature is based on oslo_config's environment support, but patches it to use the `ST2_` prefix.
+  If you experience any issues when using this experimental feature, please file an issue. #6277
+  Contributed by @cognifloyd
+
 3.8.1 - December 13, 2023
 -------------------------
 Fixed

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -28,10 +28,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/config.py
+++ b/st2actions/st2actions/config.py
@@ -28,13 +28,11 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(CONF)
     CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -21,17 +21,13 @@ import st2common.config as common_config
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
-CONF = cfg.CONF
-
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/notifier/config.py
+++ b/st2actions/st2actions/notifier/config.py
@@ -25,10 +25,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/scheduler/config.py
+++ b/st2actions/st2actions/scheduler/config.py
@@ -27,10 +27,13 @@ LOG = logging.getLogger(__name__)
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=sys_constants.VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/scheduler/config.py
+++ b/st2actions/st2actions/scheduler/config.py
@@ -27,13 +27,11 @@ LOG = logging.getLogger(__name__)
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=sys_constants.VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/workflows/config.py
+++ b/st2actions/st2actions/workflows/config.py
@@ -23,10 +23,13 @@ from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=sys_constants.VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2actions/st2actions/workflows/config.py
+++ b/st2actions/st2actions/workflows/config.py
@@ -23,13 +23,11 @@ from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=sys_constants.VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -32,13 +32,11 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2api/st2api/config.py
+++ b/st2api/st2api/config.py
@@ -32,10 +32,13 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2api/tests/integration/test_gunicorn_configs.py
+++ b/st2api/tests/integration/test_gunicorn_configs.py
@@ -43,6 +43,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:
@@ -64,6 +65,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:

--- a/st2api/tests/integration/test_gunicorn_configs.py
+++ b/st2api/tests/integration/test_gunicorn_configs.py
@@ -43,6 +43,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:
             self.add_process(process=process)
@@ -63,6 +64,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:
             self.add_process(process=process)

--- a/st2api/tests/integration/test_gunicorn_configs.py
+++ b/st2api/tests/integration/test_gunicorn_configs.py
@@ -22,6 +22,7 @@ import requests
 import eventlet
 from eventlet.green import subprocess
 
+import st2tests.config
 from st2common.models.utils import profiling
 from st2common.util.shell import kill_process
 from st2tests.base import IntegrationTestCase
@@ -41,6 +42,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         )
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
+        env.update(st2tests.config.db_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:
             self.add_process(process=process)
@@ -60,6 +62,7 @@ class GunicornWSGIEntryPointTestCase(IntegrationTestCase):
         )
         env = os.environ.copy()
         env["ST2_CONFIG_PATH"] = ST2_CONFIG_PATH
+        env.update(st2tests.config.db_opts_as_env_vars())
         process = subprocess.Popen(cmd, env=env, shell=True, preexec_fn=os.setsid)
         try:
             self.add_process(process=process)

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -28,10 +28,13 @@ from st2auth import backends as auth_backends
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2auth/st2auth/config.py
+++ b/st2auth/st2auth/config.py
@@ -28,13 +28,11 @@ from st2auth import backends as auth_backends
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
+    st2cfg.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -19,6 +19,7 @@ import socket
 import sys
 
 from oslo_config import cfg
+from oslo_config.sources._environment import EnvironmentConfigurationSource
 
 from st2common.constants.system import VERSION_STRING
 from st2common.constants.system import DEFAULT_CONFIG_FILE_PATH
@@ -900,10 +901,20 @@ def register_opts(ignore_errors=False):
     )
 
 
+class St2EnvironmentConfigurationSource(EnvironmentConfigurationSource):
+    @staticmethod
+    def get_name(group_name, option_name):
+        group_name = group_name or "DEFAULT"
+        return "ST2_{}__{}".format(group_name.upper(), option_name.upper())
+
+
 def parse_args(args=None, ignore_errors=False):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = St2EnvironmentConfigurationSource()
     register_opts(ignore_errors=ignore_errors)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -908,13 +908,16 @@ class St2EnvironmentConfigurationSource(EnvironmentConfigurationSource):
         return "ST2_{}__{}".format(group_name.upper(), option_name.upper())
 
 
-def parse_args(args=None, ignore_errors=False):
+def use_st2_env_vars(conf: cfg.ConfigOpts) -> None:
     # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = St2EnvironmentConfigurationSource()
+    conf._env_driver = St2EnvironmentConfigurationSource()
+
+
+def parse_args(args=None, ignore_errors=False):
+    use_st2_env_vars(cfg.CONF)
     register_opts(ignore_errors=ignore_errors)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -212,5 +212,6 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
     def _run_command(cmd):
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         return run_command(cmd=cmd, env=env)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -212,4 +212,5 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
     def _run_command(cmd):
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         return run_command(cmd=cmd, env=env)

--- a/st2common/tests/integration/test_register_content_script.py
+++ b/st2common/tests/integration/test_register_content_script.py
@@ -19,6 +19,7 @@ import os
 import sys
 import glob
 
+import st2tests.config
 from st2tests.base import IntegrationTestCase
 from st2common.util.shell import run_command
 from st2tests import config as test_config
@@ -56,7 +57,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-runner-dir=%s" % (runner_dirs),
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn("Registered 3 actions.", stderr)
         self.assertEqual(exit_code, 0)
 
@@ -71,7 +72,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-no-fail-on-failure",
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
-        exit_code, _, _ = run_command(cmd=cmd)
+        exit_code, _, _ = self._run_command(cmd=cmd)
         self.assertEqual(exit_code, 0)
 
         # Fail on failure, should fail
@@ -81,7 +82,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-fail-on-failure",
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn('Directory "doesntexistblah" doesn\'t exist', stderr)
         self.assertEqual(exit_code, 1)
 
@@ -97,7 +98,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
         ]
 
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn("Registered 0 actions.", stderr)
         self.assertEqual(exit_code, 0)
 
@@ -109,7 +110,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-runner-dir=%s" % (runner_dirs),
         ]
         cmd = BASE_REGISTER_ACTIONS_CMD_ARGS + opts
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn("object has no attribute 'get'", stderr)
         self.assertEqual(exit_code, 1)
 
@@ -127,7 +128,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "-v",
             "--register-sensors",
         ]
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn("Registered 0 sensors.", stderr, "Actual stderr: %s" % (stderr))
         self.assertEqual(exit_code, 0)
 
@@ -139,7 +140,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-all",
             "--register-no-fail-on-failure",
         ]
-        exit_code, _, stderr = run_command(cmd=cmd)
+        exit_code, _, stderr = self._run_command(cmd=cmd)
         self.assertIn("Registered 0 actions.", stderr)
         self.assertIn("Registered 0 sensors.", stderr)
         self.assertIn("Registered 0 rules.", stderr)
@@ -155,7 +156,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-setup-virtualenvs",
             "--register-no-fail-on-failure",
         ]
-        exit_code, stdout, stderr = run_command(cmd=cmd)
+        exit_code, stdout, stderr = self._run_command(cmd=cmd)
         self.assertIn("Registering actions", stderr, "Actual stderr: %s" % (stderr))
         self.assertIn("Registering rules", stderr)
         self.assertIn("Setup virtualenv for %s pack(s)" % ("1"), stderr)
@@ -170,7 +171,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-setup-virtualenvs",
             "--register-no-fail-on-failure",
         ]
-        exit_code, stdout, stderr = run_command(cmd=cmd)
+        exit_code, stdout, stderr = self._run_command(cmd=cmd)
 
         self.assertIn('Setting up virtualenv for pack "dummy_pack_1"', stderr)
         self.assertIn("Setup virtualenv for 1 pack(s)", stderr)
@@ -186,7 +187,7 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-setup-virtualenvs",
             "--register-no-fail-on-failure",
         ]
-        exit_code, stdout, stderr = run_command(cmd=cmd)
+        exit_code, stdout, stderr = self._run_command(cmd=cmd)
 
         self.assertIn('Setting up virtualenv for pack "dummy_pack_1"', stderr)
         self.assertIn("Setup virtualenv for 1 pack(s)", stderr)
@@ -200,9 +201,15 @@ class ContentRegisterScriptTestCase(IntegrationTestCase):
             "--register-recreate-virtualenvs",
             "--register-no-fail-on-failure",
         ]
-        exit_code, stdout, stderr = run_command(cmd=cmd)
+        exit_code, stdout, stderr = self._run_command(cmd=cmd)
 
         self.assertIn('Setting up virtualenv for pack "dummy_pack_1"', stderr)
         self.assertIn("Virtualenv successfully removed.", stderr)
         self.assertIn("Setup virtualenv for 1 pack(s)", stderr)
         self.assertEqual(exit_code, 0)
+
+    @staticmethod
+    def _run_command(cmd):
+        env = os.environ.copy()
+        env.update(st2tests.config.db_opts_as_env_vars())
+        return run_command(cmd=cmd, env=env)

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -231,6 +231,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         cwd = os.path.abspath(cwd)
         env = env or os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(
             cmd,

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -231,6 +231,7 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         cwd = os.path.abspath(cwd)
         env = env or os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(
             cmd,
             env=env,

--- a/st2common/tests/integration/test_service_setup_log_level_filtering.py
+++ b/st2common/tests/integration/test_service_setup_log_level_filtering.py
@@ -21,6 +21,7 @@ import signal
 import eventlet
 from eventlet.green import subprocess
 
+import st2tests.config
 from st2tests.base import IntegrationTestCase
 from st2tests.fixtures.conf.fixture import FIXTURE_PATH as CONF_FIXTURES_PATH
 
@@ -223,13 +224,16 @@ class ServiceSetupLogLevelFilteringTestCase(IntegrationTestCase):
         stdout = "\n".join(process.stdout.read().decode("utf-8").split("\n"))
         self.assertNotIn("heartbeat_tick", stdout)
 
-    def _start_process(self, config_path, env=None):
+    @staticmethod
+    def _start_process(config_path, env=None):
         cmd = CMD + [config_path]
         cwd = os.path.abspath(os.path.join(BASE_DIR, "../../../"))
         cwd = os.path.abspath(cwd)
+        env = env or os.environ.copy()
+        env.update(st2tests.config.db_opts_as_env_vars())
         process = subprocess.Popen(
             cmd,
-            env=env or os.environ.copy(),
+            env=env,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/st2reactor/st2reactor/cmd/trigger_re_fire.py
+++ b/st2reactor/st2reactor/cmd/trigger_re_fire.py
@@ -48,8 +48,7 @@ def _parse_config():
     CONF.register_cli_opts(cli_opts)
     st2cfg.register_opts(ignore_errors=False)
 
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
+    st2cfg.use_st2_env_vars(CONF)
     CONF(args=sys.argv[1:])
 
 

--- a/st2reactor/st2reactor/cmd/trigger_re_fire.py
+++ b/st2reactor/st2reactor/cmd/trigger_re_fire.py
@@ -48,6 +48,8 @@ def _parse_config():
     CONF.register_cli_opts(cli_opts)
     st2cfg.register_opts(ignore_errors=False)
 
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
     CONF(args=sys.argv[1:])
 
 

--- a/st2reactor/st2reactor/garbage_collector/config.py
+++ b/st2reactor/st2reactor/garbage_collector/config.py
@@ -27,13 +27,11 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/garbage_collector/config.py
+++ b/st2reactor/st2reactor/garbage_collector/config.py
@@ -27,10 +27,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -25,13 +25,11 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/rules/config.py
+++ b/st2reactor/st2reactor/rules/config.py
@@ -25,10 +25,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -26,10 +26,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/sensor/config.py
+++ b/st2reactor/st2reactor/sensor/config.py
@@ -26,13 +26,11 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = st2cfg.St2EnvironmentConfigurationSource()
+    st2cfg.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/timer/config.py
+++ b/st2reactor/st2reactor/timer/config.py
@@ -25,13 +25,11 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/st2reactor/timer/config.py
+++ b/st2reactor/st2reactor/timer/config.py
@@ -25,10 +25,13 @@ CONF = cfg.CONF
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -20,8 +20,7 @@ import sys
 import signal
 import datetime
 
-from oslo_config import cfg
-
+import st2tests.config
 from st2common.util import concurrency
 from st2common.constants import action as action_constants
 from st2common.util import date as date_utils
@@ -277,7 +276,7 @@ class GarbageCollectorServiceTestCase(IntegrationTestCase, CleanDbTestCase):
     def _start_garbage_collector(self):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
-        env["ST2_DATABASE__DB_NAME"] = cfg.CONF.database.db_name
+        env.update(st2tests.config.db_opts_as_env_vars())
         process = subprocess.Popen(
             CMD_INQUIRY,
             stdout=subprocess.PIPE,

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -277,6 +277,7 @@ class GarbageCollectorServiceTestCase(IntegrationTestCase, CleanDbTestCase):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(
             CMD_INQUIRY,

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -20,6 +20,8 @@ import sys
 import signal
 import datetime
 
+from oslo_config import cfg
+
 from st2common.util import concurrency
 from st2common.constants import action as action_constants
 from st2common.util import date as date_utils
@@ -274,12 +276,15 @@ class GarbageCollectorServiceTestCase(IntegrationTestCase, CleanDbTestCase):
 
     def _start_garbage_collector(self):
         subprocess = concurrency.get_subprocess_module()
+        env=os.environ.copy()
+        env["ST2_DATABASE__DB_NAME"] = cfg.CONF.database.db_name
         process = subprocess.Popen(
             CMD_INQUIRY,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,
             preexec_fn=os.setsid,
+            env=env,
         )
         self.add_process(process=process)
         return process

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -277,6 +277,7 @@ class GarbageCollectorServiceTestCase(IntegrationTestCase, CleanDbTestCase):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         process = subprocess.Popen(
             CMD_INQUIRY,
             stdout=subprocess.PIPE,

--- a/st2reactor/tests/integration/test_garbage_collector.py
+++ b/st2reactor/tests/integration/test_garbage_collector.py
@@ -276,7 +276,7 @@ class GarbageCollectorServiceTestCase(IntegrationTestCase, CleanDbTestCase):
 
     def _start_garbage_collector(self):
         subprocess = concurrency.get_subprocess_module()
-        env=os.environ.copy()
+        env = os.environ.copy()
         env["ST2_DATABASE__DB_NAME"] = cfg.CONF.database.db_name
         process = subprocess.Popen(
             CMD_INQUIRY,

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -246,6 +246,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.coord_opts_as_env_vars())
         print("Using command: %s" % (" ".join(cmd)))
         process = subprocess.Popen(
             cmd,

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -246,6 +246,7 @@ class SensorContainerTestCase(IntegrationTestCase):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
         env.update(st2tests.config.db_opts_as_env_vars())
+        env.update(st2tests.config.mq_opts_as_env_vars())
         env.update(st2tests.config.coord_opts_as_env_vars())
         print("Using command: %s" % (" ".join(cmd)))
         process = subprocess.Popen(

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -245,7 +245,7 @@ class SensorContainerTestCase(IntegrationTestCase):
     def _start_sensor_container(self, cmd=DEFAULT_CMD):
         subprocess = concurrency.get_subprocess_module()
         env = os.environ.copy()
-        env["ST2_DATABASE__DB_NAME"] = cfg.CONF.database.db_name
+        env.update(st2tests.config.db_opts_as_env_vars())
         print("Using command: %s" % (" ".join(cmd)))
         process = subprocess.Popen(
             cmd,

--- a/st2reactor/tests/integration/test_sensor_container.py
+++ b/st2reactor/tests/integration/test_sensor_container.py
@@ -244,6 +244,8 @@ class SensorContainerTestCase(IntegrationTestCase):
 
     def _start_sensor_container(self, cmd=DEFAULT_CMD):
         subprocess = concurrency.get_subprocess_module()
+        env = os.environ.copy()
+        env["ST2_DATABASE__DB_NAME"] = cfg.CONF.database.db_name
         print("Using command: %s" % (" ".join(cmd)))
         process = subprocess.Popen(
             cmd,
@@ -251,6 +253,7 @@ class SensorContainerTestCase(IntegrationTestCase):
             stderr=subprocess.PIPE,
             shell=False,
             preexec_fn=os.setsid,
+            env=env,
         )
         self.add_process(process=process)
         return process

--- a/st2stream/st2stream/config.py
+++ b/st2stream/st2stream/config.py
@@ -32,13 +32,11 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def parse_args(args=None):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
-        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2stream/st2stream/config.py
+++ b/st2stream/st2stream/config.py
@@ -32,10 +32,13 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def parse_args(args=None):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     cfg.CONF(
         args=args,
         version=VERSION_STRING,
         default_config_files=[DEFAULT_CONFIG_FILE_PATH],
+        use_env=True,  # Make our env var support explicit (default is True)
     )
 
 

--- a/st2tests/st2tests/base.py
+++ b/st2tests/st2tests/base.py
@@ -565,6 +565,11 @@ class IntegrationTestCase(TestCase):
 
     processes = {}
 
+    @classmethod
+    def setUpClass(cls):
+        # this prepares the vars for use in configuring the subprocesses via env var
+        tests_config.parse_args()
+
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
         self._stop_running_processes()

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -165,6 +165,13 @@ def _override_coordinator_opts(noop=False):
     CONF.set_override(name="lock_timeout", override=1, group="coordination")
 
 
+def coord_opts_as_env_vars() -> Dict[str, str]:
+    env = {}
+    if CONF.coordination.url is not None:
+        env["ST2_COORDINATION__URL"] = CONF.coordination.url
+    return env
+
+
 def _override_workflow_engine_opts():
     cfg.CONF.set_override("retry_stop_max_msec", 200, group="workflow_engine")
     cfg.CONF.set_override("retry_wait_fixed_msec", 100, group="workflow_engine")

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -39,9 +39,11 @@ def reset():
 
 
 def parse_args(args=None, coordinator_noop=True):
+    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
+    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
     _setup_config_opts(coordinator_noop=coordinator_noop)
 
-    kwargs = {}
+    kwargs = {"use_env": True}
     if USE_DEFAULT_CONFIG_FILES:
         kwargs["default_config_files"] = [DEFAULT_CONFIG_FILE_PATH]
 

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -39,11 +39,10 @@ def reset():
 
 
 def parse_args(args=None, coordinator_noop=True):
-    # Override oslo_config's 'OS_' env var prefix with 'ST2_'.
-    cfg.CONF._env_driver = common_config.St2EnvironmentConfigurationSource()
+    common_config.use_st2_env_vars(cfg.CONF)
     _setup_config_opts(coordinator_noop=coordinator_noop)
 
-    kwargs = {"use_env": True}
+    kwargs = {}
     if USE_DEFAULT_CONFIG_FILES:
         kwargs["default_config_files"] = [DEFAULT_CONFIG_FILE_PATH]
 

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 
 import os
+from typing import Dict
 
 from oslo_config import cfg, types
 
@@ -90,6 +91,20 @@ def _override_db_opts():
     db_name = f"st2-test{os.environ.get('ST2TESTS_PARALLEL_SLOT', '')}"
     CONF.set_override(name="db_name", override=db_name, group="database")
     CONF.set_override(name="host", override="127.0.0.1", group="database")
+
+
+def db_opts_as_env_vars() -> Dict[str, str]:
+    env = {
+        "ST2_DATABASE__HOST": CONF.database.host,
+        "ST2_DATABASE__PORT": str(CONF.database.port),
+        "ST2_DATABASE__DB_NAME": CONF.database.db_name,
+        "ST2_DATABASE__CONNECTION_TIMEOUT": str(CONF.database.connection_timeout),
+    }
+    if CONF.database.username is not None:
+        env["ST2_DATABASE__USERNAME"] = CONF.database.username
+    if CONF.database.password is not None:
+        env["ST2_DATABASE__PASSWORD"] = CONF.database.password
+    return env
 
 
 def _override_common_opts():

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -107,6 +107,10 @@ def db_opts_as_env_vars() -> Dict[str, str]:
     return env
 
 
+def mq_opts_as_env_vars() -> Dict[str, str]:
+    return {"ST2_MESSAGING__URL": CONF.messaging.url}
+
+
 def _override_common_opts():
     packs_base_path = get_fixtures_packs_base_path()
     CONF.set_override(name="base_path", override=packs_base_path, group="system")


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

We have upgraded to a version of oslo_config that supports overriding conf vars via environment variables. That support is enabled by default, but it hardcodes the env var prefix `OS_`. Since oslo_config is designed for use within OpenStack, the OpenStack devs did not have a reason to make that prefix configurable. Using `OS_` does not make sense for the StackStorm project, so I changed the prefix to `ST2_` in this subclass:

https://github.com/StackStorm/st2/blob/4e8794c99a97fd92dda85f74ae0989e56dc715e4/st2common/st2common/config.py#L904-L908

To use this class, we have to update the `cfg.CONF` global to use our subclass instead of the default. This is done with a helper method:

https://github.com/StackStorm/st2/blob/4e8794c99a97fd92dda85f74ae0989e56dc715e4/st2common/st2common/config.py#L911-L913

This helper needs to be called just before we tell oslo to parse the config (by calling `cfg.CONF(...)`), which happens in various `parse_args()` functions throughout the ST2 codebase, including the primary one here:

https://github.com/StackStorm/st2/blob/4e8794c99a97fd92dda85f74ae0989e56dc715e4/st2common/st2common/config.py#L916-L923

Finally, I made use of this feature to pass settings to Integration test subprocesses. When running the tests via pants+pytest, we have to modify things like the db-name to use a slot number so that tests can run safely in parallel without clobbering other tests' data. That slot number only gets injected in test code (in `st2tests.config`), so we needed a way to override the conf file on the fly with the updated settings for the test. For example, this test now injects various env vars to ensure the subprocess uses the conf values that the test expects:

https://github.com/StackStorm/st2/blob/4e8794c99a97fd92dda85f74ae0989e56dc715e4/st2common/tests/integration/test_service_setup_log_level_filtering.py#L232-L238

These env var helpers are defined in `st2tests.config` to make it as easy as possible for tests to inject the relevant env vars.

Bonus: This will make configuration for docker and kubernetes much more straightforward. We have had requests to make secret vars in particular settable via env vars in addition to the conf file. So, this makes that possible.