### PR TITLE
Copy dependency on st2-auth-backend-pam from st2-packages.git

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,6 +65,7 @@ target(
     dependencies=[
         "//:reqs#st2-auth-backend-flat-file",
         "//:reqs#st2-auth-ldap",
+        "//:reqs#st2-auth-backend-pam",
     ],
 )
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -78,7 +78,7 @@ Added
   working on StackStorm, improve our security posture, and improve CI reliability thanks in part
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
-  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287
+  #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/conf/st2.conf.sample
+++ b/conf/st2.conf.sample
@@ -84,7 +84,7 @@ token_ttl = 86400
 # Standalone mode options - options below only apply when auth service is running in the standalone
 # mode.
 
-# Authentication backend to use in a standalone mode. Available backends: flat_file, ldap.
+# Authentication backend to use in a standalone mode. Available backends: flat_file, ldap, pam.
 backend = flat_file
 # JSON serialized arguments which are passed to the authentication backend in a standalone mode.
 backend_kwargs = None

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -28,7 +28,7 @@ lockfile==0.12.2
 mongoengine==0.29.1
 networkx==3.1
 # jsonpath-rw is the only thing that depends on decorator (a transitive dep)
-decorator==5.1.1
+decorator==5.2.1
 # 202403: Bump oslo.config for py3.10 support.
 oslo.config==9.6.0
 oslo.utils==7.3.0
@@ -80,7 +80,7 @@ bcrypt==4.2.1
 jinja2==3.1.5
 mock==5.1.0
 pytest==7.0.1
-psutil==6.1.1
+psutil==7.0.0
 python-dateutil==2.9.0.post0
 python-statsd==2.1.0
 orjson==3.10.15

--- a/lockfiles/st2.lock
+++ b/lockfiles/st2.lock
@@ -71,6 +71,7 @@
 //     "six",
 //     "sseclient-py",
 //     "st2-auth-backend-flat-file",
+//     "st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master",
 //     "st2-auth-ldap@ git+https://github.com/StackStorm/st2-auth-ldap.git@master",
 //     "st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master",
 //     "stevedore",
@@ -1507,19 +1508,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186",
-              "url": "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl"
+              "hash": "d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a",
+              "url": "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
-              "url": "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz"
+              "hash": "65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360",
+              "url": "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz"
             }
           ],
           "project_name": "decorator",
           "requires_dists": [],
