### PR TITLE
Make tests safer to run in parallel by changing the Redis key namespace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,7 +69,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278
+  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6283
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/conf/st2.dev.conf
+++ b/conf/st2.dev.conf
@@ -87,7 +87,7 @@ protocol = udp
 # / cross server functionality
 #url = redis://localhost
 #url = kazoo://localhost
-url = redis://127.0.0.1:6379
+url = redis://127.0.0.1:6379?namespace=_st2_dev
 
 [webui]
 # webui_base_url = https://mywebhost.domain

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -72,6 +72,7 @@ tooz==6.3.0
 # lockfiles/st2.lock has pip==24.2 wheel==0.44.0 setuptools==75.2.0
 virtualenv==20.27.0
 webob==1.8.9
+webtest==3.0.1
 zake==0.2.2
 # test requirements below
 bcrypt==4.2.0

--- a/pants-plugins/uses_services/redis_rules.py
+++ b/pants-plugins/uses_services/redis_rules.py
@@ -63,7 +63,7 @@ class UsesRedisRequest:
 
     @property
     def coord_url(self) -> str:
-        return f"redis://{self.host}:{self.port}"
+        return f"redis://{self.host}:{self.port}?namespace=_st2_test"
 
 
 @dataclass(frozen=True)

--- a/pants-plugins/uses_services/redis_rules_test.py
+++ b/pants-plugins/uses_services/redis_rules_test.py
@@ -51,7 +51,14 @@ def run_redis_is_running(
             "--backend-packages=uses_services",
             *(extra_args or ()),
         ],
