### PR TITLE
pants-plugins/uses_services: add support for uses=st2cluster in BUILD metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,7 +69,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259 #6260 #6269 #6275
+  #6254 #6258 #6259 #6260 #6269 #6275 #6279
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/orquesta_runner/tests/integration/BUILD
+++ b/contrib/runners/orquesta_runner/tests/integration/BUILD
@@ -5,5 +5,6 @@ __defaults__(
 
 python_tests(
     name="tests",
-    uses=["mongo", "rabbitmq", "redis", "system_user"],
+    uses=["mongo", "rabbitmq", "redis", "st2cluster", "system_user"],
+    tags=["integration", "st2cluster"],
 )

--- a/pants-plugins/uses_services/register.py
+++ b/pants-plugins/uses_services/register.py
@@ -21,6 +21,7 @@ from uses_services import (
     platform_rules,
     rabbitmq_rules,
     redis_rules,
+    st2cluster_rules,
     system_user_rules,
 )
 from uses_services.target_types import UsesServicesField
@@ -36,5 +37,6 @@ def rules():
         *mongo_rules.rules(),
         *rabbitmq_rules.rules(),
         *redis_rules.rules(),
+        *st2cluster_rules.rules(),
         *system_user_rules.rules(),
     ]

--- a/pants-plugins/uses_services/scripts/is_st2cluster_running.py
+++ b/pants-plugins/uses_services/scripts/is_st2cluster_running.py
@@ -1,0 +1,48 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import socket
+import sys
+
+from contextlib import closing
+
+
+def _is_st2cluster_running(host: str, ports: list[str]) -> bool:
+    """Check for listening ports of st2auth, st2api, and st2stream services.
+
+    This should not import the st2 code as it should be self-contained.
+    """
+    # TODO: Once each service gains a reliable health check endpoint, use that.
+    # https://github.com/StackStorm/st2/issues/4020
+    for port in ports:
+        # based on https://stackoverflow.com/a/35370008/1134951
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            # errno=0 means the connection succeeded
+            if sock.connect_ex((host, int(port))) != 0:
+                # failed to create a connection to the port.
+                return False
+    return True
+
+
+if __name__ == "__main__":
+    hostname = "127.0.0.1"
+    service_ports = list(sys.argv[1:])
+    if not service_ports:
+        # st2.tests*.conf ends in /, but the default ends in //
+        service_ports = ["9100", "9101", "9102"]
+
+    is_running = _is_st2cluster_running(hostname, service_ports)
+    exit_code = 0 if is_running else 1
+    sys.exit(exit_code)