-          "requires_python": ">=3.5",
-          "version": "5.1.1"
+          "requires_python": ">=3.8",
+          "version": "5.2.1"
         },
         {
           "artifacts": [
@@ -3634,39 +3635,39 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3",
-              "url": "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993",
+              "url": "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377",
-              "url": "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl"
+              "hash": "39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da",
+              "url": "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003",
-              "url": "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456",
+              "url": "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5",
-              "url": "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz"
+              "hash": "1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91",
+              "url": "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8",
-              "url": "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl"
+              "hash": "4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34",
+              "url": "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160",
-              "url": "https://files.pythonhosted.org/packages/9c/39/0f88a830a1c8a3aba27fededc642da37613c57cbff143412e3536f89784f/psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25",
+              "url": "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "psutil",
           "requires_dists": [
             "abi3audit; extra == \"dev\"",
-            "black; extra == \"dev\"",
+            "black==24.10.0; extra == \"dev\"",
             "check-manifest; extra == \"dev\"",
             "coverage; extra == \"dev\"",
             "packaging; extra == \"dev\"",
@@ -3674,11 +3675,14 @@
             "pyperf; extra == \"dev\"",
             "pypinfo; extra == \"dev\"",
             "pytest-cov; extra == \"dev\"",
+            "pytest-xdist; extra == \"dev\"",
             "pytest-xdist; extra == \"test\"",
+            "pytest; extra == \"dev\"",
             "pytest; extra == \"test\"",
             "requests; extra == \"dev\"",
             "rstcheck; extra == \"dev\"",
             "ruff; extra == \"dev\"",
+            "setuptools; extra == \"dev\"",
             "setuptools; extra == \"test\"",
             "sphinx-rtd-theme; extra == \"dev\"",
             "sphinx; extra == \"dev\"",
@@ -3688,8 +3692,8 @@
             "vulture; extra == \"dev\"",
             "wheel; extra == \"dev\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "6.1.1"
+          "requires_python": ">=3.6",
+          "version": "7.0.0"
         },
         {
           "artifacts": [
@@ -5273,239 +5277,239 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "49cc4c7b940d43bd12bf87ec63f28cbc4964fc4e12c031cc8cd01650f43eb94e",
-              "url": "https://files.pythonhosted.org/packages/0d/e7/f9fafbd4f39793a20cc52e77bbd766f7384312526d402c382928dc7667f6/simplejson-3.19.3-py3-none-any.whl"
+              "hash": "8a6c1bbac39fa4a79f83cbf1df6ccd8ff7069582a9fd8db1e52cea073bc2c697",
+              "url": "https://files.pythonhosted.org/packages/4b/30/00f02a0a921556dd5a6db1ef2926a1bc7a8bbbfb1c49cfed68a275b8ab2b/simplejson-3.20.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e0d2b00ecbcd1a3c5ea1abc8bb99a26508f758c1759fd01c3be482a3655a176f",
-              "url": "https://files.pythonhosted.org/packages/01/40/ff5cae1b4ff35c7822456ad7d098371d697479d418194064b8aff8142d70/simplejson-3.19.3-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "6e18345c8dda5d699be8166b61f9d80aaee4545b709f1363f60813dc032dac53",
+              "url": "https://files.pythonhosted.org/packages/09/68/1e81ed83f38906c8859f2b973afb19302357d6003e724a6105cee0f61ec7/simplejson-3.20.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0d5a63f1768fed7e78cf55712dee81f5a345e34d34224f3507ebf71df2b754d",
-              "url": "https://files.pythonhosted.org/packages/06/25/73d515708d8ae04ecaf67451b7d55ae7391ef2b18789387c10219c66eec9/simplejson-3.19.3-cp38-cp38-musllinux_1_2_ppc64le.whl"
+              "hash": "4a586ce4f78cec11f22fe55c5bee0f067e803aab9bad3441afe2181693b5ebb5",
+              "url": "https://files.pythonhosted.org/packages/15/ca/56a6a2a33cbcf330c4d71af3f827c47e4e0ba791e78f2642f3d1ab02ff31/simplejson-3.20.1-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eed8cd98a7b24861da9d3d937f5fbfb6657350c547528a117297fe49e3960667",
-              "url": "https://files.pythonhosted.org/packages/08/15/8b4e1a8c7729b37797d0eab1381f517f928bd323d17efa7f4414c3565e1f/simplejson-3.19.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "eea7e2b7d858f6fdfbf0fe3cb846d6bd8a45446865bc09960e51f3d473c2271b",
+              "url": "https://files.pythonhosted.org/packages/21/47/50157810876c2a7ebbd6e6346ec25eda841fe061fecaa02538a7742a3d2a/simplejson-3.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b5c472099b39b274dcde27f1113db8d818c9aa3ba8f78cbb8ad04a4c1ac2118",
-              "url": "https://files.pythonhosted.org/packages/0f/55/d3da33ee3e708133da079b9d537693d7fef281e6f0d27921cc7e5b3ec523/simplejson-3.19.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+              "hash": "e580aa65d5f6c3bf41b9b4afe74be5d5ddba9576701c107c772d936ea2b5043a",
+              "url": "https://files.pythonhosted.org/packages/25/c4/627214fb418cd4a17fb0230ff0b6c3bb4a85cbb48dd69c85dcc3b85df828/simplejson-3.20.1-cp310-cp310-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b737a5fefedb8333fa50b8db3dcc9b1d18fd6c598f89fa7debff8b46bf4e511",
-              "url": "https://files.pythonhosted.org/packages/1c/73/14306559157a6faedb4ecae28ad907b64b5359be5c9ec79233546acb96a4/simplejson-3.19.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "ceab2ce2acdc7fbaa433a93006758db6ba9a659e80c4faa13b80b9d2318e9b17",
+              "url": "https://files.pythonhosted.org/packages/26/94/cab4db9530b6ca9d62f16a260e8311b04130ccd670dab75e958fcb44590e/simplejson-3.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2a954b30810988feeabde843e3263bf187697e0eb5037396276db3612434049b",
-              "url": "https://files.pythonhosted.org/packages/21/04/c96aeb3a74031255e4cbcc0ca1b6ebfb5549902f0a065f06d65ce8447c0c/simplejson-3.19.3-cp311-cp311-musllinux_1_2_ppc64le.whl"
+              "hash": "a3c2df555ee4016148fa192e2b9cd9e60bc1d40769366134882685e90aee2a1e",
+              "url": "https://files.pythonhosted.org/packages/31/db/00d1a8d9b036db98f678c8a3c69ed17d2894d1768d7a00576e787ad3e546/simplejson-3.20.1-cp310-cp310-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "50d8b742d74c449c4dcac570d08ce0f21f6a149d2d9cf7652dbf2ba9a1bc729a",
-              "url": "https://files.pythonhosted.org/packages/39/24/260ad03435ce8ef2436031951134659c7161776ec3a78094b35b9375ceea/simplejson-3.19.3-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "71b75d448fd0ceb2e7c90e72bb82c41f8462550d48529980bc0bab1d2495bfbb",
+              "url": "https://files.pythonhosted.org/packages/36/d9/87e5586e79d6a840eb4278e8b6a4c064a6ebe2276b211af20899e407629a/simplejson-3.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e086896c36210ab6050f2f9f095a5f1e03c83fa0e7f296d6cba425411364680",
-              "url": "https://files.pythonhosted.org/packages/3d/29/085111f19717f865eceaf0d4397bf3e76b08d60428b076b64e2a1903706d/simplejson-3.19.3.tar.gz"
+              "hash": "e39eaa57c7757daa25bcd21f976c46be443b73dd6c3da47fe5ce7b7048ccefe2",
+              "url": "https://files.pythonhosted.org/packages/3c/2f/d0ff0b772d4ef092876eb85c99bc591c446b0502715551dad7dfc7f7c2c0/simplejson-3.20.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1773cabfba66a6337b547e45dafbd471b09487370bcab75bd28f626520410d29",
-              "url": "https://files.pythonhosted.org/packages/4a/7f/051ed1210ddfed68babdd4ebe6139205804ad9a80ecda977ce14656a59c4/simplejson-3.19.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "6d4f320c33277a5b715db5bf5b10dae10c19076bd6d66c2843e04bd12d1f1ea5",
+              "url": "https://files.pythonhosted.org/packages/40/22/11c0f746bdb44c297cea8a37d8f7ccb75ea6681132aadfb9f820d9a52647/simplejson-3.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd7230d061e755d60a4d5445bae854afe33444cdb182f3815cff26ac9fb29a15",
-              "url": "https://files.pythonhosted.org/packages/4d/87/c310daf5e2f10306de3720f075f8ed74cbe83396879b8c55e832393233a5/simplejson-3.19.3-cp39-cp39-musllinux_1_2_i686.whl"
+              "hash": "e91703a4c5fec53e36875ae426ad785f4120bd1d93b65bed4752eeccd1789e0c",
+              "url": "https://files.pythonhosted.org/packages/48/c7/361e7f6695b56001a04e0a5cc623cd6c82ea2f45e872e61213e405cc8a24/simplejson-3.20.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "32a3ada8f3ea41db35e6d37b86dade03760f804628ec22e4fe775b703d567426",
-              "url": "https://files.pythonhosted.org/packages/56/a8/dbe799f3620a08337ff5f3be27df7b5ba5beb1ee06acaf75f3cb46f8d650/simplejson-3.19.3-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "51b41f284d603c4380732d7d619f8b34bd04bc4aa0ed0ed5f4ffd0539b14da44",
+              "url": "https://files.pythonhosted.org/packages/4b/8f/9991582665a7b6d95415e439bb4fbaa4faf0f77231666675a0fd1de54107/simplejson-3.20.1-cp39-cp39-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1df0aaf1cb787fdf34484ed4a1f0c545efd8811f6028623290fef1a53694e597",
-              "url": "https://files.pythonhosted.org/packages/58/d2/b8dcb0a07d9cd54c47f9fe8733dbb83891d1efe4fc786d9dfc8781cc04f9/simplejson-3.19.3-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "3466d2839fdc83e1af42e07b90bc8ff361c4e8796cd66722a40ba14e458faddd",
+              "url": "https://files.pythonhosted.org/packages/4c/2d/ca3caeea0bdc5efc5503d5f57a2dfb56804898fb196dfada121323ee0ccb/simplejson-3.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "619756f1dd634b5bdf57d9a3914300526c3b348188a765e45b8b08eabef0c94e",
-              "url": "https://files.pythonhosted.org/packages/59/9a/f5b786fe611395564d3e84f58f668242a7a2e674b4fac71b4e6b21d6d2b7/simplejson-3.19.3-cp39-cp39-musllinux_1_2_aarch64.whl"
+              "hash": "a8011f1dd1d676befcd4d675ebdbfdbbefd3bf350052b956ba8c699fca7d8cef",
+              "url": "https://files.pythonhosted.org/packages/4c/ba/d32fe890a5edaf4a8518adf043bccf7866b600123f512a6de0988cf36810/simplejson-3.20.1-cp39-cp39-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb47ee773ce67476a960e2db4a0a906680c54f662521550828c0cc57d0099426",
-              "url": "https://files.pythonhosted.org/packages/5b/1a/7994abb33e53ec972dd5e6dbb337b9070d3ad96017c4cff9d5dc83678ad4/simplejson-3.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "2e671dd62051129185d3a9a92c60101f56cbc174854a1a3dfb69114ebd9e1699",
+              "url": "https://files.pythonhosted.org/packages/50/69/2d307ed022eba08c4ee51e1d8ba9dfa01a8bb276ee9aa70d7911d1044f34/simplejson-3.20.1-cp38-cp38-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "add8850db04b98507a8b62d248a326ecc8561e6d24336d1ca5c605bbfaab4cad",
-              "url": "https://files.pythonhosted.org/packages/5d/de/5b03fafe3003e32d179588953d38183af6c3747e95c7dcc668c4f9eb886a/simplejson-3.19.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+              "hash": "78520f04b7548a5e476b5396c0847e066f1e0a4c0c5e920da1ad65e95f410b11",
+              "url": "https://files.pythonhosted.org/packages/52/21/57fc47eab8c1c73390b933a5ba9271f08e3e1ec83162c580357f28f5b97c/simplejson-3.20.1-cp310-cp310-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f8efb03ca77bd7725dfacc9254df00d73e6f43013cf39bd37ef1a8ed0ebb5165",
-              "url": "https://files.pythonhosted.org/packages/61/20/0035a288deaff05397d6cc0145b33f3dd2429b99cdc880de4c5eca41ca72/simplejson-3.19.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "f924b485537b640dc69434565463fd6fc0c68c65a8c6e01a823dd26c9983cf79",
+              "url": "https://files.pythonhosted.org/packages/54/53/2d93128bb55861b2fa36c5944f38da51a0bc6d83e513afc6f7838440dd15/simplejson-3.20.1-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd011fc3c1d88b779645495fdb8189fb318a26981eebcce14109460e062f209b",
-              "url": "https://files.pythonhosted.org/packages/63/a1/dee207f357bcd6b106f2ca5129ee916c24993ba08b7dfbf9a37c22442ea9/simplejson-3.19.3-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "6e6697a3067d281f01de0fe96fc7cba4ea870d96d7deb7bfcf85186d74456503",
+              "url": "https://files.pythonhosted.org/packages/54/ee/3c6e91989cdf65ec75e75662d9f15cfe167a792b893806169ea5b1da6fd2/simplejson-3.20.1-cp39-cp39-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "72e8abbc86fcac83629a030888b45fed3a404d54161118be52cb491cd6975d3e",
-              "url": "https://files.pythonhosted.org/packages/69/b3/89640bd676e26ea2315b5aaf80712a6fbbb4338e4caf872d91448502a19b/simplejson-3.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "7eaae2b88eb5da53caaffdfa50e2e12022553949b88c0df4f9a9663609373f72",
+              "url": "https://files.pythonhosted.org/packages/63/26/1c894a1c2bd95dc8be0cf5a2fa73b0d173105b6ca18c90cb981ff10443d0/simplejson-3.20.1-cp310-cp310-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef59a53be400c1fad2c914b8d74c9d42384fed5174f9321dd021b7017fd40270",
-              "url": "https://files.pythonhosted.org/packages/76/37/012f5ad2f38afa28f8a6ad9da01dc0b64492ffbaf2a3f2f8a0e1fddf9c1d/simplejson-3.19.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "88a7baa8211089b9e58d78fbc1b0b322103f3f3d459ff16f03a36cece0d0fcf0",
+              "url": "https://files.pythonhosted.org/packages/71/c7/1970916e0c51794fff89f76da2f632aaf0b259b87753c88a8c409623d3e1/simplejson-3.20.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e1a1452ad5723ff129b081e3c8aa4ba56b8734fee4223355ed7b815a7ece69bc",
-              "url": "https://files.pythonhosted.org/packages/7b/f7/bef9bc035f2e7eabc01469286238e99fd762010c714d3079925253d29f99/simplejson-3.19.3-cp38-cp38-musllinux_1_2_i686.whl"
+              "hash": "03db8cb64154189a92a7786209f24e391644f3a3fa335658be2df2af1960b8d8",
+              "url": "https://files.pythonhosted.org/packages/74/30/20001219d6fdca4aaa3974c96dfb6955a766b4e2cc950505a5b51fd050b0/simplejson-3.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2f56eb03bc9e432bb81adc8ecff2486d39feb371abb442964ffb44f6db23b332",
-              "url": "https://files.pythonhosted.org/packages/7f/4b/9a132382982f8127bc7ce5212a5585d83c174707c9dd698d0cb6a0d41882/simplejson-3.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "325b8c107253d3217e89d7b50c71015b5b31e2433e6c5bf38967b2f80630a8ca",
+              "url": "https://files.pythonhosted.org/packages/76/59/74bc90d1c051bc2432c96b34bd4e8036875ab58b4fcbe4d6a5a76985f853/simplejson-3.20.1-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637c4d4b81825c1f4d651e56210bd35b5604034b192b02d2d8f17f7ce8c18f42",
-              "url": "https://files.pythonhosted.org/packages/80/7b/45ef1da43f54d209ce2ef59b7356cda13f810186c381f38ae23a4d2b1337/simplejson-3.19.3-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "2b6436c48e64378fa844d8c9e58a5ed0352bbcfd4028369a9b46679b7ab79d2d",
+              "url": "https://files.pythonhosted.org/packages/78/e9/b7c4c26f29b41cc41ba5f0224c47adbfa7f28427418edfd58ab122f3b584/simplejson-3.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4dfa420bb9225dd33b6efdabde7c6a671b51150b9b1d9c4e5cd74d3b420b3fe1",
-              "url": "https://files.pythonhosted.org/packages/86/f3/a18b98a7a27548829f672754dd3940fb637a27981399838128d3e560087f/simplejson-3.19.3-cp310-cp310-musllinux_1_2_ppc64le.whl"
+              "hash": "e25b2a0c396f3b84fb89573d07b0e1846ed563eb364f2ea8230ca92b8a8cb786",
+              "url": "https://files.pythonhosted.org/packages/7b/9a/088179435b2c6036c67ca03baf0623e22dbb6b02ddd0fa2451b3a4786207/simplejson-3.20.1-cp38-cp38-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e88abff510dcff903a18d11c2a75f9964e768d99c8d147839913886144b2065e",
-              "url": "https://files.pythonhosted.org/packages/8c/bb/9ee3959e6929d228cf669b3f13f0edd43c5261b6cd69598640748b19ca35/simplejson-3.19.3-cp311-cp311-macosx_10_9_universal2.whl"
+              "hash": "1bd6bfe5678d73fbd5328eea6a35216503796428fc47f1237432522febaf3a0c",
+              "url": "https://files.pythonhosted.org/packages/83/c5/0dbf3045eb6701a4b32cbbfa2813efa1b354078383c727ad593ebe280536/simplejson-3.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7e062767ac165df9a46963f5735aa4eee0089ec1e48b3f2ec46182754b96f55e",
-              "url": "https://files.pythonhosted.org/packages/8f/b0/541709f6891e6c60cdbb77cb25ba6f568d960e219723a8f3b5caeb8b5323/simplejson-3.19.3-cp38-cp38-musllinux_1_2_x86_64.whl"
+              "hash": "4a8e197e4cf6d42c2c57e7c52cd7c1e7b3e37c5911df1314fb393320131e2101",
+              "url": "https://files.pythonhosted.org/packages/8f/53/f058e3a23a88834e113cf4a353acb5569f26995a07653d79425cffbb2c1b/simplejson-3.20.1-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "23228037dc5d41c36666384062904d74409a62f52283d9858fa12f4c22cffad1",
-              "url": "https://files.pythonhosted.org/packages/93/44/815a4343774760f7a82459c8f6a4d8268b4b6d23f81e7b922a5e2ca79171/simplejson-3.19.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "e66712b17d8425bb7ff8968d4c7c7fd5a2dd7bd63728b28356223c000dd2f91f",
+              "url": "https://files.pythonhosted.org/packages/95/60/8c97cdc93096437b0aca2745aca63c880fe2315fd7f6a6ce6edbb344a2ae/simplejson-3.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "49549e3d81ab4a58424405aa545602674d8c35c20e986b42bb8668e782a94bac",
-              "url": "https://files.pythonhosted.org/packages/95/8b/d2a4b8b7d38bef824cc770ab0aa6276dc5976f3a5d5c57099cd403be36ab/simplejson-3.19.3-cp38-cp38-musllinux_1_2_aarch64.whl"
+              "hash": "9e8eacf6a3491bf76ea91a8d46726368a6be0eb94993f60b8583550baae9439e",
+              "url": "https://files.pythonhosted.org/packages/99/4c/dac310a98f897ad3435b4bdc836d92e78f09e38c5dbf28211ed21dc59fa2/simplejson-3.20.1-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3dc5c1a85ff388e98ea877042daec3d157b6db0d85bac6ba5498034689793e7e",
-              "url": "https://files.pythonhosted.org/packages/96/ef/4384c2f76d44022ab59fe63406df3aa720ba4610aa6942f548fe406890ae/simplejson-3.19.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "90b573693d1526bed576f6817e2a492eaaef68f088b57d7a9e83d122bbb49e51",
+              "url": "https://files.pythonhosted.org/packages/9a/6b/8d1e076c543277c1d603230eec24f4dd75ebce46d351c0679526d202981f/simplejson-3.20.1-cp39-cp39-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b5587feda2b65a79da985ae6d116daf6428bf7489992badc29fc96d16cd27b05",
-              "url": "https://files.pythonhosted.org/packages/9a/3d/e7f1caf7fa8c004c30e2c0595a22646a178344a7f53924c11c3d263a8623/simplejson-3.19.3-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "489c3a43116082bad56795215786313832ba3991cca1f55838e52a553f451ab6",
+              "url": "https://files.pythonhosted.org/packages/9d/d7/19782d2c5393a44d3426be822ac0925b540d8c0ccb0431c18444794bfad3/simplejson-3.20.1-cp38-cp38-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0791f64fed7d4abad639491f8a6b1ba56d3c604eb94b50f8697359b92d983f36",
-              "url": "https://files.pythonhosted.org/packages/9d/52/d3202d9bba95444090d1c98e43da3c10907875babf63ed3c134d1b9437e3/simplejson-3.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "7551682b60bba3a9e2780742e101cf0a64250e76de7d09b1c4b0c8a7c7cc6834",
+              "url": "https://files.pythonhosted.org/packages/a9/85/89a0d847239a2696068503810880ee73b87177465a86a7942c95012fb875/simplejson-3.20.1-cp38-cp38-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7c0104b4b7d2c75ccedbf1d9d5a3bd2daa75e51053935a44ba012e2fd4c43752",
-              "url": "https://files.pythonhosted.org/packages/a0/ec/22e3c7407c5a199131a11cafc167076768e3578602a1b94fe5a145957998/simplejson-3.19.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "74a1608f9e6e8c27a4008d70a54270868306d80ed48c9df7872f9f4b8ac87808",
+              "url": "https://files.pythonhosted.org/packages/a9/c8/3d92b67e03a3b6207d97202669f9454ed700b35ade9bd4428265a078fb6c/simplejson-3.20.1-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e557712fc79f251673aeb3fad3501d7d4da3a27eff0857af2e1d1afbbcf6685",
-              "url": "https://files.pythonhosted.org/packages/a3/31/ef13eda5b5a0d8d9555b70151ee2956f63b845e1fac4ff904339dfb4dd89/simplejson-3.19.3-cp39-cp39-musllinux_1_2_x86_64.whl"
+              "hash": "f4bd49ecde87b0fe9f55cc971449a32832bca9910821f7072bbfae1155eaa007",
+              "url": "https://files.pythonhosted.org/packages/ad/cc/7cfd78d1e0fa5e57350b98cfe77353b6dfa13dce21afa4060e1019223852/simplejson-3.20.1-cp310-cp310-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "951095be8d4451a7182403354c22ec2de3e513e0cc40408b689af08d02611588",
-              "url": "https://files.pythonhosted.org/packages/a9/95/1e92d99039041f596e0923ec4f9153244acaf3830944dc69a7c11b23ceaa/simplejson-3.19.3-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "e64139b4ec4f1f24c142ff7dcafe55a22b811a74d86d66560c8815687143037d",
+              "url": "https://files.pythonhosted.org/packages/af/92/51b417685abd96b31308b61b9acce7ec50d8e1de8fbc39a7fd4962c60689/simplejson-3.20.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a53a07320c5ff574d8b1a89c937ce33608832f166f39dff0581ac43dc979abd",
-              "url": "https://files.pythonhosted.org/packages/a9/e9/8cec3d3efcf284f6f929ba1ad0266cb77e7810ee7dc56046fbdd22b15fbd/simplejson-3.19.3-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "69dd28d4ce38390ea4aaf212902712c0fd1093dc4c1ff67e09687c3c3e15a749",
+              "url": "https://files.pythonhosted.org/packages/b8/c8/b072b741129406a7086a0799c6f5d13096231bf35fdd87a0cffa789687fc/simplejson-3.20.1-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d9e8f836688a8fabe6a6b41b334aa550a6823f7b4ac3d3712fc0ad8655be9a8",
-              "url": "https://files.pythonhosted.org/packages/ab/4d/15718f20cb0e3875b8af9597d6bb3bfbcf1383834b82b6385ee9ac0b72a9/simplejson-3.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a2cc4f6486f9f515b62f5831ff1888886619b84fc837de68f26d919ba7bbdcbc",
+              "url": "https://files.pythonhosted.org/packages/bb/9e/da184f0e9bb3a5d7ffcde713bd41b4fe46cca56b6f24d9bd155fac56805a/simplejson-3.20.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "934a50a614fb831614db5dbfba35127ee277624dda4d15895c957d2f5d48610c",
-              "url": "https://files.pythonhosted.org/packages/ac/ae/a06523928af3a6783e2638cd4f6035c3e32de1c1063d563d9060c8d2f1ad/simplejson-3.19.3-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "6bd09c8c75666e7f62a33d2f1fb57f81da1fcbb19a9fe7d7910b5756e1dd6048",
+              "url": "https://files.pythonhosted.org/packages/c0/54/160fb59ef3441aae419d26a3fdb57648755594de43afb4406c25cf4908a1/simplejson-3.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c40df31a75de98db2cdfead6074d4449cd009e79f54c1ebe5e5f1f153c68ad20",
-              "url": "https://files.pythonhosted.org/packages/b7/41/e28a28593afc4a75d8999d057bfb7c73a103e35f927e66f4bb92571787ae/simplejson-3.19.3-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "299b1007b8101d50d95bc0db1bf5c38dc372e85b504cf77f596462083ee77e3f",
+              "url": "https://files.pythonhosted.org/packages/c8/0d/98cc5909180463f1d75fac7180de62d4cdb4e82c4fef276b9e591979372c/simplejson-3.20.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4f614581b61a26fbbba232a1391f6cee82bc26f2abbb6a0b44a9bba25c56a1c",
-              "url": "https://files.pythonhosted.org/packages/b7/d4/850948bcbcfe0b4a6c69dfde10e245d3a1ea45252f16a1e2308a3b06b1da/simplejson-3.19.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "272cc767826e924a6bd369ea3dbf18e166ded29059c7a4d64d21a9a22424b5b5",
+              "url": "https://files.pythonhosted.org/packages/d1/46/7b74803de10d4157c5cd2e89028897fa733374667bc5520a44b23b6c887a/simplejson-3.20.1-cp39-cp39-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "212fce86a22188b0c7f53533b0f693ea9605c1a0f02c84c475a30616f55a744d",
-              "url": "https://files.pythonhosted.org/packages/c3/58/fea732e48a7540035fe46d39e6fd77679f5810311d31da8661ce7a18210a/simplejson-3.19.3-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "3e7963197d958fcf9e98b212b80977d56c022384621ff463d98afc3b6b1ce7e8",
+              "url": "https://files.pythonhosted.org/packages/db/c4/6d59270529aa4c1ca6dfffefa5c72469fa471fdaac7188532b7296e10880/simplejson-3.20.1-cp38-cp38-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a0710d1a5e41c4f829caa1572793dd3130c8d65c2b194c24ff29c4c305c26e0",
-              "url": "https://files.pythonhosted.org/packages/ca/26/ecac686556c7e3757abe345afcf167773d3317acd09ea0b60a02eb4db65f/simplejson-3.19.3-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "d492ed8e92f3a9f9be829205f44b1d0a89af6582f0cf43e0d129fa477b93fe0c",
+              "url": "https://files.pythonhosted.org/packages/e1/33/d3e0779d5c58245e7370c98eb969275af6b7a4a5aec3b97cbf85f09ad328/simplejson-3.20.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc3dc9fb413fc34c396f52f4c87de18d0bd5023804afa8ab5cc224deeb6a9900",
-              "url": "https://files.pythonhosted.org/packages/d1/ce/e493116ff49fd215f7baa25195b8f684c91e65c153e2a57e04dc3f3a466b/simplejson-3.19.3-cp310-cp310-musllinux_1_2_i686.whl"
+              "hash": "03ec618ed65caab48e81e3ed29586236a8e57daef792f1f3bb59504a7e98cd10",
+              "url": "https://files.pythonhosted.org/packages/e1/94/a30a5211a90d67725a3e8fcc1c788189f2ae2ed2b96b63ed15d0b7f5d6bb/simplejson-3.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f455672f4738b0f47183c5896e3606cd65c9ddee3805a4d18e8c96aa3f47c84",
-              "url": "https://files.pythonhosted.org/packages/d5/53/6ed299b9201ea914bb6a178a7e65413ed1969981533f50bfbe8a215be98f/simplejson-3.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "bd9577ec1c8c3a43040e3787711e4c257c70035b7551a21854b5dec88dad09e1",
+              "url": "https://files.pythonhosted.org/packages/e6/74/018dd0d40cb7dd339af0a9fa992a264f347844c6ce9a6cd7a527d37d215b/simplejson-3.20.1-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0733ecd95ae03ae718ec74aad818f5af5f3155d596f7b242acbc1621e765e5fb",
-              "url": "https://files.pythonhosted.org/packages/d6/25/ccf60909457fff5259ea692023a13faafbc4cacbd022a4647b1117b66c85/simplejson-3.19.3-cp38-cp38-macosx_10_9_universal2.whl"
+              "hash": "a7e15b716d09f318c8cda3e20f82fae81684ce3d3acd1d7770fa3007df1769de",
+              "url": "https://files.pythonhosted.org/packages/eb/33/3c2cbeab7d0e8f8ba36e9cd5d85ee68e6d7ed4be93bbedd75090f5bc2961/simplejson-3.20.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c49eeb94b8f09dc8a5843c156a22b8bde6aa1ddc65ca8ddc62dddcc001e6a2d",
-              "url": "https://files.pythonhosted.org/packages/e4/15/6c3e0bd846581ac4d8f588fb97f9a436f5d1f35f0aef57d5e19a19f720e2/simplejson-3.19.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "cd2cdead1d3197f0ff43373cf4730213420523ba48697743e135e26f3d179f38",
+              "url": "https://files.pythonhosted.org/packages/ee/08/cdb6821f1058eb5db46d252de69ff7e6c53f05f1bae6368fe20d5b51d37e/simplejson-3.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "101a3c8392028cd704a93c7cba8926594e775ca3c91e0bee82144e34190903f1",
-              "url": "https://files.pythonhosted.org/packages/fd/89/690880e1639b421a919d36fadf1fc364a38c3bc4f208dc11627426cdbe98/simplejson-3.19.3-cp39-cp39-musllinux_1_2_ppc64le.whl"
+              "hash": "d34d04bf90b4cea7c22d8b19091633908f14a096caa301b24c2f3d85b5068fb8",
+              "url": "https://files.pythonhosted.org/packages/ee/22/d7ba958cfed39827335b82656b1c46f89678faecda9a7677b47e87b48ee6/simplejson-3.20.1-cp311-cp311-musllinux_1_2_ppc64le.whl"
             }
           ],
           "project_name": "simplejson",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.5",
-          "version": "3.19.3"
+          "version": "3.20.1"
         },
         {
           "artifacts": [
@@ -5598,6 +5602,19 @@
           ],
           "requires_python": ">=3.8",
           "version": "0.3.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "08b1ebb865e1b9c4f6b0912e62597258647026021a5e1f3371bc3037e5b1a95f",
+              "url": "git+https://github.com/StackStorm/st2-auth-backend-pam.git@master"
+            }
+          ],
+          "project_name": "st2-auth-backend-pam",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "0.4.0"
         },
         {
           "artifacts": [
@@ -7069,6 +7086,7 @@
     "six",
     "sseclient-py",
     "st2-auth-backend-flat-file",
+    "st2-auth-backend-pam",
     "st2-auth-ldap",
     "st2-rbac-backend",
     "stevedore",

--- a/requirements-pants.txt
+++ b/requirements-pants.txt
@@ -78,6 +78,7 @@ stevedore
 # For backward compatibility reasons, flat file backend is installed by default
 st2-auth-backend-flat-file
 st2-auth-ldap @ git+https://github.com/StackStorm/st2-auth-ldap.git@master
+st2-auth-backend-pam @ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
 st2-rbac-backend @ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 # tabulate used by tools/log_watcher.py
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi==1.17.1
 chardet==5.2.0
 ciso8601
 cryptography==43.0.3
-decorator==5.1.1
+decorator==5.2.1
 dnspython
 editor==1.6.6
 eventlet==0.39.0
@@ -42,7 +42,7 @@ paramiko==3.5.1
 passlib==1.7.4
 prettytable==3.10.2
 prompt-toolkit==3.0.50
-psutil==6.1.1
+psutil==7.0.0
 pyOpenSSL
 pygments==2.19.1
 pyinotify==0.9.6 ; platform_system=="Linux"

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ simplejson
 six==1.17.0
 sseclient-py==1.8.0
 st2-auth-backend-flat-file
+st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
 st2-auth-ldap@ git+https://github.com/StackStorm/st2-auth-ldap.git@master
 st2-rbac-backend@ git+https://github.com/StackStorm/st2-rbac-backend.git@master
 stevedore==5.3.0

--- a/st2auth/in-requirements.txt
+++ b/st2auth/in-requirements.txt
@@ -9,4 +9,6 @@ stevedore
 # For backward compatibility reasons, flat file backend is installed by default
 st2-auth-backend-flat-file
 st2-auth-ldap@ git+https://github.com/StackStorm/st2-auth-ldap.git@master
+# This requirement has been injected by st2-packages.git for many years.
+st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
 gunicorn

--- a/st2auth/requirements.txt
+++ b/st2auth/requirements.txt
@@ -13,5 +13,6 @@ passlib==1.7.4
 pymongo==4.6.3
 six==1.17.0
 st2-auth-backend-flat-file
+st2-auth-backend-pam@ git+https://github.com/StackStorm/st2-auth-backend-pam.git@master
 st2-auth-ldap@ git+https://github.com/StackStorm/st2-auth-ldap.git@master
 stevedore==5.3.0

--- a/st2common/requirements.txt
+++ b/st2common/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.17.1
 chardet==5.2.0
 ciso8601
 cryptography==43.0.3
-decorator==5.1.1
+decorator==5.2.1
 dnspython
 eventlet==0.39.0
 flex==6.14.1

--- a/st2tests/requirements.txt
+++ b/st2tests/requirements.txt
@@ -7,7 +7,7 @@
 # update the component requirements.txt
 RandomWords
 mock==5.1.0
-psutil==6.1.1
+psutil==7.0.0
 pyrabbit
 pytest==7.0.1
 webtest==3.0.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -28,7 +28,7 @@ pyyaml==6.0.2
 pygments==2.19.1
 RandomWords
 gunicorn==23.0.0
-psutil==6.1.1
+psutil==7.0.0
 webtest==3.0.1
 # Bump to latest to meet sphinx requirements.
 rstcheck==6.2.1


### PR DESCRIPTION
st2-packages.git has been injecting another dependency since 2016 (https://github.com/StackStorm/st2-packages/commit/d35c03e9044b3746a07cb6c99129ce7fabb96f6e):
```
git+https://github.com/StackStorm/st2-auth-backend-pam.git@master#egg=st2-auth-backend-pam
```
https://github.com/StackStorm/st2-packages/blob/7ed6bf12d101aa34456b711723be9f81d3be82d7/packages/st2/in-requirements.txt#L8

The legacy Makefile gets the dep indirectly via st2-packages.git, but that will be archived when we start using pants to build packages. So, this PR copies that requirement into `pants-requirements.txt` here (and to `st2auth/in-requirements.txt`):
https://github.com/StackStorm/st2/blob/f35044557da8677bcd2b379e8cf159de61d8179f/requirements-pants.txt#L81

Then, since pants can't infer a dep on plugins like this, we explicitly add the dep here:
https://github.com/StackStorm/st2/blob/f35044557da8677bcd2b379e8cf159de61d8179f/BUILD#L63-L68

Finally, I regenerated `lockfiles/st2.lock` and copied the updated pins to the legacy requirements files. Here's the lockfile diff:
```
Lockfile diff: lockfiles/st2.lock [st2]

==                    Upgraded dependencies                     ==

  decorator                      5.1.1        -->   5.2.1
  psutil                         6.1.1        -->   7.0.0
  simplejson                     3.19.3       -->   3.20.1

==                      Added dependencies                      ==

  st2-auth-backend-pam           0.4.0
```

NB: The `psutil` major version bump merely drops support for python 2.7 and a deprecated method that we do not use.