### PR TITLE
pin urllib3 to version in lockfiles/st2.lock

### DIFF
--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -53,6 +53,8 @@ pywinrm==0.5.0
 pyyaml==6.0.2
 redis==5.2.1
 requests==2.32.3
+# urllib3 is a transitive dep
+urllib3==2.2.3
 retrying==1.3.4
 routes==2.5.1
 semver==3.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ stevedore==5.3.0
 tenacity==9.0.0
 tooz==6.3.0
 typing-extensions==4.12.2
+urllib3==2.2.3
 webob==1.8.9
 webtest==3.0.1
 zake==0.2.2

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -8,6 +8,8 @@ oslo.config
 oslo.utils
 pyparsing
 requests
+# urllib3 is a transitive dep
+urllib3
 six
 pyyaml
 python-json-logger

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -23,3 +23,4 @@ python-json-logger
 pyyaml==6.0.2
 requests==2.32.3
 six==1.17.0
+urllib3==2.2.3

--- a/st2client/in-requirements.txt
+++ b/st2client/in-requirements.txt
@@ -10,6 +10,8 @@ pyyaml
 jsonschema
 jsonpath-rw
 requests
+# urllib3 is a transitive dep
+urllib3
 six
 sseclient-py
 editor

--- a/st2client/requirements.txt
+++ b/st2client/requirements.txt
@@ -26,4 +26,5 @@ requests==2.32.3
 six==1.17.0
 sseclient-py==1.8.0
 typing-extensions==4.12.2
+urllib3==2.2.3
 zipp==3.20.2

--- a/st2common/in-requirements.txt
+++ b/st2common/in-requirements.txt
@@ -24,6 +24,8 @@ zstandard
 cffi
 cryptography
 requests
+# urllib3 is a transitive dep
+urllib3
 retrying
 semver
 six

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -44,6 +44,7 @@ six==1.17.0
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 tenacity==9.0.0
 tooz==6.3.0
+urllib3==2.2.3
 webob==1.8.9
 zake==0.2.2
 zstandard==0.23.0


### PR DESCRIPTION
Fix the lint CI job failure caused by a new version of urllib3 that does not support python 3.8. This is a transitive dep, so I just copied the locked version from `lockfiles/st2.lock` into our requirements files. I added it to any `in-requirements.txt` that included `requests`.