### PR TITLE
Packaging: Add shfmt to format deb maintainer scripts / rpm scriptlets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -88,6 +88,7 @@ file(
 
 shell_sources(
     name="root",
+    skip_shfmt=True,
 )
 
 file(

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
-  #6311 #6314 #6315
+  #6311 #6314 #6315 #6317
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/core/actions/send_mail/BUILD
+++ b/contrib/core/actions/send_mail/BUILD
@@ -2,4 +2,5 @@ st2_shell_sources_and_resources(
     name="send_mail",
     sources=["send_mail"],
     skip_shellcheck=True,
+    skip_shfmt=True,
 )

--- a/contrib/examples/actions/BUILD
+++ b/contrib/examples/actions/BUILD
@@ -3,4 +3,7 @@ python_sources()
 shell_sources(
     name="shell",
     skip_shellcheck=True,
+    overrides={
+        "print_to_stdout_and_stderr.sh": dict(skip_shfmt=True),
+    }
 )

--- a/contrib/examples/actions/BUILD
+++ b/contrib/examples/actions/BUILD
@@ -3,7 +3,5 @@ python_sources()
 shell_sources(
     name="shell",
     skip_shellcheck=True,
-    overrides={
-        "print_to_stdout_and_stderr.sh": dict(skip_shfmt=True),
-    }
+    skip_shfmt=True,
 )

--- a/contrib/examples/actions/bash_exit_code/BUILD
+++ b/contrib/examples/actions/bash_exit_code/BUILD
@@ -1,1 +1,1 @@
-shell_sources()
+shell_sources(skip_shfmt=True)

--- a/contrib/examples/actions/bash_random/BUILD
+++ b/contrib/examples/actions/bash_random/BUILD
@@ -1,4 +1,5 @@
 shell_sources(
+    skip_shfmt=True,
     overrides={
         "random2.sh": dict(skip_shellcheck=True),
     },

--- a/contrib/linux/actions/BUILD
+++ b/contrib/linux/actions/BUILD
@@ -3,4 +3,5 @@ python_sources()
 shell_sources(
     name="shell",
     skip_shellcheck=True,
+    skip_shfmt=True,
 )

--- a/packaging/deb/scripts/post-install.sh
+++ b/packaging/deb/scripts/post-install.sh
@@ -31,16 +31,15 @@ set -e
 
 case "$1" in
     configure)
-      # make sure that our socket generators run
-      systemctl daemon-reload >/dev/null 2>&1 || true
-    ;;
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
+        # make sure that our socket generators run
+        systemctl daemon-reload >/dev/null 2>&1 || true
+        ;;
+    abort-upgrade | abort-remove | abort-deconfigure) ;;
 
     *)
         echo "postinst called with unknown argument \`$1'" >&2
         exit 1
-    ;;
+        ;;
 esac
 
 # dh_installdeb will replace this with shell code automatically

--- a/packaging/deb/scripts/post-remove.sh
+++ b/packaging/deb/scripts/post-remove.sh
@@ -38,13 +38,12 @@ purge_files() {
 case "$1" in
     purge)
         purge_files
-    ;;
-    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    ;;
+        ;;
+    remove | upgrade | failed-upgrade | abort-install | abort-upgrade | disappear) ;;
     *)
         echo "postrm called with unknown argument \`$1'" >&2
         exit 1
-    ;;
+        ;;
 esac
 
 # dh_installdeb will replace this with shell code automatically

