### PR TITLE
utf-8 encode before checking max size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Redis       8.6
 Fixed
 ~~~~~
 * Fix ``TypeError`` when displaying help for actions whose parameters have no ``description`` key. #6375
+* Fix utf-8 encode before checking paramter max size #6352
 
 Changed
 ~~~~~~~

--- a/contrib/runners/python_runner/python_runner/python_runner.py
+++ b/contrib/runners/python_runner/python_runner/python_runner.py
@@ -188,7 +188,10 @@ class PythonRunner(GitWorktreeActionRunner):
         # failure to fork the wrapper process when using large parameters.
         stdin = None
         stdin_params = None
-        if len(serialized_parameters) >= MAX_PARAM_LENGTH:
+        if (
+            len(serialized_parameters.encode(sys.getdefaultencoding(), errors="ignore"))
+            >= MAX_PARAM_LENGTH
+        ):
             stdin = subprocess.PIPE
             LOG.debug("Parameters are too big...changing to stdin")
             stdin_params = '{"parameters": %s}\n' % (serialized_parameters)

--- a/contrib/runners/python_runner/tests/unit/test_output_schema.py
+++ b/contrib/runners/python_runner/tests/unit/test_output_schema.py
@@ -40,6 +40,7 @@ PASCAL_ROW_ACTION_PATH = os.path.join(
 MOCK_SYS = mock.Mock()
 MOCK_SYS.argv = []
 MOCK_SYS.executable = sys.executable
+MOCK_SYS.getdefaultencoding.return_value = sys.getdefaultencoding()
 
 MOCK_EXECUTION = mock.Mock()
 MOCK_EXECUTION.id = "598dbf0c0640fd54bffc688b"

--- a/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
+++ b/contrib/runners/python_runner/tests/unit/test_pythonrunner.py
@@ -97,6 +97,7 @@ PRINT_TO_STDOUT_STDERR_ACTION = os.path.join(
 mock_sys = mock.Mock()
 mock_sys.argv = []
 mock_sys.executable = sys.executable
+mock_sys.getdefaultencoding.return_value = sys.getdefaultencoding()
 
 MOCK_EXECUTION = mock.Mock()
 MOCK_EXECUTION.id = "598dbf0c0640fd54bffc688b"


### PR DESCRIPTION
check size of bytes instead of length of string
fixed #6331 