### PR TITLE
Enhance st2ctl Docker detection and usage hints (#4988)

### DIFF
--- a/st2common/bin/st2ctl
+++ b/st2common/bin/st2ctl
@@ -69,6 +69,28 @@ function must_be_root() {
     fi
 }
 
+# -- Detect whether running inside a Docker container --
+function running_in_docker() {
+    # /.dockerenv exists in Docker; cgroup contains “docker” on most systems
+    if [ -f /.dockerenv ] || grep -qa 'docker' /proc/1/cgroup; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Tell the user to use Docker commands instead of st2ctl
+function suggest_docker_usage() {
+    echo -e "\e[31mError: “st2ctl $1” is not supported inside Docker.\e[0m"
+    echo ""
+    echo "Please manage StackStorm services with Docker commands, e.g.:"
+    echo "  docker ps"
+    echo "  docker-compose restart st2api"
+    echo "  docker-compose logs -f st2stream"
+    exit 1
+}
+
+
 function not_running_in_k8s() {
     if [ -n "$KUBERNETES_SERVICE_HOST" ]; then
         echo -e "\e[31mError: \"st2ctl status\" is not supported under Kubernetes, please use Kubernetes tools such as \"kubectl\" to view the StackStorm services in this cluster. \e[0m\n"
@@ -212,6 +234,15 @@ function getpids() {
     fi
   done
 }
+
+# If in Docker, refuse any of the VM‐style commands
+if running_in_docker; then
+    case "$1" in
+        status|start|stop|restart|restart-component|reopen-log-files|reload)
+            suggest_docker_usage "$1"
+            ;;
+    esac
+fi
 
 
 case ${1} in


### PR DESCRIPTION
# Enhance `st2ctl` Docker detection and usage hints

This pull request adds support for detecting when `st2ctl` is being run inside a Docker container and, for VM-style commands, immediately exits with a clear error message and guidance on the proper Docker commands to use.

---

## Background

The `st2ctl` script was originally written to manage StackStorm services on a single host or VM, using tools like `ps`, `systemctl`, or direct process checks. In containerized deployments, each StackStorm component runs in its own Docker container, so those VM-style operations:

- Fail or return misleading results when run inside a container  
- Don’t reflect the recommended Docker-native workflow  

Issue [#4988](https://github.com/StackStorm/st2/issues/4988) requests that `st2ctl` detect this scenario and provide helpful Docker-specific guidance instead of attempting unsupported operations.

---

## What’s Changed

1. **Docker detection helper**  
   Added a new function `running_in_docker()` which returns success if either:  
   - The file `/.dockerenv` is present, or  
   - The string “docker” appears in `/proc/1/cgroup`

2. **Usage suggestion helper**  
   Added `suggest_docker_usage(subcommand)` which:  
   - Prints a red-highlighted error:  
     ```
     Error: “st2ctl <subcommand>” is not supported inside Docker.
     ```
   - Prints examples of the correct Docker commands to manage services:
     ```
     docker ps
     docker-compose restart st2api
     docker-compose logs -f st2stream
     ```
   - Exits with status code `1`

3. **Early exit for VM-style commands**  
   Inserted a pre-dispatch check before the main `case "$1" in … esac` block:
   ```bash
   if running_in_docker; then
     case "$1" in
       status|start|stop|restart|restart-component|reopen-log-files|reload)
         suggest_docker_usage "$1"
         ;;
     esac
   fi
