### PR TITLE
Add new option `[messaging].prefix` to configure prefix of RabbitMQ exchange/queue names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,7 +69,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278
+  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11
@@ -91,6 +91,12 @@ Added
   For example, the `[database].password` setting in `st2.conf` could be overriden using `ST2_DATABASE__PASSWORD`.
   This new feature is based on oslo_config's environment support, but patches it to use the `ST2_` prefix.
   If you experience any issues when using this experimental feature, please file an issue. #6277
+  Contributed by @cognifloyd
+
+* Add new option `[messaging].prefix` to configure the prefix used in RabbitMQ exchanges and queues.
+  The default is `st2` (resulting in exchange names like `st2.execution` and `st2.sensor`).
+  This is primarily designed to support safely running tests in parallel where creating a vhost for
+  each parallel test run would be a maintenance burden. #6282
   Contributed by @cognifloyd
 
 3.8.1 - December 13, 2023

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -230,6 +230,8 @@ connection_retries = 10
 connection_retry_wait = 10000
 # Login method to use (AMQPLAIN, PLAIN, EXTERNAL, etc.).
 login_method = None
+# Prefix for all exchange and queue names.
+prefix = st2
 # Use SSL / TLS to connect to the messaging server. Same as appending "?ssl=true" at the end of the connection URL string.
 ssl = False
 # ca_certs file contains a set of concatenated CA certificates, which are used to validate certificates passed from RabbitMQ.

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -103,6 +103,7 @@ ssh_key_file = /home/vagrant/.ssh/stanley_rsa
 
 [messaging]
 url = amqp://guest:guest@127.0.0.1:5672/
+prefix = st2dev
 # Uncomment to test SSL options
 #url = amqp://guest:guest@127.0.0.1:5671/
 #ssl = True

--- a/pants-plugins/uses_services/rabbitmq_rules_test.py
+++ b/pants-plugins/uses_services/rabbitmq_rules_test.py
@@ -51,7 +51,14 @@ def run_rabbitmq_is_running(
             "--backend-packages=uses_services",
             *(extra_args or ()),
         ],