--- a/pants-plugins/uses_services/scripts/is_st2cluster_running.py
+++ b/pants-plugins/uses_services/scripts/is_st2cluster_running.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The StackStorm Authors.
+# Copyright 2024 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/uses_services/st2cluster_rules.py
+++ b/pants-plugins/uses_services/st2cluster_rules.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The StackStorm Authors.
+# Copyright 2024 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/uses_services/st2cluster_rules.py
+++ b/pants-plugins/uses_services/st2cluster_rules.py
@@ -1,0 +1,164 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+
+from pants.backend.python.goals.pytest_runner import (
+    PytestPluginSetupRequest,
+    PytestPluginSetup,
+)
+from pants.backend.python.target_types import Executable
+from pants.backend.python.util_rules.pex import (
+    PexRequest,
+    VenvPex,
+    VenvPexProcess,
+    rules as pex_rules,
+)
+from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.rules import collect_rules, Get, rule
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope
+from pants.engine.target import Target
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+from uses_services.exceptions import ServiceMissingError
+from uses_services.platform_rules import Platform
+from uses_services.scripts.is_st2cluster_running import (
+    __file__ as is_st2cluster_running_full_path,
+)
+from uses_services.target_types import UsesServicesField
+
+
+@dataclass(frozen=True)
+class UsesSt2ClusterRequest:
+    """One or more targets need a running st2 cluster with all st2* services."""
+
+    auth_port: int = 9100
+    api_port: int = 9101
+    stream_port: int = 9102
+
+    @property
+    def ports(self) -> tuple[str, ...]:
+        return str(self.auth_port), str(self.api_port), str(self.stream_port)
+
+
+@dataclass(frozen=True)
+class St2ClusterIsRunning:
+    pass
+
+
+class PytestUsesSt2ClusterRequest(PytestPluginSetupRequest):
+    @classmethod
+    def is_applicable(cls, target: Target) -> bool:
+        if not target.has_field(UsesServicesField):
+            return False
+        uses = target.get(UsesServicesField).value
+        return uses is not None and "st2cluster" in uses
+
+
+@rule(
+    desc="Ensure ST2 Cluster is running and accessible before running tests.",
+    level=LogLevel.DEBUG,
+)
+async def st2cluster_is_running_for_pytest(
+    request: PytestUsesSt2ClusterRequest,
+) -> PytestPluginSetup:
+    # this will raise an error if st2cluster is not running
+    _ = await Get(St2ClusterIsRunning, UsesSt2ClusterRequest())
+
+    return PytestPluginSetup()
+
+
+@rule(
+    desc="Test to see if ST2 Cluster is running and accessible.",
+    level=LogLevel.DEBUG,
+)
+async def st2cluster_is_running(
+    request: UsesSt2ClusterRequest, platform: Platform
+) -> St2ClusterIsRunning:
+    script_path = "./is_st2cluster_running.py"
+
+    # pants is already watching this directory as it is under a source root.
+    # So, we don't need to double watch with PathGlobs, just open it.
+    with open(is_st2cluster_running_full_path, "rb") as script_file:
+        script_contents = script_file.read()
+
+    script_digest = await Get(
+        Digest, CreateDigest([FileContent(script_path, script_contents)])
+    )
+    script_pex = await Get(
+        VenvPex,
+        PexRequest(
+            output_filename="script.pex",
+            internal_only=True,
+            sources=script_digest,
+            main=Executable(script_path),
+        ),
+    )
+
+    result = await Get(
+        FallibleProcessResult,
+        VenvPexProcess(
+            script_pex,
+            argv=request.ports,
+            input_digest=script_digest,
+            description="Checking to see if ST2 Cluster is up and accessible.",
+            # this can change from run to run, so don't cache results.
+            cache_scope=ProcessCacheScope.PER_SESSION,
+            level=LogLevel.DEBUG,
+        ),
+    )
+    is_running = result.exit_code == 0
+
+    if is_running:
+        return St2ClusterIsRunning()
+
+    # st2cluster is not running, so raise an error with instructions.
+    instructions = dedent(
+        """\
+        A full StackStorm cluster is required to run some integration tests.
+        To start the dev StackStorm cluster, run this from the repo root
+        (probably in a new terminal/window, as the output is quite verbose):
+
+        tools/launchdev.sh start -x
+
+        This runs each StackStorm microservice in a tmux session. You can
+        inspect the logs for this service in the `logs/` directory.
+
+        If tmux is not installed, please install it with a package manager,
+        or use vagrant for local development with something like:
+
+        vagrant init stackstorm/st2
+        vagrant up
+        vagrant ssh
+
+        Please see: https://docs.stackstorm.com/install/vagrant.html
+        """
+    )
+    raise ServiceMissingError(
+        service="st2cluster",
+        platform=platform,
+        instructions=instructions,
+        msg=f"The dev StackStorm cluster seems to be down.\n{instructions}",
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(PytestPluginSetupRequest, PytestUsesSt2ClusterRequest),
+        *pex_rules(),
+    ]

