### PR TITLE
[codex] Format execution elapsed time for humans

### DIFF
--- a/st2client/st2client/commands/action.py
+++ b/st2client/st2client/commands/action.py
@@ -41,6 +41,7 @@ from st2client.utils import jsutil
 from st2client.utils.date import format_isodate_for_user_timezone
 from st2client.utils.date import parse as parse_isotime
 from st2client.utils.color import format_status
+from st2common.expressions.functions.time import to_human_time_from_seconds
 
 LOG = logging.getLogger(__name__)
 
@@ -182,15 +183,15 @@ def format_execution_status(instance):
         start_timestamp = parse_isotime(start_timestamp)
         start_timestamp = calendar.timegm(start_timestamp.timetuple())
         now = int(time.time())
-        elapsed_seconds = now - start_timestamp
-        instance.status = "%s (%ss elapsed)" % (instance.status, elapsed_seconds)
+        elapsed_seconds = to_human_time_from_seconds(now - start_timestamp)
+        instance.status = "%s (%s elapsed)" % (instance.status, elapsed_seconds)
     elif status in LIVEACTION_COMPLETED_STATES and start_timestamp and end_timestamp:
         start_timestamp = parse_isotime(start_timestamp)
         start_timestamp = calendar.timegm(start_timestamp.timetuple())
         end_timestamp = parse_isotime(end_timestamp)
         end_timestamp = calendar.timegm(end_timestamp.timetuple())
-        elapsed_seconds = end_timestamp - start_timestamp
-        instance.status = "%s (%ss elapsed)" % (instance.status, elapsed_seconds)
+        elapsed_seconds = to_human_time_from_seconds(end_timestamp - start_timestamp)
+        instance.status = "%s (%s elapsed)" % (instance.status, elapsed_seconds)
 
     return instance
 

--- a/st2client/tests/unit/test_action.py
+++ b/st2client/tests/unit/test_action.py
@@ -22,6 +22,7 @@ from tests import base
 
 from st2client import shell
 from st2client import models
+from st2client.commands import action as action_command
 from st2client.utils import httpclient
 
 LOG = logging.getLogger(__name__)
@@ -102,6 +103,33 @@ class ActionCommandTestCase(base.BaseCLITestCase):
     def __init__(self, *args, **kwargs):
         super(ActionCommandTestCase, self).__init__(*args, **kwargs)
         self.shell = shell.Shell()
+
+    def test_format_execution_status_uses_human_readable_elapsed_time_for_completed_execution(
+        self,
+    ):
+        instance = mock.Mock(
+            status=action_command.LIVEACTION_STATUS_SUCCEEDED,
+            start_timestamp="2020-01-01T00:00:00.000000Z",
+            end_timestamp="2020-01-01T00:05:39.000000Z",
+        )
+
+        result = action_command.format_execution_status(instance)
+
+        self.assertEqual(result.status, "succeeded (5m39s elapsed)")
+
+    @mock.patch.object(action_command.time, "time", mock.MagicMock(return_value=1577837139))
+    def test_format_execution_status_uses_human_readable_elapsed_time_for_running_execution(
+        self,
+    ):
+        instance = mock.Mock(
+            status=action_command.LIVEACTION_STATUS_RUNNING,
+            start_timestamp="2020-01-01T00:00:00.000000Z",
+            end_timestamp=None,
+        )
+
+        result = action_command.format_execution_status(instance)
+
+        self.assertEqual(result.status, "running (5m39s elapsed)")
 
     @mock.patch.object(
         models.ResourceManager,


### PR DESCRIPTION
## Summary

- format execution elapsed time with the existing human-readable duration helper
- cover completed and running execution status formatting

Fixes StackStorm/st2#4944.

## Testing

- `python3 -m pytest st2client/tests/unit/test_action.py -q` (blocked locally: `pytest` is not installed in the system Python)