-        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+        env_inherit={
+            "PATH",
+            "PYENV_ROOT",
+            "HOME",
+            "ST2TESTS_REDIS_HOST",
+            "ST2TESTS_REDIS_PORT",
+            "ST2TESTS_PARALLEL_SLOT",
+        },
     )
     result = rule_runner.request(
         RedisIsRunning,
@@ -62,7 +69,7 @@ def run_redis_is_running(
 
 # Warning this requires that redis be running
 def test_redis_is_running(rule_runner: RuleRunner) -> None:
-    request = UsesRedisRequest()
+    request = UsesRedisRequest.from_env(env=rule_runner.environment)
     mock_platform = platform(os="TestMock")
 
     # we are asserting that this does not raise an exception
@@ -74,7 +81,7 @@ def test_redis_is_running(rule_runner: RuleRunner) -> None:
 def test_redis_not_running(rule_runner: RuleRunner, mock_platform: Platform) -> None:
     request = UsesRedisRequest(
         host="127.100.20.7",
-        port="10",  # 10 is an unassigned port, unlikely to be used
+        port=10,  # 10 is an unassigned port, unlikely to be used
     )
 
     with pytest.raises(ExecutionError) as exception_info:

--- a/pants-plugins/uses_services/scripts/is_redis_running.py
+++ b/pants-plugins/uses_services/scripts/is_redis_running.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     # unit tests do not use redis, they use use an in-memory coordinator: "zake://"
     # integration tests use this url with a conf file derived from conf/st2.dev.conf
-    coord_url = args.get(1, "redis://127.0.0.1:6379")
+    coord_url = args.get(1, "redis://127.0.0.1:6379?namespace=_st2_test")
 
     is_running = _is_redis_running(coord_url)
     exit_code = 0 if is_running else 1

--- a/pants-plugins/uses_services/scripts/is_redis_running.py
+++ b/pants-plugins/uses_services/scripts/is_redis_running.py
@@ -39,8 +39,8 @@ def _is_redis_running(coord_url: str) -> bool:
 if __name__ == "__main__":
     args = dict((k, v) for k, v in enumerate(sys.argv))
 
-    # unit tests do not use redis, they use use an in-memory coordinator: "zake://"
-    # integration tests use this url with a conf file derived from conf/st2.dev.conf
+    # unit and integration tests require a coordinator, and mostly use this redis url.
+    # In some cases, unit tests can also use an in-memory coordinator: "zake://"
     coord_url = args.get(1, "redis://127.0.0.1:6379?namespace=_st2_test")
 
     is_running = _is_redis_running(coord_url)

--- a/pants.toml
+++ b/pants.toml
@@ -240,6 +240,7 @@ extra_env_vars = [
   # Use this so that the test system does not require the stanley user.
   # For example: export ST2TESTS_SYSTEM_USER=${USER}
   "ST2TESTS_SYSTEM_USER",
+  "ST2_SYSTEM_USER__USER",
   # Use these to override MongoDB connection details
   # "ST2_DATABASE__HOST", # Tests override this with "127.0.0.1"
   "ST2_DATABASE__PORT",
@@ -247,9 +248,12 @@ extra_env_vars = [
   "ST2_DATABASE__CONNECTION_TIMEOUT",
   "ST2_DATABASE__USERNAME",
   "ST2_DATABASE__PASSWORD",
-  # Use these to override the redis host and port
+  # Use these to override Redis connection details
   "ST2TESTS_REDIS_HOST",
   "ST2TESTS_REDIS_PORT",
+  # "ST2_COORDINATION__URL", # Tests will override this with one of:
+  #         "redis://{ST2TESTS_REDIS_HOST}:{ST2TESTS_REDIS_PORT}?namespace=_st2_test{ST2TESTS_PARALLEL_SLOT}
+  #         "zake://"
 ]
 # 10 min should be more than enough even for integration tests.
 timeout_default = 600 # seconds

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ tooz==6.3.0
 typing-extensions==4.12.2
 unittest2
 webob==1.8.9
-webtest
+webtest==3.0.1
 zake==0.2.2
 zipp==3.20.2
 zstandard==0.23.0

--- a/st2tests/requirements.txt
+++ b/st2tests/requirements.txt
@@ -14,4 +14,4 @@ psutil==6.1.0
 pyrabbit
 rednose
 unittest2
-webtest
+webtest==3.0.1

--- a/st2tests/st2tests/config.py
+++ b/st2tests/st2tests/config.py
@@ -163,7 +163,9 @@ def _override_coordinator_opts(noop=False):
     redis_host = os.environ.get("ST2TESTS_REDIS_HOST", False)
     if redis_host:
         redis_port = os.environ.get("ST2TESTS_REDIS_PORT", "6379")
-        driver = f"redis://{redis_host}:{redis_port}"
+        # namespace= is the tooz redis driver's key prefix (default is "_tooz")
+        namespace = f"_st2_test{os.environ.get('ST2TESTS_PARALLEL_SLOT', '')}"
+        driver = f"redis://{redis_host}:{redis_port}?namespace={namespace}"
 
     CONF.set_override(name="url", override=driver, group="coordination")
     CONF.set_override(name="lock_timeout", override=1, group="coordination")

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -134,13 +134,14 @@ function init()
     if [ -z "$ST2_CONF" ]; then
         ST2_CONF=${ST2_REPO}/conf/st2.dev.conf
     fi
-    # The ST2TESTS_* vars are only for tests. ST2_* overrides the conf var directly.
+    # ST2_* vars directly override conf vars using oslo_config's env var feature.
+    # The ST2TESTS_* vars are only for tests, and take precedence over ST2_* vars.
     if [ -n "${ST2TESTS_SYSTEM_USER}" ]; then
-        export ST2_SYSTEM_USER__USER="${ST2_SYSTEM_USER__USER:-${ST2TESTS_SYSTEM_USER}}"
+        export ST2_SYSTEM_USER__USER="${ST2TESTS_SYSTEM_USER}"
         ST2VARS+=("ST2_SYSTEM_USER__USER")
     fi
     if [ -n "${ST2TESTS_REDIS_HOST}" ] && [ -n "${ST2TESTS_REDIS_PORT}"]; then
-        export ST2_COORDINATION__URL="${ST2_COORDINATION__URL:-redis://${ST2TESTS_REDIS_HOST}:${ST2TESTS_REDIS_PORT}}?namespace=_st2_dev"
+        export ST2_COORDINATION__URL="redis://${ST2TESTS_REDIS_HOST}:${ST2TESTS_REDIS_PORT}?namespace=_st2_dev"
         ST2VARS+=("ST2_COORDINATION__URL")
     fi
 

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -140,7 +140,7 @@ function init()
         ST2VARS+=("ST2_SYSTEM_USER__USER")
     fi
     if [ -n "${ST2TESTS_REDIS_HOST}" ] && [ -n "${ST2TESTS_REDIS_PORT}"]; then
-        export ST2_COORDINATION__URL="${ST2_COORDINATION__URL:-redis://${ST2TESTS_REDIS_HOST}:${ST2TESTS_REDIS_PORT}}"
+        export ST2_COORDINATION__URL="${ST2_COORDINATION__URL:-redis://${ST2TESTS_REDIS_HOST}:${ST2TESTS_REDIS_PORT}}?namespace=_st2_dev"
         ST2VARS+=("ST2_COORDINATION__URL")
     fi
 

--- a/tools/launchdev.sh
+++ b/tools/launchdev.sh
@@ -97,6 +97,9 @@ function eecho()
 function init()
 {
     heading "Initialising system variables ..."
+    # Capture list of exported vars before adding any others
+    ST2VARS=(${!ST2_@})
+
     ST2_BASE_DIR="/opt/stackstorm"
     COMMAND_PATH=${0%/*}
     CURRENT_DIR=$(pwd)
@@ -130,6 +133,15 @@ function init()
 
     if [ -z "$ST2_CONF" ]; then
         ST2_CONF=${ST2_REPO}/conf/st2.dev.conf
+    fi
+    # The ST2TESTS_* vars are only for tests. ST2_* overrides the conf var directly.
+    if [ -n "${ST2TESTS_SYSTEM_USER}" ]; then
+        export ST2_SYSTEM_USER__USER="${ST2_SYSTEM_USER__USER:-${ST2TESTS_SYSTEM_USER}}"
+        ST2VARS+=("ST2_SYSTEM_USER__USER")
+    fi
+    if [ -n "${ST2TESTS_REDIS_HOST}" ] && [ -n "${ST2TESTS_REDIS_PORT}"]; then
+        export ST2_COORDINATION__URL="${ST2_COORDINATION__URL:-redis://${ST2TESTS_REDIS_HOST}:${ST2TESTS_REDIS_PORT}}"
+        ST2VARS+=("ST2_COORDINATION__URL")
     fi
 
     ST2_CONF=$(readlink -f ${ST2_CONF})
@@ -237,6 +249,9 @@ function st2start()
     done
 
     local PRE_SCRIPT_VARS=()
+    for var_name in "${ST2VARS[@]}"; do
+      PRE_SCRIPT_VARS+=("${var_name}=${!var_name}")
+    done
     PRE_SCRIPT_VARS+=("ST2_CONFIG_PATH=${ST2_CONF}")
 
     # PRE_SCRIPT should not end with ';' so that using it is clear.


### PR DESCRIPTION
This PR's commits were extracted from #6273 where I'm working on getting pants+pytest to run integration tests.

When running tests in parallel, the keys stored in redis for one test can mess up the expected redis keys needed by a different test. The community edition of redis has 16 logical databases, but if someone has more cores than that or uses pants remote test execution (with a default of 128 possible remote executors running in parallel), then 16 is not enough.

It turns out, the tooz redis driver already has a config option to support this: `namespace`. By default, the tooz driver uses `_tooz` as the key namespace. We can change that by passing a `namespace` query param in `[coordination].url`.

So, I updated the tests config to change the namespace using the pants-provided `ST2TESTS_PARLLEL_SLOT` env var here (building on the `ST2TESTS_REDIS_*` env vars added in #6245):

https://github.com/StackStorm/st2/blob/c394a52bb0e52fe4d15e53bccd062a29dfe51215/st2tests/st2tests/config.py#L160-L168

I updated `tools/launchdev.sh` to respect `ST2_*` env vars (the oslo_config env vars added in #6277) and the `ST2TESTS_*` env vars (This builds on the refactor from #6276 to make it simpler to update the command used to run each service):

https://github.com/StackStorm/st2/blob/c394a52bb0e52fe4d15e53bccd062a29dfe51215/tools/launchdev.sh#L137-L146

The redis namespace for `tools/launchdev.sh` is defined in `st2.dev.conf` here:

https://github.com/StackStorm/st2/blob/c394a52bb0e52fe4d15e53bccd062a29dfe51215/conf/st2.dev.conf#L90

I updated `pants-plugins/uses_services` to use the new env vars as well, following the patterns established in #6278. `pants.toml` did not need any additional vars, since it already has the `ST2TESTS_REDIS_*` env  vars:

https://github.com/StackStorm/st2/blob/c394a52bb0e52fe4d15e53bccd062a29dfe51215/pants.toml#L251-L256

I did, however, add `ST2_SYSTEM_USER__USER` to `[tests].extra_env_vars` in `pants.toml` here:

https://github.com/StackStorm/st2/blob/c394a52bb0e52fe4d15e53bccd062a29dfe51215/pants.toml#L240-L243