### PR TITLE
Packaging: extract venv (from pex) and packs (from archives) during rpm/deb post-install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
-  #6311 #6314 #6315 #6317 #6319 #6312
+  #6311 #6314 #6315 #6317 #6319 #6312 #6320
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/packaging/deb/scripts/post-install.sh
+++ b/packaging/deb/scripts/post-install.sh
@@ -83,8 +83,15 @@ systemd_enable_and_restart() {
     fi
 }
 
+rebuild_st2_venv() {
+    /opt/stackstorm/install/st2.pex
+}
+
 case "$1" in
     configure)
+        # Fail install if venv build fails
+        rebuild_st2_venv || exit $?
+
         # shellcheck disable=SC2086
         systemd_enable_and_restart ${_ST2_SERVICES}
         ;;

--- a/packaging/rpm/scripts/post-install.sh
+++ b/packaging/rpm/scripts/post-install.sh
@@ -21,6 +21,13 @@ st2timersengine
 st2workflowengine
 "
 
+rebuild_st2_venv() {
+    /opt/stackstorm/install/st2.pex
+}
+
+# Fail install if venv build fails
+rebuild_st2_venv || exit $?
+
 # Native .rpm specs use macros that get expanded into shell snippets.
 # We are using nfpm, so we inline the macro expansion here.
 # %systemd_post

--- a/packaging/rpm/scripts/post-install.sh
+++ b/packaging/rpm/scripts/post-install.sh
@@ -7,6 +7,15 @@ set -e
 #   * on upgrade: $1 > 1
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
 
+# The default set of packs installed with st2.
+_ST2_PACKS="
+chatops
+core
+default
+linux
+packs
+"
+
 _ST2_SERVICES="
 st2actionrunner
 st2api
@@ -25,8 +34,19 @@ rebuild_st2_venv() {
     /opt/stackstorm/install/st2.pex
 }
 
-# Fail install if venv build fails
+extract_st2_pack() {
+    pack=${1}
+    shift
+    # shellcheck disable=SC2209
+    PAGER=cat /opt/stackstorm/install/packs/"${pack}".tgz.run --quiet --accept "${@}"
+}
+
+# Fail install if venv build or pack extraction fails
 rebuild_st2_venv || exit $?
+for pack in ${_ST2_PACKS}; do
+    extract_st2_pack "${pack}" || exit $?
+done
+extract_st2_pack examples --target /usr/share/doc/st2/examples || :
 
 # Native .rpm specs use macros that get expanded into shell snippets.
 # We are using nfpm, so we inline the macro expansion here.


### PR DESCRIPTION
This PR is working towards doing packaging via pantsbuild. Eventually, I hope to archive and stop using st2-packages.git.

This PR is the last (planned) packaging PR that edits a deb maintainer script and an rpm scriptlet.

As noted in #6319, I did not expand the debhelper snippets and rpm macros that manage building the `/opt/stackstorm/st2` virtualenv. Instead of expanding them, this PR replaces them with logic that is uniform for both deb and rpm. This replacement avoids the dh_virtualenv debhelper that is unsupported upstream, and skips the complexity of using the external tool we used in rpms.

This PR makes the rpm/deb post-install scripts:
- run the pex to extract the virtualenv.
    - added in #6307
- run the pack archives to install them in `/opt/stackstorm/packs` and `/usr/share/doc/st2/examples`.
    -  added in #6311

The deb / rpm packages will need to place the pex and pack archives somewhere so that they are available during the when the post-install script runs. So, a big question is: Where should we put these files? Here are some options

| Option | Pex Archives                           | Pack Archives                                 |
|--------|----------------------------------------|-----------------------------------------------|
| 1      | `/opt/stackstorm/install/st2*.pex`     | `/opt/stackstorm/install/packs/*.tgz.run`     |
| 2      | `/usr/share/st2/install/st2*.pex`      | `/usr/share/st2/install/packs/*.tgz.run`      |
| 3      | `/usr/share/st2/archives/st2*.pex`     | `/usr/share/st2/archives/packs/*.tgz.run`     |
| 4      | `/usr/share/doc/st2/install/st2*.pex`  | `/usr/share/doc/st2/install/packs/*.tgz.run`  |
| 5      | `/usr/share/doc/st2/archives/st2*.pex` | `/usr/share/doc/st2/archives/packs/*.tgz.run` |

This PR uses option 1. I think my second choice would be option 3. Any other ideas? Where should we put these install archives?