### PR TITLE
Packaging: remove dead/broken/legacy code from `packaging/{rpm,deb}/scripts`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
+  #6314
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/packaging/deb/scripts/post-install.sh
+++ b/packaging/deb/scripts/post-install.sh
@@ -17,43 +17,8 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-ST2_USER=st2
-PACKS_GROUP=st2packs
-ST2_UPGRADESTAMP="/tmp/.stamp-stackstorm-st2-deb-package"
-upgrading=0
-
-## Permissions of files which should be set on install
-SET_PERMS=$(cat <<EHD | sed 's/\s\+/ /g'
--R ug+rw root:_packsgroup /opt/stackstorm/packs
--R ug+rw root:_packsgroup /usr/share/doc/st2/examples
-   ug+rw root:_packsgroup /opt/stackstorm/virtualenvs
-   755 _st2user:root      /opt/stackstorm/configs
-   755 _st2user:root      /opt/stackstorm/exports
-   755 _st2user:root      /var/log/st2
-   755 _st2user:root      /var/run/st2
-   600 _st2user:_st2user  /etc/st2/htpasswd
-EHD
-)
-
-## Fix directories permissions on install (different across maint scripts!)
-set_permissions() {
-  local fileperms="$1"
-  fileperms=$(echo "$fileperms" | sed -e "s/_st2user/$ST2_USER/g" -e "s/_packsgroup/$PACKS_GROUP/g")
-  # Reqursively chown given destinations!
-  echo "$fileperms" | cut -f1,3,4 -d' ' | xargs -L1 chown
-  # Set directories mode
-  echo "$fileperms" | cut -f1,2,4 -d' ' | xargs -L1 chmod
-}
-
-# Choose first install or upgrade
-[ -f $ST2_UPGRADESTAMP ] && upgrading=1 || :
-
 case "$1" in
     configure)
-      # Initially set destination files owenership (only on the first install)
-      [ "$upgrading" = 1 ] || set_permissions "$SET_PERMS"
-      rm -f $ST2_UPGRADESTAMP
-
       # make sure that our socket generators run
       systemctl daemon-reload >/dev/null 2>&1 || true
     ;;

--- a/packaging/deb/scripts/post-remove.sh
+++ b/packaging/deb/scripts/post-remove.sh
@@ -18,11 +18,8 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-## Save st2 logrotate config on remove, but wipe it out on purge.
-preserve_logrotate() {
-  if [ "$1" = remove ]; then
-    [ -f /etc/logrotate.d/st2 ] && mv /etc/logrotate.d/st2-pkgsaved.disabled 1>/dev/null 2>&1 || :
-  elif [ "$1" = purge ]; then
+purge_files() {
+    # This -pkgsaved.disabled file might be left over from old (buggy) deb packages
     rm -f /etc/logrotate.d/st2-pkgsaved.disabled 1>/dev/null 2>&1 || :
     # Clean up other StackStorm related configs and directories
     rm -rf /etc/st2 1>/dev/null 2>&1 || :
@@ -30,14 +27,13 @@ preserve_logrotate() {
     rm -rf /root/.st2 1>/dev/null 2>&1 || :
     rm -rf /var/log/st2 1>/dev/null 2>&1 || :
     rm -f /etc/sudoers.d/st2 1>/dev/null 2>&1 || :
-  fi
 }
 
 case "$1" in
-    remove|purge)
-      preserve_logrotate "$1"
+    purge)
+        purge_files
     ;;
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
     *)
         echo "postrm called with unknown argument \`$1'" >&2

--- a/packaging/deb/scripts/pre-install.sh
+++ b/packaging/deb/scripts/pre-install.sh
@@ -16,7 +16,6 @@ set -e
 PACKS_GROUP=st2packs
 SYS_USER=stanley
 ST2_USER=st2
-ST2_CONFPATH="/etc/st2/st2.conf"
 ST2_UPGRADESTAMP="/tmp/.stamp-stackstorm-st2-deb-package"
 
 ## Permissions of directories which has to be reset on upgrade
@@ -46,18 +45,6 @@ create_users() {
     adduser --group $SYS_USER
     adduser --disabled-password --gecos "" --ingroup $SYS_USER $SYS_USER
   fi
-}
-
-## [NOT USED!] Get current system user from the st2.conf
-config_sysuser() {
-  # exit hooked
-  return 0
-  local sysuser=
-  if [ -f $ST2_CONFPATH ]; then
-    sysuser=$(cat $ST2_CONFPATH |
-      sed -n -e '/\[system_user\]/,/\[.*\]\|\$/ { /\[.*\]/d; /user\s*=/ { s/\s*user\s*=\s*//; p } }')
-  fi
-  echo $sysuser
 }
 
 ## Update logrotate configuration

--- a/packaging/deb/scripts/pre-install.sh
+++ b/packaging/deb/scripts/pre-install.sh
@@ -47,12 +47,6 @@ create_users() {
   fi
 }
 
-## Update logrotate configuration
-enable_logrotate() {
-  [ -f /etc/logrotate.d/st2-pkgsaved.disabled ] &&
-    mv -f /etc/logrotate.d/st2-pkgsaved.disabled /etc/logrotate.d/st2 || :
-}
-
 ## Fix directories permissions on upgrade (different across maint scripts!)
 #  NB! USED FOR COMPATIBILITY ON UPGRADE FROM PREVIOUS VERSIONS OF PACKAGES.
 #  NB! In future package releases reseting permissions SHOULD BE REMOVED.