-        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+        env_inherit={
+            "PATH",
+            "PYENV_ROOT",
+            "HOME",
+            "ST2_MESSAGING__URL",
+            "ST2_MESSAGING__PREFIX",
+            "ST2TESTS_PARALLEL_SLOT",
+        },
     )
     result = rule_runner.request(
         RabbitMQIsRunning,
@@ -62,7 +69,7 @@ def run_rabbitmq_is_running(
 
 # Warning this requires that rabbitmq be running
 def test_rabbitmq_is_running(rule_runner: RuleRunner) -> None:
-    request = UsesRabbitMQRequest()
+    request = UsesRabbitMQRequest.from_env(env=rule_runner.environment)
     mock_platform = platform(os="TestMock")
 
     # we are asserting that this does not raise an exception

--- a/pants.toml
+++ b/pants.toml
@@ -247,6 +247,9 @@ extra_env_vars = [
   "ST2_DATABASE__CONNECTION_TIMEOUT",
   "ST2_DATABASE__USERNAME",
   "ST2_DATABASE__PASSWORD",
+  # Use these to override RabbitMQ connection details
+  "ST2_MESSAGING__URL",
+  "ST2_MESSAGING__PREFIX", # Tests will modify this to be "{prefix}{ST2TESTS_PARALLEL_SLOT}"
   # Use these to override the redis host and port
   "ST2TESTS_REDIS_HOST",
   "ST2TESTS_REDIS_PORT",

--- a/st2actions/tests/integration/test_actions_queue_consumer.py
+++ b/st2actions/tests/integration/test_actions_queue_consumer.py
@@ -17,11 +17,10 @@ from __future__ import absolute_import
 import random
 import eventlet
 
-from kombu import Exchange
-from kombu import Queue
 from unittest import TestCase
 
 from st2common.transport.consumers import ActionsQueueConsumer
+from st2common.transport.kombu import Exchange, Queue
 from st2common.transport.publishers import PoolPublisher
 from st2common.transport import utils as transport_utils
 from st2common.models.db.liveaction import LiveActionDB
@@ -35,7 +34,7 @@ class ActionsQueueConsumerTestCase(TestCase):
 
     def test_stop_consumption_on_shutdown(self):
         exchange = Exchange("st2.execution.test", type="topic")
-        queue_name = "test-" + str(random.randint(1, 10000))
+        queue_name = f"st2.test-{random.randint(1, 10000)}"
         queue = Queue(
             name=queue_name, exchange=exchange, routing_key="#", auto_delete=True
         )

--- a/st2common/benchmarks/micro/test_publisher_compression.py
+++ b/st2common/benchmarks/micro/test_publisher_compression.py
@@ -16,7 +16,6 @@ from st2common.util.monkey_patch import monkey_patch
 
 monkey_patch()
 
-from kombu import Exchange
 from kombu.serialization import pickle
 
 import os
@@ -27,6 +26,7 @@ import zstandard as zstd
 
 from st2common.models.db.liveaction import LiveActionDB
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange
 
 from common import FIXTURES_DIR
 from common import PYTEST_FIXTURE_FILE_PARAM_DECORATOR

--- a/st2common/st2common/config.py
+++ b/st2common/st2common/config.py
@@ -404,6 +404,11 @@ def register_opts(ignore_errors=False):
             help="Compression algorithm to use for compressing the payloads which are sent over "
             "the message bus. Defaults to no compression.",
         ),
+        cfg.StrOpt(
+            "prefix",
+            default="st2",
+            help="Prefix for all exchange and queue names.",
+        ),
     ]
 
     do_register_opts(messaging_opts, "messaging", ignore_errors)

--- a/st2common/st2common/transport/actionalias.py
+++ b/st2common/st2common/transport/actionalias.py
@@ -15,8 +15,9 @@
 # All Exchanges and Queues related to liveaction.
 
 from __future__ import absolute_import
-from kombu import Exchange, Queue
+
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = [
     "ActionAliasPublisher",

--- a/st2common/st2common/transport/actionexecutionstate.py
+++ b/st2common/st2common/transport/actionexecutionstate.py
@@ -17,9 +17,8 @@
 
 from __future__ import absolute_import
 
-from kombu import Exchange, Queue
-
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = ["ActionExecutionStatePublisher"]
 

--- a/st2common/st2common/transport/announcement.py
+++ b/st2common/st2common/transport/announcement.py
@@ -15,12 +15,11 @@
 
 from __future__ import absolute_import
 
-from kombu import Exchange, Queue
-
 from st2common import log as logging
 from st2common.constants.trace import TRACE_CONTEXT
 from st2common.models.api.trace import TraceContext
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = ["AnnouncementPublisher", "AnnouncementDispatcher", "get_queue"]
 

--- a/st2common/st2common/transport/bootstrap_utils.py
+++ b/st2common/st2common/transport/bootstrap_utils.py
@@ -31,7 +31,7 @@ from st2common.transport.actionalias import ACTIONALIAS_XCHG
 from st2common.transport.actionexecutionstate import ACTIONEXECUTIONSTATE_XCHG
 from st2common.transport.announcement import ANNOUNCEMENT_XCHG
 from st2common.transport.connection_retry_wrapper import ConnectionRetryWrapper
-from st2common.transport.execution import EXECUTION_XCHG
+from st2common.transport.execution import EXECUTION_XCHG, EXECUTION_OUTPUT_XCHG
 from st2common.transport.liveaction import LIVEACTION_XCHG, LIVEACTION_STATUS_MGMT_XCHG
 from st2common.transport.reactor import SENSOR_CUD_XCHG
 from st2common.transport.reactor import TRIGGER_CUD_XCHG, TRIGGER_INSTANCE_XCHG
@@ -67,6 +67,7 @@ EXCHANGES = [
     ACTIONEXECUTIONSTATE_XCHG,
     ANNOUNCEMENT_XCHG,
     EXECUTION_XCHG,
+    EXECUTION_OUTPUT_XCHG,
     LIVEACTION_XCHG,
     LIVEACTION_STATUS_MGMT_XCHG,
     TRIGGER_CUD_XCHG,

--- a/st2common/st2common/transport/execution.py
+++ b/st2common/st2common/transport/execution.py
@@ -16,8 +16,9 @@
 # All Exchanges and Queues related to liveaction.
 
 from __future__ import absolute_import
-from kombu import Exchange, Queue
+
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = [
     "ActionExecutionPublisher",

--- a/st2common/st2common/transport/kombu.py
+++ b/st2common/st2common/transport/kombu.py
@@ -1,0 +1,36 @@
+# Copyright 2024 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import kombu
+from oslo_config import cfg
+
+
+class Exchange(kombu.Exchange):
+    def __call__(self, *args, **kwargs):
+        # update exchange name with prefix just before binding (as late as possible).
+        prefix = cfg.CONF.messaging.prefix
+        if self.name and prefix != "st2":
+            self.name = self.name.replace("st2.", f"{prefix}.", 1)
+        return super().__call__(*args, **kwargs)
+
+
+class Queue(kombu.Queue):
+    def __call__(self, *args, **kwargs):
+        # update queue name with prefix just before binding (as late as possible).
+        prefix = cfg.CONF.messaging.prefix
+        if self.name and prefix != "st2":
+            self.name = self.name.replace("st2.", f"{prefix}.", 1)
+        return super().__call__(*args, **kwargs)

--- a/st2common/st2common/transport/liveaction.py
+++ b/st2common/st2common/transport/liveaction.py
@@ -17,9 +17,8 @@
 
 from __future__ import absolute_import
 
-from kombu import Exchange, Queue
-
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = ["LiveActionPublisher", "get_queue", "get_status_management_queue"]
 

--- a/st2common/st2common/transport/publishers.py
+++ b/st2common/st2common/transport/publishers.py
@@ -71,10 +71,11 @@ class PoolPublisher(object):
                     # completely invalidating this ConnectionPool. Also, a ConnectionPool for
                     # producer does not really solve any problems for us so better to create a
                     # Producer for each publish.
-                    producer = Producer(channel)
+                    # passing exchange to Producer __init__ allows auto_declare to declare
+                    # anything that's missing (especially useful for tests).
+                    producer = Producer(channel, exchange=exchange)
                     kwargs = {
                         "body": payload,
-                        "exchange": exchange,
                         "routing_key": routing_key,
                         "serializer": "pickle",
                         "compression": compression,

--- a/st2common/st2common/transport/queues.py
+++ b/st2common/st2common/transport/queues.py
@@ -22,8 +22,6 @@ encountering cylic import issues.
 
 from __future__ import absolute_import
 
-from kombu import Queue
-
 from st2common.constants import action as action_constants
 from st2common.transport import actionalias
 from st2common.transport import actionexecutionstate
@@ -33,6 +31,7 @@ from st2common.transport import liveaction
 from st2common.transport import publishers
 from st2common.transport import reactor
 from st2common.transport import workflow
+from st2common.transport.kombu import Queue
 
 __all__ = [
     "ACTIONSCHEDULER_REQUEST_QUEUE",

--- a/st2common/st2common/transport/reactor.py
+++ b/st2common/st2common/transport/reactor.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from kombu import Exchange, Queue
 
 from st2common import log as logging
 from st2common.constants.trace import TRACE_CONTEXT
 from st2common.models.api.trace import TraceContext
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = [
     "TriggerCUDPublisher",

--- a/st2common/st2common/transport/workflow.py
+++ b/st2common/st2common/transport/workflow.py
@@ -17,16 +17,13 @@
 
 from __future__ import absolute_import
 
-import kombu
-
 from st2common.transport import publishers
+from st2common.transport.kombu import Exchange, Queue
 
 __all__ = ["WorkflowExecutionPublisher", "get_queue", "get_status_management_queue"]
 
-WORKFLOW_EXECUTION_XCHG = kombu.Exchange("st2.workflow", type="topic")
-WORKFLOW_EXECUTION_STATUS_MGMT_XCHG = kombu.Exchange(
-    "st2.workflow.status", type="topic"
-)
+WORKFLOW_EXECUTION_XCHG = Exchange("st2.workflow", type="topic")
+WORKFLOW_EXECUTION_STATUS_MGMT_XCHG = Exchange("st2.workflow.status", type="topic")
 
 
 class WorkflowExecutionPublisher(
@@ -40,10 +37,8 @@ class WorkflowExecutionPublisher(
 
 
 def get_queue(name, routing_key):
-    return kombu.Queue(name, WORKFLOW_EXECUTION_XCHG, routing_key=routing_key)
+    return Queue(name, WORKFLOW_EXECUTION_XCHG, routing_key=routing_key)
 
 
 def get_status_management_queue(name, routing_key):
-    return kombu.Queue(
-        name, WORKFLOW_EXECUTION_STATUS_MGMT_XCHG, routing_key=routing_key
-    )
+    return Queue(name, WORKFLOW_EXECUTION_STATUS_MGMT_XCHG, routing_key=routing_key)

--- a/st2common/st2common/util/queues.py
+++ b/st2common/st2common/util/queues.py
@@ -47,7 +47,7 @@ def get_queue_name(queue_name_base, queue_name_suffix, add_random_uuid_to_suffix
         # might cause issues in RabbitMQ.
         u_hex = uuid.uuid4().hex
         uuid_suffix = uuid.uuid4().hex[len(u_hex) - 10 :]
-        queue_suffix = "%s-%s" % (queue_name_suffix, uuid_suffix)
+        queue_suffix = f"{queue_name_suffix}-{uuid_suffix}"
 
-    queue_name = "%s.%s" % (queue_name_base, queue_suffix)
+    queue_name = f"{queue_name_base}.{queue_suffix}"
     return queue_name

--- a/st2common/tests/unit/test_queue_consumer.py
+++ b/st2common/tests/unit/test_queue_consumer.py
@@ -23,6 +23,7 @@ from st2tests.base import DbTestCase
 from tests.unit.base import FakeModelDB
 
 
+# AMQP connection is mocked, so these do not need messaging.prefix
 FAKE_XCHG = Exchange("st2.tests", type="topic")
 FAKE_WORK_Q = Queue("st2.tests.unit", FAKE_XCHG)
 

--- a/st2common/tests/unit/test_state_publisher.py
+++ b/st2common/tests/unit/test_state_publisher.py
@@ -31,6 +31,7 @@ from st2common.transport import publishers
 from st2tests import DbTestCase
 
 
+# PoolPublisher is mocked, so this does not need messaging.prefix
 FAKE_STATE_MGMT_XCHG = kombu.Exchange("st2.fake.state", type="topic")
 
 

--- a/st2common/tests/unit/test_transport.py
+++ b/st2common/tests/unit/test_transport.py
@@ -25,13 +25,12 @@ import eventlet
 
 from bson.objectid import ObjectId
 from kombu.mixins import ConsumerMixin
-from kombu import Exchange
-from kombu import Queue
 from oslo_config import cfg
 
 from st2common.transport.publishers import PoolPublisher
 from st2common.transport.utils import _get_ssl_kwargs
 from st2common.transport import utils as transport_utils
+from st2common.transport.kombu import Exchange, Queue
 from st2common.models.db.liveaction import LiveActionDB
 
 __all__ = ["TransportUtilsTestCase"]
@@ -69,7 +68,7 @@ class TransportUtilsTestCase(unittest.TestCase):
         live_action_db.result = {"foo": "bar"}
 
         exchange = Exchange("st2.execution.test", type="topic")
-        queue_name = "test-" + str(random.randint(1, 10000))
+        queue_name = f"st2.test-{random.randint(1, 10000)}"
         queue = Queue(
             name=queue_name, exchange=exchange, routing_key="#", auto_delete=True
         )

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -66,6 +66,7 @@ def _setup_config_opts(coordinator_noop=True):
 
 def _override_config_opts(coordinator_noop=False):
     _override_db_opts()
+    _override_mq_opts()
     _override_common_opts()
     _override_api_opts()
     _override_keyvalue_opts()
@@ -107,8 +108,18 @@ def db_opts_as_env_vars() -> Dict[str, str]:
     return env
 
 
+def _override_mq_opts():
+    mq_prefix = CONF.messaging.prefix
+    mq_prefix = "st2test" if mq_prefix == "st2" else mq_prefix
+    mq_prefix = mq_prefix + os.environ.get("ST2TESTS_PARALLEL_SLOT", "")
+    CONF.set_override(name="prefix", override=mq_prefix, group="messaging")
+
+
 def mq_opts_as_env_vars() -> Dict[str, str]:
-    return {"ST2_MESSAGING__URL": CONF.messaging.url}
+    return {
+        "ST2_MESSAGING__URL": CONF.messaging.url,
+        "ST2_MESSAGING__PREFIX": CONF.messaging.prefix,
+    }
 
 
 def _override_common_opts():
@@ -268,6 +279,11 @@ def _register_api_opts():
             "login_method",
             default=None,
             help="Login method to use (AMQPLAIN, PLAIN, EXTERNAL, etc.).",
+        ),
+        cfg.StrOpt(
+            "prefix",
+            default="st2",
+            help="Prefix for all exchange and queue names.",
         ),
     ]
 


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

## Overview

This adds a new option `[messaging].prefix` to configure the prefix used in RabbitMQ exchange and queue names.

Examples of how this affects our exchange/queue names:

| `prefix=st2` (default) | `prefix=st2dev` (launchdev.sh) | `prefix=foobar`        | **Type** |
|------------------------|--------------------------------|------------------------|----------|
| `st2.execution`        | `st2dev.execution`             | `foobar.execution`     | Exchange |
| `st2.sensor`           | `st2.sensor`                   | `foobar.sensor`        | Exchange |
| `st2.workflow.work`    | `st2dev.workflow.work`         | `foobar.workflow.work` | Queue    |

I recommend reviewing each commit separately.

## Purpose

This is primarily designed to support safely running tests in parallel.

## Implementation

This is where the `[messaging].prefix` option is defined with a default of `st2` to keep the current behavior (There is an analogous definition in `st2tests/st2tests/config.py`):

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/st2common/st2common/config.py#L407-L414

Until a `kombu.Exchange` or a `kombu.Queue` is declared, the exchange/queue objects just hold the config (including the name) required to declare it. When kombu declares an exchange/queue, it calls the instance in something like this:

```python
# in st2 code
FOOBAR_XCHG = Exchange("foobar")

# in kombu
FOOBAR_XCHG(*args, **kwargs)
```

ST2 exchanges/queues are mostly defined as module-level vars, which is fine since they merely collect the name and other declaration details. So, this is where we create a subclass that applies the prefix just before an exchange or queue gets declared:

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/st2common/st2common/transport/kombu.py#L21-L36

Then, I just had to swap the imports from `kombu.Exchange` and `kombu.Queue` to the new subclasses.

This is where the tests use the `ST2TESTS_PARALLEL_SLOT` env var (provided by pants when running tests) is used to modify the default prefix used in tests:

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/st2tests/st2tests/config.py#L111-L115

This method is what passes that config to integration test subprocesses using the new oslo_config env var support (similar to how the database test logic added in #6278 using the oslo_config env var support added in #6277).

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/st2tests/st2tests/config.py#L118-L122

Similar to #6278, we also configure pants to pass these vars to tests, updating `pants-plugins/uses_services` to advertise this in the error message that shows when attempting to run tests without a running rabbitmq-server.

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/pants.toml#L250-L252

Finally, the kombu exchange names are also used in event streaming. Event streaming clients should use the well-known exchange names and not be aware of any configured prefix. So, we revert the prefix to `st2.` for event streaming here:

https://github.com/StackStorm/st2/blob/b6d23c9c20d2d91ce1c3f4bc9a783a81dc49633f/st2common/st2common/stream/listener.py#L60-L69

## Alternatives

To prevent parallel tests from interacting with each other, I tried using RabbitMQ vhosts before settling on a configurable exchange/queue name prefix. Creating a `vhost`, however, requires out-of-band administration to create it. This is because vhost creation is not part of AMQP; Instead, it is part of the CLI and Management APIs of RabbitMQ. So, before running tests, the dev would have to run some kind of script (which we would have to maintain) that calculates how many tests might run in parallel and create a vhost for each parallel slot. At first glance, this would seem be limited by the number of CPU cores on the dev machine, but pants also supports remote execution to offload test runs to some Remote Executors which defaults to 128 slots. Creating 12 + 128 vhosts seems like quite a maintenance burden just to run tests.

Once I determined that vhost was not a great option, I tried several different ways to make the exchange/queue name prefix configurable. But, each of them left some tests failing because the exchanges/queues were not pre-declared when the test ran. 
1. First, I tried to just load the config from the global `oslo_config.cfg.CONF`, but most of our exchanges/queues are defined as module-level variables meaning they get imported before the oslo_config has been configured with options and before reading the conf file(s).
2. Then, I tried to apply the prefix just before the exchanges/queues get declared in the service startup code. But, sensors and actionrunners use subprocesses that do not explicitly pre-declare the exchange/queue they need (The parent process would have already done that--So why should they?).
3. Finally, I landed on letting kombu auto-declare exchanges/queues as needed and creating subclasses of `kombu.Exchange` and `kombu.Queue` that handle applying the configured prefix just before it's declared.