### PR TITLE
Fix to #6335 Keypair API response inconsistency admin vs. non-admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Other options that were renamed under `[database]` are (more details available i
 
 Fixed
 ~~~~~
+* Fixed 6335 by, instead of iterating over individual key names that the user has access to, fetching all the keys
+  and then only returning those that the user has access to. This way the 'prefix' and 'name' filters are honored
+  and the behavior of the method is consistent regardless of whether the user is an admin or not.
 * Fixed #6021 and #5327 by adding max_page_size to api_opts and added limit and offset to list_values() methods of
   both action_service and sensor_service
 * Fix `packs.get` action. Assumed `master` is primary branch on all packs. #6225


### PR DESCRIPTION
### WHAT:
This PR updates the get_all method of API V1 KeyValue controller so that if it's called by a non-admin user, instead of iterating over a list of keys that the user has access to and fetching them one by one, we fetch them in the same way as if we were an admin and then only add those to the output that the user has access to. 

### WHY:
This makes it so that the 'prefix' and 'name' filters are honoured even before we only return keys that the user has access to. This should also correct the st2client behaviour that throws an error when calling get_key_by_name (or whatever the name of the method is), as that one does a call to keys?name=<name> instead of keys/<name>.