--- a/packaging/deb/scripts/pre-install.sh
+++ b/packaging/deb/scripts/pre-install.sh
@@ -22,35 +22,34 @@ ST2_USER=st2
 
 ## Create stackstorm users and groups
 create_users() {
-  # create st2 user (services user)
-  (id $ST2_USER 1>/dev/null 2>&1) ||
-    adduser --group --disabled-password --no-create-home --system $ST2_USER
+    # create st2 user (services user)
+    (id $ST2_USER 1>/dev/null 2>&1) ||
+        adduser --group --disabled-password --no-create-home --system $ST2_USER
 
-  # make st2 member of st2packs group
-  (getent group $PACKS_GROUP 1>/dev/null 2>&1) || groupadd -r $PACKS_GROUP
-  (groups $ST2_USER 2>/dev/null | grep -q "\b${PACKS_GROUP}\b") ||
-    usermod -a -G $PACKS_GROUP $ST2_USER
+    # make st2 member of st2packs group
+    (getent group $PACKS_GROUP 1>/dev/null 2>&1) || groupadd -r $PACKS_GROUP
+    (groups $ST2_USER 2>/dev/null | grep -q "\b${PACKS_GROUP}\b") ||
+        usermod -a -G $PACKS_GROUP $ST2_USER
 
-  # create stanley user (for actionrunner service)
-  if (! id $SYS_USER 1>/dev/null 2>&1); then
-    adduser --group $SYS_USER
-    adduser --disabled-password --gecos "" --ingroup $SYS_USER $SYS_USER
-  fi
+    # create stanley user (for actionrunner service)
+    if (! id $SYS_USER 1>/dev/null 2>&1); then
+        adduser --group $SYS_USER
+        adduser --disabled-password --gecos "" --ingroup $SYS_USER $SYS_USER
+    fi
 }
 
 case "$1" in
     install)
-      create_users
-    ;;
+        create_users
+        ;;
     upgrade)
-      create_users
-    ;;
-    abort-upgrade)
-    ;;
+        create_users
+        ;;
+    abort-upgrade) ;;
     *)
         echo "preinst called with unknown argument \`$1'" >&2
         exit 1
-    ;;
+        ;;
 esac
 
 # dh_installdeb will replace this with shell code automatically

--- a/packaging/rpm/scripts/pre-install.sh
+++ b/packaging/rpm/scripts/pre-install.sh
@@ -12,18 +12,18 @@ ST2_USER=%{svc_user}
 
 ## Create stackstorm users and groups (differs from debian)
 create_users() {
-  # create st2 user (services user)
-  (id $ST2_USER 1>/dev/null 2>&1) ||
-    adduser --no-create-home --system --user-group $ST2_USER
+    # create st2 user (services user)
+    (id $ST2_USER 1>/dev/null 2>&1) ||
+        adduser --no-create-home --system --user-group $ST2_USER
 
-  # make st2 member of st2packs group
-  (getent group $PACKS_GROUP 1>/dev/null 2>&1) || groupadd -r $PACKS_GROUP
-  (groups $ST2_USER 2>/dev/null | grep -q "\b${PACKS_GROUP}\b") ||
-    usermod -a -G $PACKS_GROUP $ST2_USER
+    # make st2 member of st2packs group
+    (getent group $PACKS_GROUP 1>/dev/null 2>&1) || groupadd -r $PACKS_GROUP
+    (groups $ST2_USER 2>/dev/null | grep -q "\b${PACKS_GROUP}\b") ||
+        usermod -a -G $PACKS_GROUP $ST2_USER
 
-  # create stanley user (unprivileged action user, we don't ship sudoers.d config)
-  (id $SYS_USER 1>/dev/null 2>&1) ||
-    adduser --user-group $SYS_USER
+    # create stanley user (unprivileged action user, we don't ship sudoers.d config)
+    (id $SYS_USER 1>/dev/null 2>&1) ||
+        adduser --user-group $SYS_USER
 }
 
 create_users

--- a/pants-plugins/macros.py
+++ b/pants-plugins/macros.py
@@ -181,6 +181,7 @@ def st2_shell_sources_and_resources(**kwargs):
     shell_sources(**kwargs)  # noqa: F821
 
     kwargs.pop("skip_shellcheck", None)
+    kwargs.pop("skip_shfmt", None)
 
     kwargs["name"] += "_resources"
     resources(**kwargs)  # noqa: F821

