### PR TITLE
Pants+Packaging: Add `makeself_archive` for each pack to facilitate installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
+  #6311
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/chatops/BUILD
+++ b/contrib/chatops/BUILD
@@ -3,3 +3,11 @@ __defaults__(all=dict(inject_pack_python_path=True))
 pack_metadata(
     name="metadata",
 )
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        "./actions",
+        "./tests",
+    ],
+)

--- a/contrib/chatops/tests/BUILD
+++ b/contrib/chatops/tests/BUILD
@@ -1,5 +1,5 @@
 # tests can only be dependencies of other tests in this directory
-__dependents_rules__(("*", "/**", "!*"))
+__dependents_rules__(("*", "/**", f"//{build_file_dir().parent}:files", "!*"))
 
 __defaults__(
     {python_test: dict(tags=["pack"])},

--- a/contrib/core/BUILD
+++ b/contrib/core/BUILD
@@ -10,9 +10,20 @@ python_requirements(
 )
 
 python_sources(
+    # this is for fixture.py
     dependencies=[
         ":metadata",
         "./actions",
         "./actions/send_mail:send_mail_resources",
+    ],
+)
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        ":reqs",
+        "./actions",
+        "./actions/send_mail:send_mail_resources",
+        "./tests",
     ],
 )

--- a/contrib/core/tests/BUILD
+++ b/contrib/core/tests/BUILD
@@ -1,5 +1,5 @@
 # tests can only be dependencies of other tests in this directory
-__dependents_rules__(("*", "/**", "!*"))
+__dependents_rules__(("*", "/**", f"//{build_file_dir().parent}:files", "!*"))
 
 __defaults__(
     {python_test: dict(tags=["pack"])},

--- a/contrib/debug/BUILD
+++ b/contrib/debug/BUILD
@@ -3,3 +3,10 @@ __defaults__(all=dict(inject_pack_python_path=True))
 pack_metadata(
     name="metadata",
 )
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        "./actions",
+    ],
+)

--- a/contrib/default/BUILD
+++ b/contrib/default/BUILD
@@ -3,3 +3,9 @@ __defaults__(all=dict(inject_pack_python_path=True))
 pack_metadata(
     name="metadata",
 )
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+    ],
+)

--- a/contrib/examples/BUILD
+++ b/contrib/examples/BUILD
@@ -18,3 +18,29 @@ python_requirement(
     name="flask",
     requirements=["flask"],
 )
+
+# Also capture the requirements file for distribution in the pack archive.
+files(
+    name="reqs",
+    sources=["requirements*.txt"],
+)
+
+st2_pack_archive(
+    # we need to list targets of all files because transitive dep targets are NOT included
+    dependencies=[
+        ":metadata",
+        ":reqs",
+        "./actions",
+        "./actions:shell",
+        "./actions/bash_exit_code",
+        "./actions/bash_ping",
+        "./actions/bash_random",
+        "./actions/pythonactions",
+        "./actions/ubuntu_pkg_info",
+        "./actions/ubuntu_pkg_info/lib",
+        "./actions/windows",
+        "./lib",
+        "./sensors",
+        "./tests",
+    ],
+)

--- a/contrib/examples/actions/windows/BUILD
+++ b/contrib/examples/actions/windows/BUILD
@@ -1,0 +1,3 @@
+files(
+    sources=["*.ps1"],
+)

--- a/contrib/examples/tests/BUILD
+++ b/contrib/examples/tests/BUILD
@@ -1,5 +1,5 @@
 # tests can only be dependencies of other tests in this directory
-__dependents_rules__(("*", "/**", "!*"))
+__dependents_rules__(("*", "/**", f"//{build_file_dir().parent}:files", "!*"))
 
 __defaults__(
     {python_test: dict(tags=["pack"])},

--- a/contrib/hello_st2/BUILD
+++ b/contrib/hello_st2/BUILD
@@ -3,3 +3,19 @@ __defaults__(all=dict(inject_pack_python_path=True))
 pack_metadata(
     name="metadata",
 )
+
+# Capture the requirements file for distribution in the pack archive;
+# we do not need to use `python_requirements()` for this sample file.
+files(
+    name="reqs",
+    sources=["requirements*.txt"],
+)
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        ":reqs",
+        "./actions",
+        "./sensors",
+    ],
+)

