### PR TITLE
Packaging: Inject st2 version into rpm/deb packages (pants-plugins/release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
-  #6311 #6314 #6315 #6317 #6319 #6312
+  #6311 #6314 #6315 #6317 #6319 #6312 #6321
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/contrib/runners/orquesta_runner/in-requirements.txt
+++ b/contrib/runners/orquesta_runner/in-requirements.txt
@@ -1,1 +1,2 @@
 orquesta@ git+https://github.com/StackStorm/orquesta.git@5ba1467614b2ef8b4709b2ca89e68baa671e8975
+setuptools

--- a/contrib/runners/orquesta_runner/requirements.txt
+++ b/contrib/runners/orquesta_runner/requirements.txt
@@ -6,3 +6,4 @@
 # in-requirements.txt for that component and then run 'make requirements' to
 # update the component requirements.txt
 orquesta@ git+https://github.com/StackStorm/orquesta.git@5ba1467614b2ef8b4709b2ca89e68baa671e8975
+setuptools<78

--- a/fixed-requirements.txt
+++ b/fixed-requirements.txt
@@ -72,6 +72,9 @@ tooz==6.3.0
 # virtualenv==20.29.2 (<21) has pip==25.0.1 wheel==0.45.1 setuptools==75.3.0
 # lockfiles/st2.lock has pip==25.0.1 wheel==0.45.1 setuptools==75.3.0
 virtualenv==20.29.2
+# This setuptools version number is in the Makefile, but CircleCI builds are pulling a version
+# that is incompatible with our logshipper fork.
+setuptools<78
 webob==1.8.9
 webtest==3.0.1
 zake==0.2.2

--- a/pants.toml
+++ b/pants.toml
@@ -31,6 +31,9 @@ backend_packages = [
   # packaging
   "pants.backend.experimental.makeself",
 
+  # packaging
+  "pants.backend.experimental.nfpm",
+
   # internal plugins in pants-plugins/
   "pants.backend.plugin_development",
   "api_spec",

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ requests==2.32.3
 retrying==1.3.4
 routes==2.5.1
 semver==3.0.4
+setuptools<78
 simplejson
 six==1.17.0
 sseclient-py==1.8.0

--- a/st2actions/in-requirements.txt
+++ b/st2actions/in-requirements.txt
@@ -19,6 +19,9 @@ lockfile
 # needed by core "linux" pack - TODO: create virtualenv for linux pack on postinst
 pyinotify
 logshipper@ git+https://github.com/StackStorm/logshipper.git@stackstorm_patched ; platform_system=="Linux"
+# logshipper has metadata in setup.cfg that is not supported by setuptools 78, so we need
+# an explicit dep (from fixed-requirements.txt) to prevent CircleCI from pulling that in.
+setuptools
 # required by pack_mgmt/setup_virtualenv.py#L135
 virtualenv
 # needed by requests

--- a/st2actions/requirements.txt
+++ b/st2actions/requirements.txt
@@ -22,5 +22,6 @@ python-dateutil==2.9.0.post0
 python-json-logger
 pyyaml==6.0.2
 requests==2.32.3
+setuptools<78
 six==1.17.0
 urllib3==2.2.3


### PR DESCRIPTION
This PR is working towards doing packaging via pantsbuild. Eventually, I hope to archive and stop using st2-packages.git.

This PR enables the `nfpm` backend in pants and updates `pants-plugins/release` so that it can inject the version number into the rpm/deb similar to how that plugin injects the version in python wheels that pants builds. To keep this PR focused on `pants-plugins/release`, it does not add any BUILD metadata like `nfpm_deb_package` or `nfpm_rpm_package`. Adding the BUILD metadata, and using the changes introduced in this PR, will come in follow-up PRs.

### Relevant pants docs about nfpm:
- [`nfpm` subsystem](https://www.pantsbuild.org/stable/reference/subsystems/nfpm)
- [`nfpm_deb_package` target](https://www.pantsbuild.org/stable/reference/targets/nfpm_deb_package)
    - [`version_schema` field](https://www.pantsbuild.org/stable/reference/targets/nfpm_deb_package#version_schema)
    - [`version` field](https://www.pantsbuild.org/stable/reference/targets/nfpm_deb_package#version)
- [`nfpm_rpm_package` target](https://www.pantsbuild.org/stable/reference/targets/nfpm_rpm_package)
    - [`version_schema` field](https://www.pantsbuild.org/stable/reference/targets/nfpm_rpm_package#version_schema)
    - [`version` field](https://www.pantsbuild.org/stable/reference/targets/nfpm_rpm_package#version)
- [`InjectNfpmPackageFieldsRequest` plugin hook](https://github.com/pantsbuild/pants/blob/2.25.x/docs/notes/2.25.x.md#nfpm)

### Relevant pants docs about developing our `pants-plugins/release`:
- [Plugins overview](https://www.pantsbuild.org/stable/docs/writing-plugins/overview)
- [Testing Plugins](https://www.pantsbuild.org/stable/docs/writing-plugins/the-rules-api/testing-plugins)

## Implemenation notes

It can be helpful to review each commit of this PR.

- 82905736b77959610149e93b503168e1900cab88: enable the nFPM backend in pants.

- 3e20568df0b5f217c79eb6255926332eb1dddb98: `pants-plugins/release` was introduced in #5891 to help with injecting wheel metadata (like the version number) into the generated wheels. Since we already have the logic to get the version number, and we want to do the same for nfpm, I extracted that into a separate pants rule called `extract_version`.
    https://github.com/StackStorm/st2/blob/3e20568df0b5f217c79eb6255926332eb1dddb98/pants-plugins/release/rules.py#L103-L104

- 6b508a2980b4d70f25cf18ab0a7930e78f39249b: Then I implemented an `InjectNfpmPackageFieldsRequest` with the `inject_package_fields` rule.
    https://github.com/StackStorm/st2/blob/6b508a2980b4d70f25cf18ab0a7930e78f39249b/pants-plugins/release/rules.py#L196-L205
    And, this registers our implementation with a `UnionRule` here:
    https://github.com/StackStorm/st2/blob/6b508a2980b4d70f25cf18ab0a7930e78f39249b/pants-plugins/release/rules.py#L234
    This is where this rule uses the `extract_version` rule introduced in the last commit:
    https://github.com/StackStorm/st2/blob/6b508a2980b4d70f25cf18ab0a7930e78f39249b/pants-plugins/release/rules.py#L208-L215
    Then the cleans up the version to match nfpm's expectations of `semver` formatted versions:
    https://github.com/StackStorm/st2/blob/6b508a2980b4d70f25cf18ab0a7930e78f39249b/pants-plugins/release/rules.py#L217-L221
    Finally, the rule defines the fields that get injected in `nfpm_deb_package` and `nfpm_rpm_package` targets.
    https://github.com/StackStorm/st2/blob/6b508a2980b4d70f25cf18ab0a7930e78f39249b/pants-plugins/release/rules.py#L223-L226
    If the version extracted is `3.9.0dev`, then the equivalent hard-coded BUILD metadata would look like:
    ```python
    nfpm_deb_package(
        ...
        version_schema="semver",
        version="3.9.0-dev",
        ...
    )
    ```

_Note: A follow-up PR will inject `version_release`, another nfpm package field. I did not include that in this PR, because it involves a script to retrieve the release number from packagecloud._