--- a/pants-plugins/uses_services/st2cluster_rules_test.py
+++ b/pants-plugins/uses_services/st2cluster_rules_test.py
@@ -1,0 +1,95 @@
+# Copyright 2023 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+from pants.engine.internals.scheduler import ExecutionError
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+from .data_fixtures import platform, platform_samples
+from .exceptions import ServiceMissingError
+from .st2cluster_rules import (
+    St2ClusterIsRunning,
+    UsesSt2ClusterRequest,
+    rules as st2cluster_rules,
+)
+from .platform_rules import Platform
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *st2cluster_rules(),
+            QueryRule(St2ClusterIsRunning, (UsesSt2ClusterRequest, Platform)),
+        ],
+        target_types=[],
+    )
+
+
+def run_st2cluster_is_running(
+    rule_runner: RuleRunner,
+    uses_st2cluster_request: UsesSt2ClusterRequest,
+    mock_platform: Platform,
+    *,
+    extra_args: list[str] | None = None,
+) -> St2ClusterIsRunning:
+    rule_runner.set_options(
+        [
+            "--backend-packages=uses_services",
+            *(extra_args or ()),
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    result = rule_runner.request(
+        St2ClusterIsRunning,
+        [uses_st2cluster_request, mock_platform],
+    )
+    return result
+
+
+# Warning this requires that st2cluster be running
+def test_st2cluster_is_running(rule_runner: RuleRunner) -> None:
+    request = UsesSt2ClusterRequest()
+    mock_platform = platform(os="TestMock")
+
+    # we are asserting that this does not raise an exception
+    is_running = run_st2cluster_is_running(rule_runner, request, mock_platform)
+    assert is_running
+
+
+@pytest.mark.parametrize("mock_platform", platform_samples)
+def test_st2cluster_not_running(
+    rule_runner: RuleRunner, mock_platform: Platform
+) -> None:
+    request = UsesSt2ClusterRequest(
+        # some unassigned ports that are unlikely to be used
+        auth_port=10,
+        api_port=12,
+        stream_port=14,
+    )
+
+    with pytest.raises(ExecutionError) as exception_info:
+        run_st2cluster_is_running(rule_runner, request, mock_platform)
+
+    execution_error = exception_info.value
+    assert len(execution_error.wrapped_exceptions) == 1
+
+    exc = execution_error.wrapped_exceptions[0]
+    assert isinstance(exc, ServiceMissingError)
+
+    assert exc.service == "st2cluster"
+    assert "The dev StackStorm cluster seems to be down" in str(exc)
+    assert exc.instructions != ""

--- a/pants-plugins/uses_services/st2cluster_rules_test.py
+++ b/pants-plugins/uses_services/st2cluster_rules_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The StackStorm Authors.
+# Copyright 2024 The StackStorm Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants-plugins/uses_services/target_types.py
+++ b/pants-plugins/uses_services/target_types.py
@@ -14,7 +14,7 @@
 from pants.engine.target import StringSequenceField
 
 
-supported_services = ("mongo", "rabbitmq", "redis", "system_user")
+supported_services = ("mongo", "rabbitmq", "redis", "st2cluster", "system_user")
 
 
 class UsesServicesField(StringSequenceField):

--- a/st2tests/integration/orquesta/BUILD
+++ b/st2tests/integration/orquesta/BUILD
@@ -1,6 +1,7 @@
 python_tests(
     name="tests",
-    uses=["mongo", "rabbitmq", "redis", "system_user"],
+    uses=["mongo", "rabbitmq", "redis", "st2cluster", "system_user"],
+    tags=["integration", "st2cluster"],
 )
 
 python_test_utils(


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

Today, we run a dev st2 cluster using `tools/launchdev.sh` for all integration tests. However, only a subset of the tests actually make use of the running service. The only tests that require the dev st2 cluster are orquesta runner integration tests (which run today as part of integration tests) and the orquesta integration tests (in `st2tests/integration/orquesta`) that today run in a separate Orquesta Tests CI job.

The rest of the integration tests actually start the `st2api` or other process as part of the test, so they ignore the dev cluster, meaning CI doesn't need to the overhead of running the full cluster to run those tests. Plus, when running the tests locally, you don't need to run the dev cluster either, unless you need to run the orquesta tests.

So, this PR adds a new `st2cluster` service to `pants-plugins/uses_services` so that we can check for the running dev cluster and raise an error if the cluster isn't running when attempting to run the tests that need it.

I also added an `st2cluster` tag to the BUILD metadata of these tests so that it is simple to run only the tests that need `st2cluster` or run all `integration` tagged tests except for the `st2cluster` tagged tasks. To skip the `st2cluster` tagged tasks, you might run pants like this: `pants --tag=integration --tag=-st2cluster test ::`.

It might be helpful to review each commit of this PR. Sorry for the size of the first commit; I don't see a sane way to split this PR up any farther.

For background on `pants-plugins/uses_services` see:
- #5864
- #5884
- #5893
- #5898
- #6244