--- a/contrib/linux/BUILD
+++ b/contrib/linux/BUILD
@@ -7,3 +7,15 @@ pack_metadata(
 python_requirements(
     name="reqs",
 )
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        ":reqs",
+        "./actions",
+        "./actions/checks",
+        # "./actions/lib",  # nothing in dir
+        "./sensors",
+        "./tests",
+    ],
+)

--- a/contrib/linux/tests/BUILD
+++ b/contrib/linux/tests/BUILD
@@ -1,5 +1,5 @@
 # tests can only be dependencies of other tests in this directory
-__dependents_rules__(("*", "/**", "!*"))
+__dependents_rules__(("*", "/**", f"//{build_file_dir().parent}:files", "!*"))
 
 __defaults__(
     {python_test: dict(tags=["pack"])},

--- a/contrib/packs/BUILD
+++ b/contrib/packs/BUILD
@@ -3,3 +3,12 @@ __defaults__(all=dict(inject_pack_python_path=True))
 pack_metadata(
     name="metadata",
 )
+
+st2_pack_archive(
+    dependencies=[
+        ":metadata",
+        "./actions",
+        "./actions/pack_mgmt",
+        "./tests",
+    ],
+)

--- a/contrib/packs/tests/BUILD
+++ b/contrib/packs/tests/BUILD
@@ -1,5 +1,5 @@
 # tests can only be dependencies of other tests in this directory
-__dependents_rules__(("*", "/**", "!*"))
+__dependents_rules__(("*", "/**", f"//{build_file_dir().parent}:files", "!*"))
 
 __defaults__(
     {python_test: dict(tags=["pack"])},

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -116,6 +116,10 @@ def st2_component_python_distribution(**kwargs):
 # https://github.com/pex-tool/pex/blob/v2.1.137/pex/common.py#L39-L45
 MTIME = "1980-01-01T00:00:00Z"
 
+# These are used for system packages (rpm/deb)
+ST2_PACKS_GROUP = "st2packs"
+ST2_SVC_USER = "st2"
+
 
 def st2_pack_archive(**kwargs):
     """Create a makeself_archive using files from the given dependencies.
@@ -159,7 +163,7 @@ def st2_pack_archive(**kwargs):
             f"/opt/stackstorm/packs/{pack_name}",
             # reproducibility flags:
             "--tar-extra",  # extra tar args: '--arg=value' (equals delimited) space separated
-            f"--owner=root:0 --group=root:0 --mtime={MTIME} --exclude=LICENSE",
+            f"--owner=root --group={ST2_PACKS_GROUP} --mtime={MTIME} --exclude=LICENSE",
             "--packaging-date",
             MTIME,
         ),

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -142,6 +142,8 @@ def st2_pack_archive(**kwargs):
         root_output_directory=".",
     )
 
+    # https://www.pantsbuild.org/stable/docs/shell/self-extractable-archives
+    # https://www.pantsbuild.org/stable/reference/targets/makeself_archive
     makeself_archive(  # noqa: F821
         name="archive",
         label=f"{pack_name} StackStorm pack",
@@ -149,8 +151,7 @@ def st2_pack_archive(**kwargs):
             ":files",  # archive contents
             "//:license",  # LICENSE file included in archive header, excluded from contents
         ],
-        # startup_script=["echo", "pack-archive"],
-        args=(
+        args=(  # see: https://makeself.io/#usage
             # Makeself expects '--arg value' (space) not '--arg=value' (equals) for cmdline
             "--license",
             "__archive/LICENSE",
@@ -158,16 +159,9 @@ def st2_pack_archive(**kwargs):
             f"/opt/stackstorm/packs/{pack_name}",
             # reproducibility flags:
             "--tar-extra",  # extra tar args: '--arg=value' (equals delimited) space separated
-            f"--owner=root:0 --group=root:0 --mtime={MTIME} --exclude=LICENSE",  # TODO: include LICENSE file?
+            f"--owner=root:0 --group=root:0 --mtime={MTIME} --exclude=LICENSE",
             "--packaging-date",
-            MTIME,  # TODO: maybe use release date instead of an epoch date?
-            # compression/encryption flags:
-            # "--gzip",  # gzip is the default compressor
-            # "--complevel", "9",  # 9 is the default compression level
-            # "--gpg-encrypt",  # gpg (encrypt only) handles compression if selected
-            # "--gpg-asymmetric-encrypt-sign",  # gpg (encrypt and sign) handles compression if selected
-            # "--gpg-extra", "...",  # if using gpg, pass extra gpg args here
-            # "--nocomp",  # maybe use no compression to use rpm/deb's compression instead of gzip (default)?
+            MTIME,
         ),
         output_path=f"packaging/packs/{pack_name}.tgz.run",
     )

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
@@ -36,6 +36,7 @@ from pack_metadata.target_types import PackContentResourceTypes
         ((PackContentResourceTypes.pack_config_schema,), 4, "config.schema.yaml"),
         ((PackContentResourceTypes.pack_config_example,), 4, "config.yaml.example"),
         ((PackContentResourceTypes.pack_icon,), 4, "icon.png"),
+        ((PackContentResourceTypes.pack_doc,), 1, ".md"),
         ((PackContentResourceTypes.action_metadata,), 5, ".yaml"),
         ((PackContentResourceTypes.sensor_metadata,), 1, ".yaml"),
         ((PackContentResourceTypes.rule_metadata,), 0, ""),

--- a/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
+++ b/pants-plugins/pack_metadata/python_rules/python_pack_content_test.py
@@ -36,14 +36,14 @@ from pack_metadata.target_types import PackContentResourceTypes
         ((PackContentResourceTypes.pack_config_schema,), 4, "config.schema.yaml"),
         ((PackContentResourceTypes.pack_config_example,), 4, "config.yaml.example"),
         ((PackContentResourceTypes.pack_icon,), 4, "icon.png"),
-        ((PackContentResourceTypes.pack_doc,), 1, ".md"),
+        ((PackContentResourceTypes.pack_doc,), 4, ".md"),
         ((PackContentResourceTypes.action_metadata,), 5, ".yaml"),
         ((PackContentResourceTypes.sensor_metadata,), 1, ".yaml"),
         ((PackContentResourceTypes.rule_metadata,), 0, ""),
         ((PackContentResourceTypes.policy_metadata,), 0, ""),
         ((PackContentResourceTypes.unknown,), 0, ""),
         # all content types
-        ((), 22, ""),
+        ((), 26, ""),
         # some content types
         (
             (

--- a/pants-plugins/pack_metadata/target_types.py
+++ b/pants-plugins/pack_metadata/target_types.py
@@ -43,6 +43,7 @@ class PackContentResourceTypes(Enum):
     pack_config_schema = "pack_config_schema"
     pack_config_example = "pack_config_example"
     pack_icon = "pack_icon"
+    pack_doc = "pack_doc"
     # in subdirectory (see _content_type_by_path_parts below
     action_metadata = "action_metadata"
     action_chain_workflow = "action_chain_workflow"
@@ -86,6 +87,8 @@ class PackContentResourceTypeField(StringField):
         if value is not None:
             return PackContentResourceTypes(value)
         path = PurePath(address.relative_file_path)
+        if path.suffix == ".md":
+            return PackContentResourceTypes.pack_doc
         _yaml_suffixes = (".yaml", ".yml")
         if len(path.parent.parts) == 0:
             # in the pack root
@@ -123,8 +126,7 @@ class PackMetadataSourcesField(ResourcesGeneratingSourcesField):
         "**/*.yml",
         "icon.png",  # used in st2web ui
         # "requirements*.txt",  # including this causes target conflicts
-        # "README.md",
-        # "HISTORY.md",
+        "**/*.md",  # including README.md, HISTORY.md
         # exclude yaml files under tests
         "!tests/**/*.yml",
         "!tests/**/*.yaml",

--- a/pants.toml
+++ b/pants.toml
@@ -27,6 +27,9 @@ backend_packages = [
   "pants.backend.shell",
   "pants.backend.shell.lint.shellcheck",
 
+  # packaging
+  "pants.backend.experimental.makeself",
+
   # internal plugins in pants-plugins/
   "pants.backend.plugin_development",
   "api_spec",
@@ -43,8 +46,6 @@ pants_ignore.add = [
   "test_dist_utils.py",
   "setup.py",
   # keep tailor from using legacy requirements files (not for pants)
-  "contrib/examples/requirements.txt",
-  "contrib/hello_st2/requirements.txt",
   "contrib/runners/*/in-requirements.txt",
   "contrib/runners/*/requirements.txt",
   "st2*/in-requirements.txt",


### PR DESCRIPTION
## Background

### Pack install
There are several packs that get installed with st2 (Installing via the deb/rpm is the only official way to get these):
- `chatops`
- `core`
- `default`
- `linux`
- `packs`

Unlike exchange packs, these 5 packs are not git repos, so if anyone makes a change (for shame :wink:), there isn't a simple way to revert the pack without reinstalling the st2 rpm/deb.

There are 3 other packs in the st2 repo:
- `examples`
    - The `examples` pack gets installed under `/usr/share/doc/st2/examples`. The official way to install that pack is to copy it manually: https://docs.stackstorm.com/start.html#start-deploy-examples
- `hello_st2`
    - The `hello_st2` pack is only for a docs tutorial on creating packs, so there is no official way to install it: https://docs.stackstorm.com/reference/packs.html#creating-your-first-pack
- `debug`
    - The `debug` pack is a much more recent pack added in #5155, but it is not mentioned in the docs and there is no official install method.

### Pantsbuild + nFPM

Once we start building rpm/deb packages with pants + nfpm, we will need to enumerate all of the files that go in the rpm/deb packages. Pants runs nfpm in a sandbox, and pants does not have a way to populate the sandbox with file owner, file group, file permissions (except the execute bit which is also the only thing git can persist), or file modification times. nFPM has a feature that allows it to include a `tree` of files, but that pulls the file owner, file group, file permissions and file modification times from the tree of files, so pants does not expose that nFPM feature. Instead, each file--with all of its file attributes--must be explicitly defined in BUILD metadata.

For most of the files in our rpm/deb file, that pants+nfpm limitation is a non-issue; we were already defining those explicitly in the deb control files and rpm spec files. The big exception to that is packs. Listing each file in a pack sounds very onerous and error prone. All of the pack files have uniform file attributes (except for the execute bit, but everything has a way to deal with that difference).

## Solution: Pants + Makeself

So, I looked for a way to package an archive of each pack's contents, and then include that archive in the rpm/deb. During installation, the post-install (or similar) scriptlet would be responsible for unpacking those archives under `/opt/stackstorm/packs`.

Someone in the pants community slack pointed me towards a nifty tool that pants has an integration for: [`makeself`](https://makeself.io/). This tool makes it relatively simple to build self-extracting archives with very few runtime deps. These are the relevant pants docs about it:
- https://www.pantsbuild.org/stable/docs/shell/self-extractable-archives
- https://www.pantsbuild.org/stable/reference/targets/makeself_archive

Packaging the 8 in-repo st2 packs via pants `makeself_archive` targets has several benefits:
- The rpm/deb needs to include only 1 file for each pack: the makeself archive. So, we only need to add nfpm metadata for the archive itself, not each file in its contents. The archive itself handles ownership/permissions of its contents. 
- People could also use these archives to re/install packs if something happens. For example, reinstalling a pack after a user inadvertently edits one of the workflows via the workflow composer.

So, this PR adds a `makeself_archive` target in pants BUILD metadata for each of the packs under `contrib/`. Since these all need to be built the same, I created the `st2_pack_archive` macro in `pants-plugins/macros.py` (see the [docs about macros](https://www.pantsbuild.org/stable/docs/writing-plugins/macros)).

The first step in using `makeself` is enabling the pants `makeself` backend:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants.toml#L30-L31

_**Macro Name Note**: All of our other macros are prefixed with `st2_` and targets defined in actual plugins (not macros) do not have that prefix. So, this uses the `st2_` prefix as well._

The simpleast usage of the `st2_pack_archive` macro is for the `default` pack:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/default/BUILD#L7-L11

The `:metadata` target is our `pack_metadata` target (implemented by `pants-plugins/pack_metadata`). 

### Markdown files in packs

So far, `pack_metadata` did not include markdown files--which should be distributed with the pack--so I added `**/*.md` to the default sources list:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/pack_metadata/target_types.py#L129

And registered markdown files as the new resource type `pack_doc` here:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/pack_metadata/target_types.py#L90-L91

### `st2_pack_archive` usage

The chatops pack has non-metadata files (python actions) and test files that need to be included in the installed pack. So, we register these as deps here:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/chatops/BUILD#L7-L13

This, however caused a visibility error because tests have [`__dependents_rules__`](https://www.pantsbuild.org/stable/docs/using-pants/validating-dependencies) that block anything outside of the tests directory from depending on the tests. So, I added an exception for the `:files` target (which is created in the `st2_pack_archive` macro and is described further below) like this:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/chatops/tests/BUILD#L1-L2

In this, `build_file_dir()` returns a pathlib.Path object that we can use to reference the parent directory. We have to use this instead of `../` because pants does not support relative parent paths in dependencies. So, the `//` anchors the address at the root of the repo, and then `build_file_dir().parent` picks the pack's directory (the parent of tests) without hardcoding the absolute path. This should make any future refactoring more seamless as fewer places need to be updated if a pack dir is moved/renamed.

The `core` pack also needs to include its `requirements.txt` file (Which is owned by the `python_requirements` target named `:reqs`), as well as a shell script in actions (`./actions` pulls in the python, and `./actions/send_mail:send_mail_resources` pulls in the shell script).

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/core/BUILD#L21-L29

Unlike the `core` pack, the `hello_st2` and `examples` packs do not have `python_requirements` targets. And, we don't want pants to pull requirements from that file as having the same requirement in multiple requirements files (in this case `requirements-pants.txt` and the pack `requirements.txt` file) causes problems for pants dep inferrence. So, I had to remove these requirements files from the pants ignore list (in `pants.toml`) and add a `files` target (instead of a `python_requirements` target) to own that file:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/hello_st2/BUILD#L7-L12

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/examples/BUILD#L22-L26

The `examples` pack has the most complex usage of `st2_pack_archive` because, sadly, transitive deps do not get included, so I had to list a bunch of deps:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/contrib/examples/BUILD#L28-L46

The other packs are similar.

### `st2_pack_archive` implementation

`st2_pack_archive` is a macro function:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L120-L124

First we get the directory of the BUILD file and return _without creating any targets_ if the pack is in `st2tests/`. This is important because the `contrib/core` pack is symlinked under st2tests, and we only want to create an archive for the pack once.

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L125-L129

There are many packs in `st2tests` with `pack_metadata` targets, but they do not need pack archives for distribution. That's why I kept `pack_metadata` separate from `st2_pack_archive`. It's a very good thing that pants macros do not have to create targets, allowing us to return early in this case.

Next, the macro ensures that a dep on `:metadata` is always present, even if we don't explicitly provide it in the BUILD file that uses `st2_pack_archive`. I did explicitly include `:metadata`, so this is a safety mechanism for future development where we might add a new pack.

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L132-L134

#### `:files` target

I mentioned the `:files` target above. One of the quirks of `makeself_archive` targets is that they only include `files` targets. So anything that is `python_sources`, `shell_sources`, `resources`, or other targets will be silently excluded from the makeself archive. So, I needed a way to treat all these targets--all of the targets listed in `dependencies`--as `files` targets. There are some experimental pants targets that allow for treating targets as if they were `python_sources` ([`experimental_wrap_as_python_sources`](https://www.pantsbuild.org/stable/reference/targets/experimental_wrap_as_python_sources)) or `resources` ([`experimental_wrap_as_resources`](https://www.pantsbuild.org/stable/reference/targets/experimental_wrap_as_resources)). But there is no `experimental_wrap_as_files` target, so I needed a different way to capture the dependencies as files. I used `shell_command` to do this:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L136-L143

The command `true` serves as a "noop" of sorts. The key pieces of this are [`execution_dependencies`](https://www.pantsbuild.org/stable/reference/targets/shell_command#execution_dependencies) which causes all of the deps to go in this noop command's sandbox, then [`output_directories=["."]`](https://www.pantsbuild.org/stable/reference/targets/shell_command#output_directories) says to capture all output files in the BUILD file's directory in the sandbox, and [`root_output_directory="."`](https://www.pantsbuild.org/stable/reference/targets/shell_command#root_output_directory) makes pants strip the BUILD file directory so that all of the files in the pack end up at the root of the makeself archive.

Finally, we build the `makeself_archive` with a convenient [`label`](https://www.pantsbuild.org/stable/reference/targets/makeself_archive#label) that gets printed when the archive extracts itself:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L147-L149

Next we include all of the pack files by putting `:files` in files:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L150-L153

I also included the LICENSE file so that the makeself archive can prompt the user to accept the license before unpacking. I configured that makeself feature here with `--license`:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L154-L157

Then, we pre-configure the archive so it will extract itself under `/opt/stackstorm/packs`:

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L158-L159

And we configure the pack file permissions/attributes using args that get passed through to tar. Note that st2-packages uses owner `root` and group `st2packs` for everything in `/opt/stackstorm/packs` ([1](https://github.com/StackStorm/st2-packages/blob/master/packages/st2/rpm/st2.spec#L130), [2](https://github.com/StackStorm/st2-packages/blob/master/packages/st2/rpm/preinst_script.spec#L9), [3](https://github.com/StackStorm/st2-packages/blob/master/packages/st2/debian/preinst#L24) and [4](https://github.com/StackStorm/st2-packages/blob/master/packages/st2/debian/postinst#L27)), but this uses root as the group temporarily. a follow-up PR will handle adding the `st2packs` group. We also set all timestamps to the value of `MTIME` so that the build is repeatable - no matter when we build an archive from a given commit, it will always generate exactly the same archive byte-for-byte.

https://github.com/StackStorm/st2/blob/1a66cefec63d792a84bcb973512ec189daf73317/pants-plugins/macros.py#L164-L168

ST2_PACKS_GROUPS is defined here. There was some logic in st2-packages that attempted to pull the user/group from `st2.conf` ([here](https://github.com/StackStorm/st2-packages/blob/d4d2d8dfdf1c88412e5d58635adb87da9c671952/packages/st2/debian/preinst#L51-L61)), but that code was not actually used anywhere (there's even a comment saying "NOT USED!"), so the group name is effectively hardcoded as `st2packs` ([1](https://github.com/StackStorm/st2-packages/blob/d4d2d8dfdf1c88412e5d58635adb87da9c671952/packages/st2/rpm/st2.spec#L5), [2](https://github.com/StackStorm/st2-packages/blob/d4d2d8dfdf1c88412e5d58635adb87da9c671952/packages/st2/debian/preinst#L16), [3](https://github.com/StackStorm/st2-packages/blob/d4d2d8dfdf1c88412e5d58635adb87da9c671952/packages/st2/debian/postinst#L21)). Plus, we're already hard-coding the group in the systemd files ([here](https://github.com/StackStorm/st2/blob/1a66cefec63d792a84bcb973512ec189daf73317/packaging/deb/systemd/st2actionrunner%40.service#L9) and [here](https://github.com/StackStorm/st2/blob/1a66cefec63d792a84bcb973512ec189daf73317/packaging/rpm/systemd/st2actionrunner%40.service#L9)), so I went with hard-coding it here:

https://github.com/StackStorm/st2/blob/1a66cefec63d792a84bcb973512ec189daf73317/pants-plugins/macros.py#L119-L120

MTIME is defined here, using the same value used by pex (thus, this will be the timestamp of `/opt/stackstorm/st2` once unpacked using the pex added in #6307):

https://github.com/StackStorm/st2/blob/940fb13fcf1f03435fcd6a81f8d4fa6b3bddb802/pants-plugins/macros.py#L115-L117

### Using a `makeself_archive`

These examples use the `chatops` pack, but could just as easily use any of the other 7 packs.

To package the `chatops` pack run:

```
pants package contrib/chatops::
```

Or to be more precise, you could use the target name like this

```
pants package contrib/chatops:archive
```

Then, you can run the pack to install it (/opt/stackstorm/packs should already exist):

```
sudo dist/packs/chatops.tgz.run
```

Or to test it with a temp directory:

```
sudo dist/packs/chatops.tgz.run --target /tmp/chatops-pack
```

This is how the post-install deb/rpm script will unpack the pack archive (packaging scriptlets run as root):

```
PAGER=cat /path/to/chatops.tgz.run --quiet --accept
``` 

The license gets piped through the PAGER before allowing the user to accept the license, even if auto accept is on the command line, using `PAGER=cat` ensures this does not pause the automated install.

And, to populate `/usr/share/docs/st2/examples` using the archive, the post-install script would do:

```
PAGER=cat /path/to/examples.tgz.run --quiet --accept --target /usr/share/docs/st2/examples
``` 