--- a/pants.toml
+++ b/pants.toml
@@ -240,10 +240,8 @@ install_from_resolve = "st2"
 [shfmt]
 args = [
   # https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags
-  "--indent",
-  "4",  # default is 0 (use tabs)
+  "--indent=4", # default is 0 (use tabs)
   "--case-indent",
-  "--simplify",
 ]
 
 [test]

--- a/pants.toml
+++ b/pants.toml
@@ -26,6 +26,7 @@ backend_packages = [
   # shell
   "pants.backend.shell",
   "pants.backend.shell.lint.shellcheck",
+  "pants.backend.shell.lint.shfmt",
 
   # packaging
   "pants.backend.experimental.makeself",
@@ -235,6 +236,15 @@ config = "@lint-configs/regex-lint.yaml"
 
 [setuptools]
 install_from_resolve = "st2"
+
+[shfmt]
+args = [
+  # https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags
+  "--indent",
+  "4",  # default is 0 (use tabs)
+  "--case-indent",
+  "--simplify",
+]
 
 [test]
 extra_env_vars = [

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -2,4 +2,5 @@ python_sources()
 
 shell_sources(
     name="shell",
+    skip_shfmt=True,
 )

--- a/scripts/ci/BUILD
+++ b/scripts/ci/BUILD
@@ -1,11 +1,1 @@
-shell_sources(
-    overrides={
-        (
-            "add-itest-user-key.sh",
-            "permissions-workaround.sh",
-            "run-nightly-make-task-if-exists.sh",
-            "submit-codecov-coverage.sh",
-            "time-command.sh",
-        ): dict(skip_shfmt=True),
-    },
-)
+shell_sources(skip_shfmt=True)

--- a/scripts/ci/BUILD
+++ b/scripts/ci/BUILD
@@ -1,1 +1,11 @@
-shell_sources()
+shell_sources(
+    overrides={
+        (
+            "add-itest-user-key.sh",
+            "permissions-workaround.sh",
+            "run-nightly-make-task-if-exists.sh",
+            "submit-codecov-coverage.sh",
+            "time-command.sh",
+        ): dict(skip_shfmt=True),
+    },
+)

--- a/scripts/github/BUILD
+++ b/scripts/github/BUILD
@@ -8,12 +8,5 @@ files(
 
 shell_sources(
     dependencies=[":assets"],
-    overrides={
-        (
-            "install-apt-packages-use-cache.sh",
-            "install-mongosh.sh",
-            "install-virtualenv.sh",
-            "setup-environment.sh",
-        ): dict(skip_shfmt=True),
-    },
+    skip_shfmt=True,
 )

--- a/scripts/github/BUILD
+++ b/scripts/github/BUILD
@@ -8,4 +8,12 @@ files(
 
 shell_sources(
     dependencies=[":assets"],
+    overrides={
+        (
+            "install-apt-packages-use-cache.sh",
+            "install-mongosh.sh",
+            "install-virtualenv.sh",
+            "setup-environment.sh",
+        ): dict(skip_shfmt=True),
+    },
 )

--- a/st2actions/bin/BUILD
+++ b/st2actions/bin/BUILD
@@ -9,4 +9,5 @@ st2_shell_sources_and_resources(
     name="shell",
     sources=["*.sh"],
     skip_shellcheck=True,
+    skip_shfmt=True,
 )

--- a/st2common/bin/BUILD
+++ b/st2common/bin/BUILD
@@ -15,6 +15,7 @@ st2_shell_sources_and_resources(
     name="shell",
     sources=["st2ctl", "st2-self-check", "st2-run-pack-tests"],
     skip_shellcheck=True,
+    skip_shfmt=True,
     overrides={
         "st2ctl": dict(
             dependencies=[

--- a/st2common/bin/migrations/v2.1/BUILD
+++ b/st2common/bin/migrations/v2.1/BUILD
@@ -3,4 +3,5 @@ python_sources()
 shell_sources(
     name="shell",
     skip_shellcheck=True,
+    skip_shfmt=True,
 )

--- a/st2common/tests/fixtures/BUILD
+++ b/st2common/tests/fixtures/BUILD
@@ -3,4 +3,5 @@ python_sources()
 st2_shell_sources_and_resources(
     name="shell",
     sources=["*.sh"],
+    skip_shfmt=True,
 )

--- a/st2tests/integration/BUILD
+++ b/st2tests/integration/BUILD
@@ -12,4 +12,5 @@ shell_sources(
         "st2tests/conf:vagrant_ssh_key",
     ],
     skip_shellcheck=True,
+    skip_shfmt=True,
 )

--- a/st2tests/st2tests/fixtures/generic/actions/BUILD
+++ b/st2tests/st2tests/fixtures/generic/actions/BUILD
@@ -1,4 +1,5 @@
 st2_shell_sources_and_resources(
     name="shell",
     sources=["*.sh"],
+    skip_shfmt=True,
 )

--- a/st2tests/st2tests/fixtures/packs/BUILD
+++ b/st2tests/st2tests/fixtures/packs/BUILD
@@ -18,6 +18,7 @@ st2_shell_sources_and_resources(
     name="test_content_version_shell",
     # do not check across git submodule boundary
     skip_shellcheck=True,
+    skip_shfmt=True,
     sources=[
         "test_content_version/**/*.sh",
     ],

--- a/st2tests/st2tests/fixtures/ssl_certs/BUILD
+++ b/st2tests/st2tests/fixtures/ssl_certs/BUILD
@@ -17,4 +17,5 @@ python_sources(
 
 shell_sources(
     name="util",
+    skip_shfmt=True,
 )

--- a/st2tests/testpacks/errorcheck/actions/BUILD
+++ b/st2tests/testpacks/errorcheck/actions/BUILD
@@ -1,1 +1,1 @@
-shell_sources(skip_shellcheck=True)
+shell_sources(skip_shellcheck=True, skip_shfmt=True)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -51,4 +51,11 @@ shell_sources(
     dependencies=[
         "conf:st2_dev_conf",
     ],
+    overrides={
+        (
+            "db_cleanup.sh",
+            "launchdev.sh",
+            "st2-setup-tests",
+        ): dict(skip_shfmt=True),
+    },
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -48,14 +48,8 @@ shell_sources(
         "st2-setup-*",
     ],
     skip_shellcheck=True,
+    skip_shfmt=True,
     dependencies=[
         "conf:st2_dev_conf",
     ],
-    overrides={
-        (
-            "db_cleanup.sh",
-            "launchdev.sh",
-            "st2-setup-tests",
-        ): dict(skip_shfmt=True),
-    },
 )


### PR DESCRIPTION
This PR is working towards doing packaging via pantsbuild. Eventually, I hope to archive and stop using st2-packages.git.

The inconsistent formatting makes it harder to compare deb vs rpm scripts. At first I reformatted manually, but that will get lost quickly as we all make improvements. So, I added `shfmt` to format deb maintainer scripts / rpm scriptlets. To enable it I added the shfmt backend to `[GLOBAL].backend_packages` in `pants.toml`.

https://github.com/StackStorm/st2/blob/08fd2ba5d4e4cbeceae1af4ba7ef905480898fd3/pants.toml#L29

I want to keep this PR focused on packaging, so I added `skip_shfmt=True` to all the BUILD metadata for shell scripts that would be reformatted (other than `packaging/{rpm,deb}/scripts/*.sh`. Someone else can remove those `skip_shfmt` parameters to enable formatting other shell scripts. 

`shfmt` does not have a lot of options for formatting. I changed 2 of them:

https://github.com/StackStorm/st2/blob/08fd2ba5d4e4cbeceae1af4ba7ef905480898fd3/pants.toml#L240-L245

Most of our shell scripts use spaces instead of tabs for indentation. Some have 2 spaces while others have 4. I went with 4 for now (`--indent=4`). We can change it later if that proves annoying. I just want consistency.

All of our shell scripts indent case statements (though the indent size is inconsistent), so I enabled the `--case-indent` option as well. The formatting is a little different than I normally use, but it is at least consistent.