### PR TITLE
DRAFT: with items persistent storage and speed improvements

### DIFF
--- a/st2common/st2common/persistence/workflow.py
+++ b/st2common/st2common/persistence/workflow.py
@@ -21,7 +21,7 @@ from st2common.models.db import workflow as wf_db_models
 from st2common.persistence import base as persistence
 
 
-__all__ = ["WorkflowExecution", "TaskExecution"]
+__all__ = ["WorkflowExecution", "TaskExecution", "TaskItemState"]
 
 
 class WorkflowExecution(persistence.StatusBasedResource):
@@ -51,6 +51,46 @@ class TaskExecution(persistence.StatusBasedResource):
     @classmethod
     def _get_impl(cls):
         return cls.impl
+
+    @classmethod
+    def delete_by_query(cls, *args, **query):
+        return cls._get_impl().delete_by_query(*args, **query)
+
+
+class TaskItemState(persistence.StatusBasedResource):
+    impl = db.ChangeRevisionMongoDBAccess(wf_db_models.TaskItemStateDB)
+    publisher = None
+
+    @classmethod
+    def _get_impl(cls):
+        return cls.impl
+
+    @classmethod
+    def get_by_task_and_item(cls, task_execution_id, item_id):
+        """
+        Retrieve the state record for a specific item in a task execution.
+
+        Args:
+            task_execution_id: ID of the task execution
+            item_id: ID of the specific item
+
+        Returns:
+            TaskItemStateDB: The state record for the specified item
+        """
+        return cls._get_impl().get(task_execution=task_execution_id, item_id=item_id)
+
+    @classmethod
+    def query_by_task_execution(cls, task_execution_id):
+        """
+        Retrieve all item state records for a task execution.
+
+        Args:
+            task_execution_id: ID of the task execution
+
+        Returns:
+            list: List of TaskItemStateDB objects for all items in the task
+        """
+        return cls.query(task_execution=task_execution_id)
 
     @classmethod
     def delete_by_query(cls, *args, **query):


### PR DESCRIPTION
Testing out persistent storage for faster with items.
1. When creating task executions for itemized tasks separate state records for each item
2. Task execution records now contain minimal metadata rather than full context for all items
3. Individual item states are updated independently, avoiding the need to load/modify the entire context
4. Results are aggregated only when needed (when determining final task status)
