### PR TITLE
Update gitpython to 3.1.57 for security patches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ dnspython
 editor==1.6.6
 eventlet==0.40.3
 gitdb==4.0.12
-gitpython==3.1.45
+gitpython==3.1.57
 greenlet==3.1.1
 gunicorn<26
 importlib-metadata


### PR DESCRIPTION
Bumps gitpython from 3.1.45 to 3.1.57 (patch-level update).

## Fixed vulnerabilities

All advisories below were confirmed via osv-scanner before/after the change:

| Advisory | Severity | Summary |
|----------|----------|---------|
| GHSA-x2qx-6953-8485 / PYSEC-2026-2161 | 9.8 | Unsafe option check validates multi_options before shlex.split |
| GHSA-rpm5-65cw-6hj4 / PYSEC-2026-2160 | 8.8 | Command injection via Git options bypass |
| GHSA-2f96-g7mh-g2hx | 8.8 | Command injection via long-option prefix abbreviation bypass |
| GHSA-r9mr-m37c-5fr3 | 8.8 | Unsafe git option guard bypass via single-char token smuggling |
| GHSA-956x-8gvw-wg5v | 8.4 | Command injection via unguarded options in Repo.archive() |
| GHSA-3f7w-8rr8-f37f | 8.1 | Unguarded git option forwarding in IndexFile.checkout() |
| GHSA-fjr4-x663-mwxc | 8.1 | Arbitrary file overwrite via git diff --output injection |
| PYSEC-2026-2163 / GHSA-v87r-6q3f-2j67 | 7.8 | Newline injection in config_writer enables RCE |
| PYSEC-2026-2162 / GHSA-7545-fcxq-7j24 | 7.8 | Path traversal in reference APIs |
| GHSA-6p8h-3wgx-97gf | 7.5 | Incomplete unsafe_git_clone_options denylist omits --template |
| GHSA-94p4-4cq8-9g67 | 7.5 | Environment-variable exfiltration via Repo.create_remote() |
| GHSA-rwj8-pgh3-r573 | 7.5 | Environment-variable exfiltration via os.path.expandvars |
| GHSA-3rp5-jjmw-4wv2 | 7.0 | git-config section-name injection enables arbitrary config |
| GHSA-mv93-w799-cj2w | 7.0 | Newline injection in config_writer section parameter |
| GHSA-539m-9xh6-q6rr | 6.5 | Incomplete unsafe_git_archive_options denylist |
| GHSA-p538-c434-8v24 | 5.4 | Arbitrary file truncation via git rev-list --output injection |

## Verification

- osv-scanner before: 16 gitpython advisories detected at 3.1.45
- osv-scanner after: 0 gitpython advisories at 3.1.57
- Diff: only requirements.txt, single version bump
- No application logic or source code changes