### PR TITLE
Packaging: Add `distro_id` field to `nfpm_deb_package` and `nfpm_rpm_package` targets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Added
   to pants' use of PEX lockfiles. This is not a user-facing addition.
   #6118 #6141 #6133 #6120 #6181 #6183 #6200 #6237 #6229 #6240 #6241 #6244 #6251 #6253
   #6254 #6258 #6259 #6260 #6269 #6275 #6279 #6278 #6282 #6283 #6273 #6287 #6306 #6307
-  #6311 #6314 #6315 #6317 #6319 #6312 #6320 #6321 #6323
+  #6311 #6314 #6315 #6317 #6319 #6312 #6320 #6321 #6323 #6324
   Contributed by @cognifloyd
 * Build of ST2 EL9 packages #6153
   Contributed by @amanda11

--- a/pants-plugins/release/register.py
+++ b/pants-plugins/release/register.py
@@ -17,7 +17,11 @@ Please see https://www.pantsbuild.org/docs/plugins-setup-py
 """
 
 from release.rules import rules as release_rules
+from release.target_types import rules as release_target_types_rules
 
 
 def rules():
-    return release_rules()
+    return [
+        *release_target_types_rules(),
+        *release_rules(),
+    ]

--- a/pants-plugins/release/rules.py
+++ b/pants-plugins/release/rules.py
@@ -51,6 +51,7 @@ from .packagecloud_rules import (
     packagecloud_get_next_release,
 )
 from .packagecloud_rules import rules as packagecloud_rules
+from .target_types import DistroIDField
 
 
 REQUIRED_KWARGS = (
@@ -240,7 +241,7 @@ async def inject_package_fields(
     next_release = await packagecloud_get_next_release(
         PackageCloudNextReleaseRequest(
             nfpm_arch=target[NfpmArchField].value,
-            distro_id="",  # TODO: add field for distro ID
+            distro_id=target[DistroIDField].value,
             package_name=target[NfpmPackageNameField].value,
             package_version=version,
             production=not is_dev,

--- a/pants-plugins/release/target_types.py
+++ b/pants-plugins/release/target_types.py
@@ -1,0 +1,52 @@
+# Copyright 2025 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pants.backend.nfpm.target_types import NfpmDebPackage, NfpmRpmPackage
+from pants.engine.target import StringField
+from pants.util.strutil import help_text
+
+
+class DistroIDField(StringField):
+    nfpm_alias = ""  # Not an nFPM field
+    alias = "distro_id"
+    valid_choices = (  # officially supported (or planned future support)
+        # ubuntu
+        "focal",
+        "jammy",
+        "noble",
+        # el
+        "el8",
+        "el9",
+    )
+    required = True
+    help = help_text(
+        """
+        The package distribution and version.
+
+        This is an internal StackStorm field used by pants-plugins/release.
+        The IDs are StackStorm-specific IDs that get translated into distribution + version.
+        These examples show how the distro_id gets translated into packagecloud values:
+          - distro_id "el8" is distro "el" with version "8";
+          - distro_id "focal" is distro "ubuntu" with version "focal".
+        """
+    )
+
+
+def rules():
+    return [
+        NfpmDebPackage.register_plugin_field(DistroIDField),
+        NfpmRpmPackage.register_plugin_field(DistroIDField),
+    ]


### PR DESCRIPTION
This PR is working towards doing packaging via pantsbuild. Eventually, I hope to archive and stop using st2-packages.git.

This is a follow-up to #6323, resolving the TODO explained in https://github.com/StackStorm/st2/pull/6323#discussion_r2012211865.

In `pants-plugins/release`, a new `distro_id` field is defined here:
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/target_types.py#L22-L24

This field basically accepts an enum of `valid_choices`. These `valid_choices` should be a list of supported or soon-to-be-supported distros:
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/target_types.py#L25-L33

And mark the field as `required` so that all BUILD targets have this field defined (if the field is registered for that target).
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/target_types.py#L34

This registers the new field on the `nfpm_deb_package` and `nfpm_rpm_package` targets:
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/target_types.py#L48-L52

To finish the field registration, the field rules get added to `pants-plugins/release/register.py`:
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/register.py#L19-L27

Finally, replace the TODO with the value of the `distro_id` field here:
https://github.com/StackStorm/st2/blob/00ff205ebefddc97ef6378a74ccaca7feaf353f9/pants-plugins/release/rules.py#L244