### PR TITLE
Update python_runner.py-for parameter length bug

### DIFF
--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -188,7 +188,8 @@ class PythonRunner(GitWorktreeActionRunner):
         # failure to fork the wrapper process when using large parameters.
         stdin = None
         stdin_params = None
-        if len(serialized_parameters) >= MAX_PARAM_LENGTH:
+        serialized_parameters_bytes = serialized_parameters.encode('utf-8')
+        if len(serialized_parameters_bytes) >= MAX_PARAM_LENGTH:
             stdin = subprocess.PIPE
             LOG.debug("Parameters are too big...changing to stdin")
             stdin_params = '{"parameters": %s}\n' % (serialized_parameters)


### PR DESCRIPTION
Fix the bug of calculating the length of parameters in st2, when encountering Chinese, etc., non-English characters, the old calculation method will be shorter than the actual length, causing the command line to execute an extremely long error.