### PR TITLE
Promote Jake Z (@skiedude) to Maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -45,6 +45,7 @@ Being part of Technical Steering Committee (TSC) [@StackStorm/maintainers](https
   - Ansible, Docker, K8s, StackStorm Exchange. [StackStorm Adoption](https://github.com/StackStorm/st2/pull/5836)
 * Mick McGrath ([@mickmcgrath13](https://github.com/mickmcgrath13)), _Bitovi_ <<mick@bitovi.com>>
   - Systems, ST2 Exchange. [Case Study](https://stackstorm.com/case-study-bitovi/).
+* Jake Z ([@skiedude](https://github.com/skiedude)) - _Adobe_ - ChatOps, K8s, CI.
 
 --------
 
@@ -67,7 +68,6 @@ They're not part of the TSC voting process, but appreciated for their contributi
 * Sravanthi Konduru ([@sravs-dev](https://github.com/sravs-dev)), _Salesforce_, - Core, StackStorm Exchange.
 * Tristan Struthers ([@trstruth](https://github.com/trstruth)) - Docker, K8s, Orquesta, Community.
 * Yuri Dubler ([@lm-ydubler](https://github.com/lm-ydubler)) - _LogicMonitor_ - StackStorm Exchange, CI.
-* Jake Z ([@skiedude](https://github.com/skiedude)) - _Adobe_ - ChatOps, K8s, CI.
 
 # Friends
 People that are currently not very active maintainers/contributors but who participated in and formed the project we have today.


### PR DESCRIPTION
Jake has been constantly active in the Slack community offering help to people, he's been present in all TSC meetings contributing to technical discussions https://github.com/StackStorm/community/issues/157 https://github.com/StackStorm/community/issues/156  and provided support throughout the release of StackStorm v3.9 for documentation https://github.com/StackStorm/st2docs/pull/1175 rbac backend https://github.com/StackStorm/st2-rbac-backend/pull/76 ChatOps https://github.com/StackStorm/st2chatops/pull/193 and Pack Testing https://github.com/StackStorm/st2/pull/6363

Jake's consistent participation and assistance to the StackStorm project demonstrates he is a valuable member to the community and would be a good fit in the role as a maintainer.

As per the project Governance, this PR is a request for @StackStorm/tsc members to vote on this promotion by approving the PR.