@@ -77,11 +71,9 @@ set_permissions() {
 case "$1" in
     install)
       create_users
-      enable_logrotate
     ;;
     upgrade)
       create_users
-      enable_logrotate
       set_permissions "$RESET_PERMS"
       touch $ST2_UPGRADESTAMP
     ;;

--- a/packaging/deb/scripts/pre-install.sh
+++ b/packaging/deb/scripts/pre-install.sh
@@ -16,18 +16,6 @@ set -e
 PACKS_GROUP=st2packs
 SYS_USER=stanley
 ST2_USER=st2
-ST2_UPGRADESTAMP="/tmp/.stamp-stackstorm-st2-deb-package"
-
-## Permissions of directories which has to be reset on upgrade
-RESET_PERMS=$(cat <<EHD | sed 's/\s\+/ /g'
-ug+rw root:_packsgroup /opt/stackstorm/packs
-ug+rw root:_packsgroup /usr/share/doc/st2/examples
-ug+rw root:_packsgroup /opt/stackstorm/virtualenvs
-755 _st2user:root      /opt/stackstorm/configs
-755 _st2user:root      /opt/stackstorm/overrides
-755 _st2user:root      /opt/stackstorm/exports
-EHD
-)
 
 ## Create stackstorm users and groups
 create_users() {
@@ -47,35 +35,12 @@ create_users() {
   fi
 }
 
-## Fix directories permissions on upgrade (different across maint scripts!)
-#  NB! USED FOR COMPATIBILITY ON UPGRADE FROM PREVIOUS VERSIONS OF PACKAGES.
-#  NB! In future package releases reseting permissions SHOULD BE REMOVED.
-#
-set_permissions() {
-  local fileperms="$1" mode= ownership= path= current_ownership= user= group=
-
-  echo "$fileperms" | sed -e "s/_packsgroup/$PACKS_GROUP/g" -e "s/_st2user/$ST2_USER/g" |
-  while read mode ownership path; do
-    user=$(echo $ownership | cut -f1 -d:)
-    group=$(echo $ownership | cut -f2 -d:)
-    # set top level permissions whether it's a file or directory
-    [ -e $path ] || continue
-    chown $ownership $path && chmod $mode $path
-
-    # recursively change permissions of children (since those are directories)
-    find $path -mindepth 1 -maxdepth 1 -not \( -user $user -group $group \) |
-      xargs -I {} sh -c "echo chown -R $ownership {} && echo chmod -R $mode {}"
-  done
-}
-
 case "$1" in
     install)
       create_users
     ;;
     upgrade)
       create_users
-      set_permissions "$RESET_PERMS"
-      touch $ST2_UPGRADESTAMP
     ;;
     abort-upgrade)
     ;;

--- a/packaging/rpm/scripts/pre-install.sh
+++ b/packaging/rpm/scripts/pre-install.sh
@@ -4,17 +4,6 @@ PACKS_GROUP=%{packs_group}
 SYS_USER=%{stanley_user}
 ST2_USER=%{svc_user}
 
-## Permissions of directories which has to be reset on upgrade
-RESET_PERMS=$(cat <<EHD | sed 's/\s\+/ /g'
-ug+rw root:_packsgroup /opt/stackstorm/packs
-ug+rw root:_packsgroup /usr/share/doc/st2/examples
-ug+rw root:_packsgroup /opt/stackstorm/virtualenvs
-755 _st2user:root      /opt/stackstorm/configs
-755 _st2user:root      /opt/stackstorm/exports
-755 _st2user:root      /opt/stackstorm/overrides
-EHD
-)
-
 ## Create stackstorm users and groups (differs from debian)
 create_users() {
   # create st2 user (services user)
@@ -31,30 +20,4 @@ create_users() {
     adduser --user-group $SYS_USER
 }
 
-## Fix directories permissions on upgrade (different across maint scripts!)
-#  NB! USED FOR COMPATIBILITY ON UPGRADE FROM PREVIOUS VERSIONS OF PACKAGES.
-#  NB! In future package releases reseting permissions SHOULD BE REMOVED.
-#
-set_permissions() {
-  local fileperms="$1" mode= ownership= path= current_ownership= user= group=
-
-  echo "$fileperms" | sed -e "s/_packsgroup/$PACKS_GROUP/g" -e "s/_st2user/$ST2_USER/g" |
-  while read mode ownership path; do
-    user=$(echo $ownership | cut -f1 -d:)
-    group=$(echo $ownership | cut -f2 -d:)
-    # set top level permissions whether it's a file or directory
-    [ -e $path ] || continue
-    chown $ownership $path && chmod $mode $path
-
-    # recursively change permissions of children (since those are directories)
-    find $path -mindepth 1 -maxdepth 1 -not \( -user $user -group $group \) |
-      xargs -I {} sh -c "chown -R $ownership {} && chmod -R $mode {}"
-  done
-}
-
 create_users
-
-# We perform upgrade (when install count > 1)
-if [ "$1" -gt 1 ]; then
-  set_permissions "$RESET_PERMS"
-fi


### PR DESCRIPTION
This PR is working towards doing packaging via pantsbuild. Eventually, I hope to archive and stop using st2-packages.git. This PR begins refactoring `packaging/{rpm,deb}/scripts/*.sh` cherry-picked in:
- #6313

This refactor PR focuses on removing code from the scripts including dead code, broken code, and legacy code that is now pointless. I recommend reviewing each commit, as the commit description explains what is being removed and why.